### PR TITLE
Speaker's name fix & Logger output

### DIFF
--- a/Game/AI/Decks/TrickstarExecutor.cs
+++ b/Game/AI/Decks/TrickstarExecutor.cs
@@ -167,6 +167,11 @@ namespace WindBot.Game.AI.Decks
             return DefaultSpellSet();
         }
 
+        public bool Has_down_arrow(int id)
+        {
+            return (id == CardId.Linkuri || id == CardId.Linkspi || id == CardId.Unicorn);
+        }
+
         public bool IsTrickstar(int id)
         {
             return (id == CardId.Yellow || id == CardId.Red || id == CardId.Pink || id == CardId.White || id == CardId.Stage || id == CardId.Re || id == CardId.Crown);
@@ -179,27 +184,6 @@ namespace WindBot.Game.AI.Decks
                 // field spells that forbid other fields' activate
                 return (Card.Id != 71650854 && Card.Id != 78082039);
             }
-            return false;
-        }
-
-        public bool spell_trap_activate()
-        {
-            if (Card.Location != CardLocation.SpellZone && Card.Location != CardLocation.Hand) return true;
-            if (Enemy.HasInMonstersZone(CardId.Exterio,true) && !Bot.HasInHandOrHasInMonstersZone(CardId.Ghost)) return false;
-            if (Card.IsSpell())
-            {
-                if (Enemy.HasInMonstersZone(33198837, true) && !Bot.HasInHandOrHasInMonstersZone(CardId.Ghost)) return false;
-                if (Enemy.HasInSpellZone(61740673, true) || Bot.HasInSpellZone(61740673,true)) return false;
-                if (Enemy.HasInMonstersZone(37267041, true) || Bot.HasInMonstersZone(37267041, true)) return false;
-                return true;
-            }
-            if (Card.IsTrap())
-            {
-                if (Enemy.HasInSpellZone(51452091, true) || Bot.HasInSpellZone(51452091, true)) return false;
-                if (Enemy.HasInSpellZone(51452091, true) || Bot.HasInSpellZone(51452091, true)) return false;
-                return true;
-            }
-            // how to get here?
             return false;
         }
 
@@ -393,7 +377,6 @@ namespace WindBot.Game.AI.Decks
             }
             else
             {
-                if (!spell_trap_activate()) return false;
                 foreach (ClientCard card in spells)
                 {
                     if (card.IsFacedown() && card != stage_locked)
@@ -417,7 +400,6 @@ namespace WindBot.Game.AI.Decks
 
         public bool Feather_Act()
         {
-            if (!spell_trap_activate()) return false;
             if (AI.Utils.GetProblematicEnemySpell() != null)
             {
                 List<ClientCard> grave = Bot.GetGraveyardSpells();
@@ -436,7 +418,6 @@ namespace WindBot.Game.AI.Decks
 
         public bool Sheep_Act()
         {
-            if (!spell_trap_activate()) return false;
             if (Duel.Player == 0) return false;
             if (Duel.Phase == DuelPhase.End) return true;
             if (Duel.LastChainPlayer == 1 && (AI.Utils.IsChainTarget(Card) || (AI.Utils.GetLastChainCard().Id == CardId.Feather && !Bot.HasInSpellZone(CardId.Awaken)))) return true;
@@ -455,8 +436,8 @@ namespace WindBot.Game.AI.Decks
 
         public bool Stage_act()
         {
-            if (Card.Location == CardLocation.SpellZone && Card.HasPosition(CardPosition.FaceUp)) return false;
-            if (!spell_trap_activate()) return false;
+            if (Card.Location != CardLocation.Hand) return false;
+
             if (!NormalSummoned)
             {
                 if (!Bot.HasInHand(CardId.Yellow))
@@ -577,7 +558,6 @@ namespace WindBot.Game.AI.Decks
 
         public bool Pot_Act()
         {
-            if (!spell_trap_activate()) return false;
             return Bot.Deck.Count > 15;
         }
 
@@ -1055,7 +1035,6 @@ namespace WindBot.Game.AI.Decks
         public bool Reincarnation()
         {
             if (Card.Location == CardLocation.Grave) return Ts_reborn();
-            if (!spell_trap_activate()) return false;
             if (Bot.HasInHand(CardId.LockBird))
             {
                 if (lockbird_useful || AI.Utils.IsChainTarget(Card) || (Duel.Player == 1 && AI.Utils.ChainContainsCard(CardId.Feather))) {
@@ -1071,7 +1050,6 @@ namespace WindBot.Game.AI.Decks
         {
             if (Card.Location == CardLocation.Hand)
             {
-                if (!spell_trap_activate()) return false;
                 if (Duel.Phase <= DuelPhase.Main1) return Ts_reborn();
                 return false;
             }
@@ -1209,7 +1187,6 @@ namespace WindBot.Game.AI.Decks
         public bool Ring_act()
         {
             if (Duel.LastChainPlayer == 0 && AI.Utils.GetLastChainCard() != null && AI.Utils.GetLastChainCard().Id == CardId.Ghost) return false;
-            if (!spell_trap_activate()) return false;
             ClientCard target = AI.Utils.GetProblematicEnemyMonster();
             if (target == null && AI.Utils.IsChainTarget(Card))
             {
@@ -1669,10 +1646,8 @@ namespace WindBot.Game.AI.Decks
             return false;
         }
 
-        // unfinished.
         public bool GraveCall_eff()
         {
-            if (!spell_trap_activate()) return false;
             if (Duel.LastChainPlayer == 1)
             {
                 if (AI.Utils.GetLastChainCard().IsMonster() && Enemy.HasInGraveyard(AI.Utils.GetLastChainCard().Id))
@@ -1688,7 +1663,6 @@ namespace WindBot.Game.AI.Decks
 
         public bool DarkHole_eff()
         {
-            if (!spell_trap_activate()) return false;
             if (Bot.GetMonsterCount() == 0)
             {
                 

--- a/Game/AI/Decks/TrickstarExecutor.cs
+++ b/Game/AI/Decks/TrickstarExecutor.cs
@@ -37,7 +37,7 @@ namespace WindBot.Game.AI.Decks
             public const int Ring = 83555666;
             public const int Strike = 40605147;
             public const int Warn = 84749824;
-            public const int Grass = 10813327;
+            public const int Awaken = 10813327;
 
             public const int Linkuri = 41999284;
             public const int Linkspi = 98978921;
@@ -87,7 +87,7 @@ namespace WindBot.Game.AI.Decks
             AddExecutor(ExecutorType.Activate, CardId.MG, G_act);
             AddExecutor(ExecutorType.Activate, CardId.Strike, DefaultSolemnStrike);
             AddExecutor(ExecutorType.Activate, CardId.Warn, DefaultSolemnWarning);
-            AddExecutor(ExecutorType.Activate, CardId.Grass, Grass_ss);
+            AddExecutor(ExecutorType.Activate, CardId.Awaken, Awaken_ss);
             AddExecutor(ExecutorType.Activate, CardId.Urara, Hand_act_eff);
             AddExecutor(ExecutorType.Activate, CardId.Ghost, Hand_act_eff);
             AddExecutor(ExecutorType.Activate, CardId.Ring, Ring_act);
@@ -99,6 +99,7 @@ namespace WindBot.Game.AI.Decks
             AddExecutor(ExecutorType.Activate, CardId.DarkHole, DarkHole_eff);
 
             // spell clean
+            AddExecutor(ExecutorType.Activate, field_activate);
             AddExecutor(ExecutorType.Activate, CardId.Stage, Stage_Lock);
             AddExecutor(ExecutorType.Activate, CardId.Feather, Feather_Act);
             AddExecutor(ExecutorType.Activate, CardId.Stage, Stage_act);
@@ -176,12 +177,22 @@ namespace WindBot.Game.AI.Decks
             return (id == CardId.Yellow || id == CardId.Red || id == CardId.Pink || id == CardId.White || id == CardId.Stage || id == CardId.Re || id == CardId.Crown);
         }
 
+        public bool field_activate()
+        {
+            if (Card.HasPosition(CardPosition.FaceDown) && Card.HasType(CardType.Field) && Card.Location == CardLocation.SpellZone)
+            {
+                // field spells that forbid other fields' activate
+                return (Card.Id != 71650854 && Card.Id != 78082039);
+            }
+            return false;
+        }
+
         public int[] Useless_List()
         {
             return new[]
             {
                 CardId.Tuner,
-                CardId.Grass,
+                CardId.Awaken,
                 CardId.Crown,
                 CardId.Pink,
                 CardId.Pot,
@@ -216,7 +227,7 @@ namespace WindBot.Game.AI.Decks
             return atk;
         }
 
-        public bool Grass_ss()
+        public bool Awaken_ss()
         {
             // judge whether can ss from exdeck
             bool judge = (Bot.ExtraDeck.Count > 0);
@@ -231,7 +242,7 @@ namespace WindBot.Game.AI.Decks
             // can ss from exdeck
             if (judge)
             {
-                bool fornextss = AI.Utils.ChainContainsCard(CardId.Grass);
+                bool fornextss = AI.Utils.ChainContainsCard(CardId.Awaken);
                 IList<ClientCard> ex = Bot.ExtraDeck;
                 ClientCard ex_best = null;
                 foreach (ClientCard ex_card in ex)
@@ -250,7 +261,7 @@ namespace WindBot.Game.AI.Decks
                     AI.SelectCard(ex_best);
                 }
             }
-            if (!judge || AI.Utils.ChainContainsCard(CardId.Grass))
+            if (!judge || AI.Utils.ChainContainsCard(CardId.Awaken))
             {
                 // cannot ss from exdeck or have more than 1 grass in chain
                 int[] secondselect = new[]
@@ -266,7 +277,7 @@ namespace WindBot.Game.AI.Decks
                     CardId.Yellow,
                     CardId.Pink
                 };
-                if (!AI.Utils.ChainContainsCard(CardId.Grass))
+                if (!AI.Utils.ChainContainsCard(CardId.Awaken))
                 {
                     if (!judge && Bot.GetRemainingCount(CardId.Ghost, 2) > 0)
                     {
@@ -409,7 +420,7 @@ namespace WindBot.Game.AI.Decks
         {
             if (Duel.Player == 0) return false;
             if (Duel.Phase == DuelPhase.End) return true;
-            if (Duel.LastChainPlayer == 1 && (AI.Utils.IsChainTarget(Card) || (AI.Utils.GetLastChainCard().Id == CardId.Feather && !Bot.HasInSpellZone(CardId.Grass)))) return true;
+            if (Duel.LastChainPlayer == 1 && (AI.Utils.IsChainTarget(Card) || (AI.Utils.GetLastChainCard().Id == CardId.Feather && !Bot.HasInSpellZone(CardId.Awaken)))) return true;
             if (Duel.Phase > DuelPhase.Main1 && Duel.Phase < DuelPhase.Main2)
             {
                 int total_atk = 0;
@@ -1321,7 +1332,7 @@ namespace WindBot.Game.AI.Decks
             if (ex_1 != null && ex_1.Controller == 0) ex = ex_1;
             if (ex_2 != null && ex_2.Controller == 0) ex = ex_2;
             if (ex == null) return false;
-            if (!Has_down_arrow(ex.Id)) return false;
+            if (!ex.HasLinkMarker(2)) return false;
             IList<ClientCard> targets = new List<ClientCard>();
             foreach (ClientCard s_m in Bot.GetMonsters())
             {

--- a/Game/AI/Decks/TrickstarExecutor.cs
+++ b/Game/AI/Decks/TrickstarExecutor.cs
@@ -37,7 +37,7 @@ namespace WindBot.Game.AI.Decks
             public const int Ring = 83555666;
             public const int Strike = 40605147;
             public const int Warn = 84749824;
-            public const int Awaken = 10813327;
+            public const int Grass = 10813327;
 
             public const int Linkuri = 41999284;
             public const int Linkspi = 98978921;
@@ -87,7 +87,7 @@ namespace WindBot.Game.AI.Decks
             AddExecutor(ExecutorType.Activate, CardId.MG, G_act);
             AddExecutor(ExecutorType.Activate, CardId.Strike, DefaultSolemnStrike);
             AddExecutor(ExecutorType.Activate, CardId.Warn, DefaultSolemnWarning);
-            AddExecutor(ExecutorType.Activate, CardId.Awaken, Awaken_ss);
+            AddExecutor(ExecutorType.Activate, CardId.Grass, Grass_ss);
             AddExecutor(ExecutorType.Activate, CardId.Urara, Hand_act_eff);
             AddExecutor(ExecutorType.Activate, CardId.Ghost, Hand_act_eff);
             AddExecutor(ExecutorType.Activate, CardId.Ring, Ring_act);
@@ -99,7 +99,6 @@ namespace WindBot.Game.AI.Decks
             AddExecutor(ExecutorType.Activate, CardId.DarkHole, DarkHole_eff);
 
             // spell clean
-            AddExecutor(ExecutorType.Activate, field_activate);
             AddExecutor(ExecutorType.Activate, CardId.Stage, Stage_Lock);
             AddExecutor(ExecutorType.Activate, CardId.Feather, Feather_Act);
             AddExecutor(ExecutorType.Activate, CardId.Stage, Stage_act);
@@ -177,22 +176,12 @@ namespace WindBot.Game.AI.Decks
             return (id == CardId.Yellow || id == CardId.Red || id == CardId.Pink || id == CardId.White || id == CardId.Stage || id == CardId.Re || id == CardId.Crown);
         }
 
-        public bool field_activate()
-        {
-            if (Card.HasPosition(CardPosition.FaceDown) && Card.HasType(CardType.Field) && Card.Location == CardLocation.SpellZone)
-            {
-                // field spells that forbid other fields' activate
-                return (Card.Id != 71650854 && Card.Id != 78082039);
-            }
-            return false;
-        }
-
         public int[] Useless_List()
         {
             return new[]
             {
                 CardId.Tuner,
-                CardId.Awaken,
+                CardId.Grass,
                 CardId.Crown,
                 CardId.Pink,
                 CardId.Pot,
@@ -227,7 +216,7 @@ namespace WindBot.Game.AI.Decks
             return atk;
         }
 
-        public bool Awaken_ss()
+        public bool Grass_ss()
         {
             // judge whether can ss from exdeck
             bool judge = (Bot.ExtraDeck.Count > 0);
@@ -242,7 +231,7 @@ namespace WindBot.Game.AI.Decks
             // can ss from exdeck
             if (judge)
             {
-                bool fornextss = AI.Utils.ChainContainsCard(CardId.Awaken);
+                bool fornextss = AI.Utils.ChainContainsCard(CardId.Grass);
                 IList<ClientCard> ex = Bot.ExtraDeck;
                 ClientCard ex_best = null;
                 foreach (ClientCard ex_card in ex)
@@ -261,7 +250,7 @@ namespace WindBot.Game.AI.Decks
                     AI.SelectCard(ex_best);
                 }
             }
-            if (!judge || AI.Utils.ChainContainsCard(CardId.Awaken))
+            if (!judge || AI.Utils.ChainContainsCard(CardId.Grass))
             {
                 // cannot ss from exdeck or have more than 1 grass in chain
                 int[] secondselect = new[]
@@ -277,7 +266,7 @@ namespace WindBot.Game.AI.Decks
                     CardId.Yellow,
                     CardId.Pink
                 };
-                if (!AI.Utils.ChainContainsCard(CardId.Awaken))
+                if (!AI.Utils.ChainContainsCard(CardId.Grass))
                 {
                     if (!judge && Bot.GetRemainingCount(CardId.Ghost, 2) > 0)
                     {
@@ -420,7 +409,7 @@ namespace WindBot.Game.AI.Decks
         {
             if (Duel.Player == 0) return false;
             if (Duel.Phase == DuelPhase.End) return true;
-            if (Duel.LastChainPlayer == 1 && (AI.Utils.IsChainTarget(Card) || (AI.Utils.GetLastChainCard().Id == CardId.Feather && !Bot.HasInSpellZone(CardId.Awaken)))) return true;
+            if (Duel.LastChainPlayer == 1 && (AI.Utils.IsChainTarget(Card) || (AI.Utils.GetLastChainCard().Id == CardId.Feather && !Bot.HasInSpellZone(CardId.Grass)))) return true;
             if (Duel.Phase > DuelPhase.Main1 && Duel.Phase < DuelPhase.Main2)
             {
                 int total_atk = 0;
@@ -1332,7 +1321,7 @@ namespace WindBot.Game.AI.Decks
             if (ex_1 != null && ex_1.Controller == 0) ex = ex_1;
             if (ex_2 != null && ex_2.Controller == 0) ex = ex_2;
             if (ex == null) return false;
-            if (!ex.HasLinkMarker(2)) return false;
+            if (!Has_down_arrow(ex.Id)) return false;
             IList<ClientCard> targets = new List<ClientCard>();
             foreach (ClientCard s_m in Bot.GetMonsters())
             {

--- a/Game/AI/Decks/TrickstarExecutor.cs
+++ b/Game/AI/Decks/TrickstarExecutor.cs
@@ -167,11 +167,6 @@ namespace WindBot.Game.AI.Decks
             return DefaultSpellSet();
         }
 
-        public bool Has_down_arrow(int id)
-        {
-            return (id == CardId.Linkuri || id == CardId.Linkspi || id == CardId.Unicorn);
-        }
-
         public bool IsTrickstar(int id)
         {
             return (id == CardId.Yellow || id == CardId.Red || id == CardId.Pink || id == CardId.White || id == CardId.Stage || id == CardId.Re || id == CardId.Crown);
@@ -184,6 +179,27 @@ namespace WindBot.Game.AI.Decks
                 // field spells that forbid other fields' activate
                 return (Card.Id != 71650854 && Card.Id != 78082039);
             }
+            return false;
+        }
+
+        public bool spell_trap_activate()
+        {
+            if (Card.Location != CardLocation.SpellZone && Card.Location != CardLocation.Hand) return true;
+            if (Enemy.HasInMonstersZone(CardId.Exterio,true) && !Bot.HasInHandOrHasInMonstersZone(CardId.Ghost)) return false;
+            if (Card.IsSpell())
+            {
+                if (Enemy.HasInMonstersZone(33198837, true) && !Bot.HasInHandOrHasInMonstersZone(CardId.Ghost)) return false;
+                if (Enemy.HasInSpellZone(61740673, true) || Bot.HasInSpellZone(61740673,true)) return false;
+                if (Enemy.HasInMonstersZone(37267041, true) || Bot.HasInMonstersZone(37267041, true)) return false;
+                return true;
+            }
+            if (Card.IsTrap())
+            {
+                if (Enemy.HasInSpellZone(51452091, true) || Bot.HasInSpellZone(51452091, true)) return false;
+                if (Enemy.HasInSpellZone(51452091, true) || Bot.HasInSpellZone(51452091, true)) return false;
+                return true;
+            }
+            // how to get here?
             return false;
         }
 
@@ -377,6 +393,7 @@ namespace WindBot.Game.AI.Decks
             }
             else
             {
+                if (!spell_trap_activate()) return false;
                 foreach (ClientCard card in spells)
                 {
                     if (card.IsFacedown() && card != stage_locked)
@@ -400,6 +417,7 @@ namespace WindBot.Game.AI.Decks
 
         public bool Feather_Act()
         {
+            if (!spell_trap_activate()) return false;
             if (AI.Utils.GetProblematicEnemySpell() != null)
             {
                 List<ClientCard> grave = Bot.GetGraveyardSpells();
@@ -418,6 +436,7 @@ namespace WindBot.Game.AI.Decks
 
         public bool Sheep_Act()
         {
+            if (!spell_trap_activate()) return false;
             if (Duel.Player == 0) return false;
             if (Duel.Phase == DuelPhase.End) return true;
             if (Duel.LastChainPlayer == 1 && (AI.Utils.IsChainTarget(Card) || (AI.Utils.GetLastChainCard().Id == CardId.Feather && !Bot.HasInSpellZone(CardId.Awaken)))) return true;
@@ -436,8 +455,8 @@ namespace WindBot.Game.AI.Decks
 
         public bool Stage_act()
         {
-            if (Card.Location != CardLocation.Hand) return false;
-
+            if (Card.Location == CardLocation.SpellZone && Card.HasPosition(CardPosition.FaceUp)) return false;
+            if (!spell_trap_activate()) return false;
             if (!NormalSummoned)
             {
                 if (!Bot.HasInHand(CardId.Yellow))
@@ -558,6 +577,7 @@ namespace WindBot.Game.AI.Decks
 
         public bool Pot_Act()
         {
+            if (!spell_trap_activate()) return false;
             return Bot.Deck.Count > 15;
         }
 
@@ -1035,6 +1055,7 @@ namespace WindBot.Game.AI.Decks
         public bool Reincarnation()
         {
             if (Card.Location == CardLocation.Grave) return Ts_reborn();
+            if (!spell_trap_activate()) return false;
             if (Bot.HasInHand(CardId.LockBird))
             {
                 if (lockbird_useful || AI.Utils.IsChainTarget(Card) || (Duel.Player == 1 && AI.Utils.ChainContainsCard(CardId.Feather))) {
@@ -1050,6 +1071,7 @@ namespace WindBot.Game.AI.Decks
         {
             if (Card.Location == CardLocation.Hand)
             {
+                if (!spell_trap_activate()) return false;
                 if (Duel.Phase <= DuelPhase.Main1) return Ts_reborn();
                 return false;
             }
@@ -1187,6 +1209,7 @@ namespace WindBot.Game.AI.Decks
         public bool Ring_act()
         {
             if (Duel.LastChainPlayer == 0 && AI.Utils.GetLastChainCard() != null && AI.Utils.GetLastChainCard().Id == CardId.Ghost) return false;
+            if (!spell_trap_activate()) return false;
             ClientCard target = AI.Utils.GetProblematicEnemyMonster();
             if (target == null && AI.Utils.IsChainTarget(Card))
             {
@@ -1646,8 +1669,10 @@ namespace WindBot.Game.AI.Decks
             return false;
         }
 
+        // unfinished.
         public bool GraveCall_eff()
         {
+            if (!spell_trap_activate()) return false;
             if (Duel.LastChainPlayer == 1)
             {
                 if (AI.Utils.GetLastChainCard().IsMonster() && Enemy.HasInGraveyard(AI.Utils.GetLastChainCard().Id))
@@ -1663,6 +1688,7 @@ namespace WindBot.Game.AI.Decks
 
         public bool DarkHole_eff()
         {
+            if (!spell_trap_activate()) return false;
             if (Bot.GetMonsterCount() == 0)
             {
                 

--- a/Game/GameBehavior.cs
+++ b/Game/GameBehavior.cs
@@ -272,7 +272,7 @@ namespace WindBot.Game
         {
             int player = packet.ReadInt16();
             string message = packet.ReadUnicode(256);
-            string speaker = _room.Names[player];
+            string speaker = (player < 4) ? _room.Names[player] : "Unknown";
             Logger.DebugWriteLine(speaker + "(" + player.ToString() + ")" + ": " + message);
             return;
         }

--- a/Game/GameBehavior.cs
+++ b/Game/GameBehavior.cs
@@ -457,21 +457,61 @@ namespace WindBot.Game
             _duel.Phase = (DuelPhase)packet.ReadInt16();
             if (_debug && _duel.Phase == DuelPhase.Standby)
             {
+                Logger.DebugWriteLine("*********LifePoint*********");
+                Logger.DebugWriteLine(_duel.Fields[0].LifePoints.ToString() + ":" + _duel.Fields[1].LifePoints.ToString());
                 Logger.DebugWriteLine("*********Bot Hand*********");
+                string bot_hand = "";
                 foreach (ClientCard card in _duel.Fields[0].Hand)
                 {
-                    Logger.DebugWriteLine(card.Name);
+                    bot_hand += (card.Name + ", ");
                 }
+                Logger.DebugWriteLine(bot_hand);
                 Logger.DebugWriteLine("*********Bot Spell*********");
-                foreach (ClientCard card in _duel.Fields[0].SpellZone)
+                string bot_spell = "";
+                for (int i = 0; i < 7; ++i)
                 {
-                    Logger.DebugWriteLine(card?.Name);
+                    ClientCard card = _duel.Fields[0].SpellZone[i];
+                    if (card != null)
+                    {
+                        bot_spell += (card?.Name + "(" + i.ToString() + "," + (CardPosition)card.Position + "), ");
+                    }
                 }
+                Logger.DebugWriteLine(bot_spell);
                 Logger.DebugWriteLine("*********Bot Monster*********");
-                foreach (ClientCard card in _duel.Fields[0].MonsterZone)
+                string bot_monster = "";
+                for (int i = 0; i < 7; ++i)
                 {
-                    Logger.DebugWriteLine(card?.Name);
+                    ClientCard card = _duel.Fields[0].MonsterZone[i];
+                    if (card != null)
+                    {
+                        bot_monster += (card?.Name + "(" + i.ToString() + "," + (CardPosition)card.Position + "), ");
+                    }
                 }
+                Logger.DebugWriteLine(bot_monster);
+                Logger.DebugWriteLine("*********Enemy Monster*********");
+                string enemy_monster = "";
+                for (int i = 0; i < 7; ++i)
+                {
+                    ClientCard card = _duel.Fields[1].MonsterZone[i];
+                    if (card != null)
+                    {
+                        enemy_monster += (card?.Name + "(" + i.ToString() + "," + (CardPosition)card.Position + "), ");
+                    }
+                }
+                Logger.DebugWriteLine(enemy_monster);
+                Logger.DebugWriteLine("*********Enemy Spell*********");
+                string enemy_spell = "";
+                for (int i = 0; i < 7; ++i)
+                {
+                    ClientCard card = _duel.Fields[1].SpellZone[i];
+                    if (card != null)
+                    {
+                        enemy_spell += (card?.Name + "(" + i.ToString() + "," + (CardPosition)card.Position + "), ");
+                    }
+                }
+                Logger.DebugWriteLine(enemy_spell);
+                Logger.DebugWriteLine("*********Enemy Hand*********");
+                Logger.DebugWriteLine("Count: " + _duel.Fields[1].Hand.Count.ToString());
                 Logger.DebugWriteLine("*********Finish*********");
             }
             if (_debug)

--- a/Game/GameBehavior.cs
+++ b/Game/GameBehavior.cs
@@ -272,10 +272,9 @@ namespace WindBot.Game
         {
             int player = packet.ReadInt16();
             string message = packet.ReadUnicode(256);
-            string myName = (player != 0) ? _room.Names[1] : _room.Names[0];
-            string otherName = (player == 0) ? _room.Names[1] : _room.Names[0];
-            if (player < 4)
-                Logger.DebugWriteLine(otherName + " say to " + myName + ": " + message);
+            string speaker = _room.Names[player];
+            Logger.DebugWriteLine(speaker + "(" + player.ToString() + ")" + ": " + message);
+            return;
         }
 
         private void OnErrorMsg(BinaryReader packet)
@@ -354,7 +353,7 @@ namespace WindBot.Game
             int player = GetLocalPlayer(packet.ReadByte());
             int count = packet.ReadByte();
             if (_debug)
-                Logger.WriteLine("(" + player.ToString() + " draw " + count.ToString() + " card)");
+                Logger.DebugWriteLine("(" + player.ToString() + " draw " + count.ToString() + " card)");
 
             for (int i = 0; i < count; ++i)
             {
@@ -458,25 +457,25 @@ namespace WindBot.Game
             _duel.Phase = (DuelPhase)packet.ReadInt16();
             if (_debug && _duel.Phase == DuelPhase.Standby)
             {
-                Logger.WriteLine("*********Bot Hand*********");
+                Logger.DebugWriteLine("*********Bot Hand*********");
                 foreach (ClientCard card in _duel.Fields[0].Hand)
                 {
-                    Logger.WriteLine(card.Name);
+                    Logger.DebugWriteLine(card.Name);
                 }
-                Logger.WriteLine("*********Bot Spell*********");
+                Logger.DebugWriteLine("*********Bot Spell*********");
                 foreach (ClientCard card in _duel.Fields[0].SpellZone)
                 {
-                    Logger.WriteLine(card?.Name);
+                    Logger.DebugWriteLine(card?.Name);
                 }
-                Logger.WriteLine("*********Bot Monster*********");
+                Logger.DebugWriteLine("*********Bot Monster*********");
                 foreach (ClientCard card in _duel.Fields[0].MonsterZone)
                 {
-                    Logger.WriteLine(card?.Name);
+                    Logger.DebugWriteLine(card?.Name);
                 }
-                Logger.WriteLine("*********Finish*********");
+                Logger.DebugWriteLine("*********Finish*********");
             }
             if (_debug)
-                Logger.WriteLine("(Go to " + (_duel.Phase.ToString()) + ")");
+                Logger.DebugWriteLine("(Go to " + (_duel.Phase.ToString()) + ")");
             _duel.LastSummonPlayer = -1;
             _duel.Fields[0].BattlingMonster = null;
             _duel.Fields[1].BattlingMonster = null;
@@ -489,7 +488,7 @@ namespace WindBot.Game
             int final = _duel.Fields[player].LifePoints - packet.ReadInt32();
             if (final < 0) final = 0;
             if (_debug)
-                Logger.WriteLine("(" + player.ToString() + " got damage , LifePoint left= " + final.ToString() + ")");
+                Logger.DebugWriteLine("(" + player.ToString() + " got damage , LifePoint left= " + final.ToString() + ")");
             _duel.Fields[player].LifePoints = final;
         }
 
@@ -526,7 +525,7 @@ namespace WindBot.Game
                 if (card != null)
                 {
                     if (_debug)
-                        Logger.WriteLine("(" + previousControler.ToString() + " 's " + (card.Name ?? "UnKnowCard") + " deattach " + (NamedCard.Get(cardId)?.Name) + ")");
+                        Logger.DebugWriteLine("(" + previousControler.ToString() + " 's " + (card.Name ?? "UnKnowCard") + " deattach " + (NamedCard.Get(cardId)?.Name) + ")");
                     card.Overlays.Remove(cardId);
                 }
                 previousLocation = 0; // the card is removed when it go to overlay, so here we treat it as a new card
@@ -541,7 +540,7 @@ namespace WindBot.Game
                 if (card != null)
                 {
                     if (_debug)
-                        Logger.WriteLine("(" + previousControler.ToString() + " 's " + (card.Name ?? "UnKnowCard") + " overlay " + (NamedCard.Get(cardId)?.Name) + ")");
+                        Logger.DebugWriteLine("(" + previousControler.ToString() + " 's " + (card.Name ?? "UnKnowCard") + " overlay " + (NamedCard.Get(cardId)?.Name) + ")");
                     card.Overlays.Add(cardId);
                 }
             }
@@ -550,7 +549,7 @@ namespace WindBot.Game
                 if (previousLocation == 0)
                 {
                     if (_debug)
-                        Logger.WriteLine("(" + previousControler.ToString() + " 's " + (NamedCard.Get(cardId)?.Name)
+                        Logger.DebugWriteLine("(" + previousControler.ToString() + " 's " + (NamedCard.Get(cardId)?.Name)
                         + " appear in " + (CardLocation)currentLocation + ")");
                     _duel.AddCard((CardLocation)currentLocation, cardId, currentControler, currentSequence, currentPosition);
                 }
@@ -558,7 +557,7 @@ namespace WindBot.Game
                 {
                     _duel.AddCard((CardLocation)currentLocation, card, currentControler, currentSequence, currentPosition, cardId);
                     if (_debug && card != null)
-                        Logger.WriteLine("(" + previousControler.ToString() + " 's " + (card.Name ?? "UnKnowCard")
+                        Logger.DebugWriteLine("(" + previousControler.ToString() + " 's " + (card.Name ?? "UnKnowCard")
                         + " from " +
                         (CardLocation)previousLocation + " move to " + (CardLocation)currentLocation + ")");
                 }
@@ -580,8 +579,8 @@ namespace WindBot.Game
             ClientCard defendcard = _duel.GetCard(cd, (CardLocation)ld, sd);
             if (_debug)
             {
-                if (defendcard == null) Logger.WriteLine("(" + (attackcard.Name ?? "UnKnowCard") + " direct attack!!)");
-                else Logger.WriteLine("(" + ca.ToString() + " 's " + (attackcard.Name ?? "UnKnowCard") + " attack  " + cd.ToString() + " 's " + (defendcard.Name ?? "UnKnowCard") + ")");
+                if (defendcard == null) Logger.DebugWriteLine("(" + (attackcard.Name ?? "UnKnowCard") + " direct attack!!)");
+                else Logger.DebugWriteLine("(" + ca.ToString() + " 's " + (attackcard.Name ?? "UnKnowCard") + " attack  " + cd.ToString() + " 's " + (defendcard.Name ?? "UnKnowCard") + ")");
             }                
             _duel.Fields[attackcard.Controller].BattlingMonster = attackcard;
             _duel.Fields[1 - attackcard.Controller].BattlingMonster = defendcard;
@@ -605,7 +604,7 @@ namespace WindBot.Game
             {
                 card.Position = cp;
                 if (_debug)
-                    Logger.WriteLine("(" + (card.Name ?? "UnKnowCard") + " change position to " + (CardPosition)cp + ")");
+                    Logger.DebugWriteLine("(" + (card.Name ?? "UnKnowCard") + " change position to " + (CardPosition)cp + ")");
             }
         }
 
@@ -619,7 +618,7 @@ namespace WindBot.Game
             ClientCard card = _duel.GetCard(pcc, pcl, pcs, subs);
             int cc = GetLocalPlayer(packet.ReadByte());
             if (_debug)
-                if (card != null) Logger.WriteLine("(" + cc.ToString() + " 's " + (card.Name ?? "UnKnowCard") + " activate effect)");
+                if (card != null) Logger.DebugWriteLine("(" + cc.ToString() + " 's " + (card.Name ?? "UnKnowCard") + " activate effect)");
             _ai.OnChaining(card, cc);
             _duel.ChainTargets.Clear();
             _duel.LastSummonPlayer = -1;
@@ -756,7 +755,7 @@ namespace WindBot.Game
                 ClientCard card = _duel.GetCard(player, (CardLocation)loc, seq);
                 if (card == null) continue;
                 if (_debug)
-                    Logger.WriteLine("(" + (CardLocation)loc + " 's " + (card.Name ?? "UnKnowCard") + " become target)");
+                    Logger.DebugWriteLine("(" + (CardLocation)loc + " 's " + (card.Name ?? "UnKnowCard") + " become target)");
                 _duel.ChainTargets.Add(card);
             }
         }

--- a/Logger.cs
+++ b/Logger.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.IO;
 
 namespace WindBot
 {
@@ -12,6 +13,15 @@ namespace WindBot
         {
 #if DEBUG
             Console.WriteLine("[" + DateTime.Now.ToString("yy-MM-dd HH:mm:ss") + "] " + message);
+            using (FileStream fs = new FileStream(@"d:\windbot-log.txt", FileMode.OpenOrCreate, FileAccess.Write))
+              {
+                  using (StreamWriter sw = new StreamWriter(fs))
+                 {
+                     sw.BaseStream.Seek(0, SeekOrigin.End);
+                     sw.WriteLine("{0}", "[" + DateTime.Now.ToString("yy-MM-dd HH:mm:ss") + "] " + message);
+                     sw.Flush();
+                 }
+             }
 #endif
         }
         public static void WriteErrorLine(string message)

--- a/Logger.cs
+++ b/Logger.cs
@@ -13,7 +13,7 @@ namespace WindBot
         {
 #if DEBUG
             Console.WriteLine("[" + DateTime.Now.ToString("yy-MM-dd HH:mm:ss") + "] " + message);
-            using (FileStream fs = new FileStream(@"d:\windbot-log.txt", FileMode.OpenOrCreate, FileAccess.Write))
+            using (FileStream fs = new FileStream(@Path.GetFullPath("log.txt"), FileMode.OpenOrCreate, FileAccess.Write))
               {
                   using (StreamWriter sw = new StreamWriter(fs))
                  {


### PR DESCRIPTION
It fix the speaker's bug when there're more than 2 players(like TAG duel or those who are spectators). However, the error of speaker's name still exists. I think this is because that when the duel starts, the speaker's index is not the same as that before the duel.
For example, with a name list ["Bot", "Enemy"], the index when Bot speaks is 0 before the duel starts. But when the duel starts, the index depends on whether Bot goes first. If Bot goes first, its index is 0, otherwise it will be 1, which accounts for the error.