### PR TITLE
Add a Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,11 @@
+FROM mono
+
+COPY . /windbot-source
+WORKDIR /windbot-source
+RUN xbuild /p:Configuration=Release /p:TargetFrameworkVersion=v4.5 /p:OutDir=/windbot/
+
+WORKDIR /windbot
+RUN curl --retry 5 --connect-timeout 30 --location --remote-header-name --remote-name https://github.com/moecube/ygopro-database/raw/master/locales/zh-CN/cards.cdb
+
+EXPOSE 2399
+CMD [ "mono", "/windbot/WindBot.exe", "ServerMode=true", "ServerPort=2399" ]


### PR DESCRIPTION
This is useful when deploying WindBot with Docker. Port 2399 is being listened for HTTP API when starting the container. This container could be connected to other YGOPro server containers for AI duel service. Alternatively, this port could also be exposed for hosting WindBot for remote servers.
In addition, `/windbot/cards.cdb` could be volumed for custom database.