### PR TITLE
Fix bot negating Horus monsters' special summoning

### DIFF
--- a/Game/AI/Decks/DarkMagicianExecutor.cs
+++ b/Game/AI/Decks/DarkMagicianExecutor.cs
@@ -496,6 +496,7 @@ namespace WindBot.Game.AI.Decks
         {
             if (Bot.LifePoints > 1500 && Duel.LastChainPlayer == 1)
                 return true;
+            if (DefaultOnlyHorusSpSummoning()) return false;
             return false;
         }
 

--- a/Game/AI/Decks/GrenMajuThunderBoarderExecutor.cs
+++ b/Game/AI/Decks/GrenMajuThunderBoarderExecutor.cs
@@ -437,6 +437,7 @@ namespace WindBot.Game.AI.Decks
 
         private bool ThunderKingRaiOheff()
         {
+           if (DefaultOnlyHorusSpSummoning()) return false;
            if(Duel.SummoningCards.Count > 0)
            {
                 foreach(ClientCard m in Duel.SummoningCards)

--- a/Game/AI/Decks/TimeThiefExecutor.cs
+++ b/Game/AI/Decks/TimeThiefExecutor.cs
@@ -370,6 +370,7 @@ namespace WindBot.Game.AI.Decks
         }
         private bool ThunderKingRaiOheff()
         {
+            if (DefaultOnlyHorusSpSummoning()) return false;
             if (Duel.SummoningCards.Count > 0)
             {
                 foreach (ClientCard m in Duel.SummoningCards)

--- a/Game/AI/DefaultExecutor.cs
+++ b/Game/AI/DefaultExecutor.cs
@@ -213,6 +213,7 @@ namespace WindBot.Game.AI
             public const int AncientWarriors = 0x137;
             public const int RescueACE = 0x18b;
             public const int VanquishSoul = 0x195;
+            public const int Horus = 0x19d;
         }
 
         protected DefaultExecutor(GameAI ai, Duel duel)
@@ -834,7 +835,7 @@ namespace WindBot.Game.AI
         /// </summary>
         protected bool DefaultSolemnJudgment()
         {
-            return !Util.IsChainTargetOnly(Card) && !(Duel.Player == 0 && Duel.LastChainPlayer == -1) && DefaultTrap();
+            return !Util.IsChainTargetOnly(Card) && !(Duel.Player == 0 && Duel.LastChainPlayer == -1) && !DefaultOnlyHorusSpSummoning() && DefaultTrap();
         }
 
         /// <summary>
@@ -842,7 +843,7 @@ namespace WindBot.Game.AI
         /// </summary>
         protected bool DefaultSolemnWarning()
         {
-            return (Bot.LifePoints > 2000) && !(Duel.Player == 0 && Duel.LastChainPlayer == -1) && DefaultTrap();
+            return (Bot.LifePoints > 2000) && !(Duel.Player == 0 && Duel.LastChainPlayer == -1) && !DefaultOnlyHorusSpSummoning() && DefaultTrap();
         }
 
         /// <summary>
@@ -850,7 +851,30 @@ namespace WindBot.Game.AI
         /// </summary>
         protected bool DefaultSolemnStrike()
         {
-            return (Bot.LifePoints > 1500) && !(Duel.Player == 0 && Duel.LastChainPlayer == -1) && DefaultTrap();
+            return (Bot.LifePoints > 1500) && !(Duel.Player == 0 && Duel.LastChainPlayer == -1) && !DefaultOnlyHorusSpSummoning() && DefaultTrap();
+        }
+
+        /// <summary>
+        /// Check whether only Horus monster is special summoning.
+        /// If returning true, should not negate the special summon since it can be special summoned again.
+        /// </summary>
+        /// <returns></returns>
+        protected bool DefaultOnlyHorusSpSummoning()
+        {
+            if (Duel.SummoningCards.Count != 0)
+            {
+                bool notOnlyHorusFlag = false;
+                foreach (ClientCard card in Duel.SummoningCards)
+                {
+                    if (!card.HasSetcode(_Setcode.Horus))
+                    {
+                        notOnlyHorusFlag = true;
+                        break;
+                    }
+                }
+                return !notOnlyHorusFlag;
+            }
+            return false;
         }
 
         /// <summary>

--- a/Game/AI/DefaultExecutor.cs
+++ b/Game/AI/DefaultExecutor.cs
@@ -866,7 +866,7 @@ namespace WindBot.Game.AI
                 bool notOnlyHorusFlag = false;
                 foreach (ClientCard card in Duel.SummoningCards)
                 {
-                    if (!card.HasSetcode(_Setcode.Horus))
+                    if (!card.HasSetcode(_Setcode.Horus) || card.LastLocation != CardLocation.Grave)
                     {
                         notOnlyHorusFlag = true;
                         break;

--- a/Game/ClientCard.cs
+++ b/Game/ClientCard.cs
@@ -15,6 +15,7 @@ namespace WindBot.Game
         public int Position { get; set; }
         public int Sequence { get; set; }
         public CardLocation Location { get; set; }
+        public CardLocation LastLocation { get; set; }
         public int Alias { get; private set; }
         public int Level { get; private set; }
         public int Rank { get; private set; }
@@ -70,6 +71,7 @@ namespace WindBot.Game
             ActionIndex = new int[16];
             ActionActivateIndex = new Dictionary<int, int>();
             Location = loc;
+            LastLocation = 0;
         }
 
         public void SetId(int id)

--- a/Game/GameBehavior.cs
+++ b/Game/GameBehavior.cs
@@ -376,15 +376,10 @@ namespace WindBot.Game
             _duel.Fields[GetLocalPlayer(1)].Init(deck, extra);
 
             // in case of ending duel in chain's solving
-            _duel.LastChainPlayer = -1;
-            _duel.LastChainLocation = 0;
             _duel.CurrentChain.Clear();
             _duel.ChainTargets.Clear();
-            _duel.LastChainTargets.Clear();
             _duel.ChainTargetOnly.Clear();
-            _duel.LastSummonPlayer = -1;
             _duel.SummoningCards.Clear();
-            _duel.LastSummonedCards.Clear();
             _duel.SolvingChainIndex = 0;
             _duel.NegatedChainIndexList.Clear();
 
@@ -803,6 +798,7 @@ namespace WindBot.Game
             _duel.ChainTargetOnly.Clear();
             _duel.SolvingChainIndex = 0;
             _duel.NegatedChainIndexList.Clear();
+            _duel.SummoningCards.Clear();
         }
 
         private void OnCardSorting(BinaryReader packet)

--- a/Game/GameBehavior.cs
+++ b/Game/GameBehavior.cs
@@ -610,6 +610,10 @@ namespace WindBot.Game
             packet.ReadInt32(); // reason
 
             ClientCard card = _duel.GetCard(previousControler, (CardLocation)previousLocation, previousSequence);
+            if (card != null)
+            {
+                card.LastLocation = (CardLocation)previousLocation;
+            }
             if ((previousLocation & (int)CardLocation.Overlay) != 0)
             {
                 previousLocation = previousLocation & 0x7f;


### PR DESCRIPTION
Since Horus monster can be special summoned until it's successfully special summoned, Bot should not try to negate their special summoning.