### PR TITLE
GameBehavior & Logger

### DIFF
--- a/Logger.cs
+++ b/Logger.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.IO;
 
 namespace WindBot
 {
@@ -12,6 +13,15 @@ namespace WindBot
         {
 #if DEBUG
             Console.WriteLine("[" + DateTime.Now.ToString("yy-MM-dd HH:mm:ss") + "] " + message);
+            using (FileStream fs = new FileStream(@Path.GetFullPath("log.txt"), FileMode.OpenOrCreate, FileAccess.Write))
+              {
+                  using (StreamWriter sw = new StreamWriter(fs))
+                 {
+                     sw.BaseStream.Seek(0, SeekOrigin.End);
+                     sw.WriteLine("{0}", "[" + DateTime.Now.ToString("yy-MM-dd HH:mm:ss") + "] " + message);
+                     sw.Flush();
+                 }
+             }
 #endif
         }
         public static void WriteErrorLine(string message)


### PR DESCRIPTION
It fix the speaker's bug when there're more than 2 players(like TAG duel or those who are spectators). However, the error of speaker's name still exists. I think this is because that when the duel starts, the speaker's index is not the same as that before the duel.

For example, with a name list ["Bot", "Enemy"], the index when Bot speaks is 0 before the duel starts. But when the duel starts, the index depends on whether Bot goes first. If Bot goes first, its index is 0, otherwise it will be 1, which accounts for the error.