### PR TITLE
Fix Eater of Millions' summon process

### DIFF
--- a/Game/AI/Decks/GrenMajuThunderBoarderExecutor.cs
+++ b/Game/AI/Decks/GrenMajuThunderBoarderExecutor.cs
@@ -523,7 +523,7 @@ namespace WindBot.Game.AI.Decks
                 targets.Add(e_c);                
                 if (targets.Count >= 5)
                 {
-                    AI.SelectCard(targets);
+                    EaterOfMillionssSelect(targets);
                     /*AI.SelectCard(new[] {
                         CardId.BingirsuTheWorldChaliceWarrior,
                         CardId.TopologicTrisbaena,
@@ -548,11 +548,19 @@ namespace WindBot.Game.AI.Decks
                 targets.Add(s_c);
                 if (targets.Count >= 5)
                 {
-                    AI.SelectCard(targets);
+                    EaterOfMillionssSelect(targets);
                     return true;
                 }
             }
             return false;
+        }
+
+        private void EaterOfMillionssSelect(IList<ClientCard> targets)
+        {
+            foreach (ClientCard card in targets)
+            {
+                AI.SelectCard(card);
+            }
         }
 
         private bool EaterOfMillionseff()

--- a/Game/AI/Decks/GrenMajuThunderBoarderExecutor.cs
+++ b/Game/AI/Decks/GrenMajuThunderBoarderExecutor.cs
@@ -557,9 +557,9 @@ namespace WindBot.Game.AI.Decks
 
         private void EaterOfMillionssSelect(IList<ClientCard> targets)
         {
-            foreach (ClientCard card in targets)
+            for (int times = 0; times < targets.Count; times ++)
             {
-                AI.SelectCard(card);
+                AI.SelectCard(targets);
             }
         }
 

--- a/Game/AI/Decks/PhantasmExecutor.cs
+++ b/Game/AI/Decks/PhantasmExecutor.cs
@@ -492,17 +492,17 @@ namespace WindBot.Game.AI.Decks
         }
         private void EaterOfMillionssSelect(IList<ClientCard> targets)
         {
-            foreach (ClientCard card in targets)
+            for (int times = 0; times < targets.Count; times ++)
             {
-                AI.SelectCard(card);
+                AI.SelectCard(targets);
             }
         }
 
         private void EaterOfMillionssSelect(params int[] ids)
         {
-            foreach (int cardId in ids)
+            for (int times = 0; times < ids.Length; times ++)
             {
-                AI.SelectCard(cardId);
+                AI.SelectCard(ids);
             }
         }
 

--- a/Game/AI/Decks/PhantasmExecutor.cs
+++ b/Game/AI/Decks/PhantasmExecutor.cs
@@ -468,7 +468,7 @@ namespace WindBot.Game.AI.Decks
             IList<ClientCard> material_list = new List<ClientCard>();
             if(Bot.HasInExtra(CardId.BorreloadDragon))
             {
-                AI.SelectCard(
+                EaterOfMillionssSelect(
                     CardId.TopologicBomberDragon,
                     CardId.TopologicTrisbaena,
                     CardId.KnightmareGryphon,
@@ -484,7 +484,26 @@ namespace WindBot.Game.AI.Decks
                     material_list.Add(m);
                 }
             }
+            if (material_list.Count == 5)
+            {
+                EaterOfMillionssSelect(material_list);
+            }
             return true;
+        }
+        private void EaterOfMillionssSelect(IList<ClientCard> targets)
+        {
+            foreach (ClientCard card in targets)
+            {
+                AI.SelectCard(card);
+            }
+        }
+
+        private void EaterOfMillionssSelect(params int[] ids)
+        {
+            foreach (int cardId in ids)
+            {
+                AI.SelectCard(cardId);
+            }
         }
 
         private bool EaterOfMillionseff()

--- a/Game/AI/Decks/TrickstarExecutor.cs
+++ b/Game/AI/Decks/TrickstarExecutor.cs
@@ -728,9 +728,9 @@ namespace WindBot.Game.AI.Decks
 
         public void Eater_ss_select(IList<ClientCard> cards)
         {
-            foreach (ClientCard card in cards)
+            for (int times = 0; times < cards.Count; times ++)
             {
-                AI.SelectCard(card);
+                AI.SelectCard(cards);
             }
         }
 

--- a/Game/AI/Decks/TrickstarExecutor.cs
+++ b/Game/AI/Decks/TrickstarExecutor.cs
@@ -709,7 +709,7 @@ namespace WindBot.Game.AI.Decks
                 targets.Add(e_c);
                 if (targets.Count >= 5)
                 {
-                    AI.SelectCard(targets);
+                    Eater_ss_select(targets);
                     return true;
                 }
             }
@@ -719,11 +719,19 @@ namespace WindBot.Game.AI.Decks
                 targets.Add(s_c);
                 if (targets.Count >= 5)
                 {
-                    AI.SelectCard(targets);
+                    Eater_ss_select(targets);
                     return true;
                 }
             }
             return false;
+        }
+
+        public void Eater_ss_select(IList<ClientCard> cards)
+        {
+            foreach (ClientCard card in cards)
+            {
+                AI.SelectCard(card);
+            }
         }
 
         public bool Eater_eff()


### PR DESCRIPTION
Now Eater of Millions use SelectUnselect to choose cost, using AI.SelectCard() only once before will make the process continue with no selecting card next. It's necessary to call AI.SelectCard() mutiple times for SelectUnselect.