### PR TITLE
Fix bot's behavior in SelectUnSelect

### DIFF
--- a/Game/ClientCard.cs
+++ b/Game/ClientCard.cs
@@ -82,8 +82,7 @@ namespace WindBot.Game
             if (Data != null)
             {
                 Name = Data.Name;
-                if (Data.Alias != 0)
-                    Alias = Data.Alias;
+                Alias = Data.Alias;
             } else {
                 Name = null;
                 Alias = 0;

--- a/Game/GameBehavior.cs
+++ b/Game/GameBehavior.cs
@@ -1090,7 +1090,7 @@ namespace WindBot.Game
                 else
                     card = _duel.GetCard(player, loc, seq);
                 if (card == null) continue;
-                if (card.Id == 0)
+                if (card.Id == 0 || card.Location == CardLocation.Deck)
                     card.SetId(id);
                 cards.Add(card);
             }
@@ -1102,6 +1102,14 @@ namespace WindBot.Game
                 CardLocation loc = (CardLocation)packet.ReadByte();
                 int seq = packet.ReadByte();
                 packet.ReadByte(); // pos
+                ClientCard card;
+                if (((int)loc & (int)CardLocation.Overlay) != 0)
+                    card = new ClientCard(id, CardLocation.Overlay, -1);
+                else
+                    card = _duel.GetCard(player, loc, seq);
+                if (card == null) continue;
+                if (card.Id == 0 || card.Location == CardLocation.Deck)
+                    card.SetId(id);
             }
             if (count2 == 0) cancelable = false;
 


### PR DESCRIPTION
![image](https://github.com/IceYGO/windbot/assets/4057650/68c84f83-8887-4220-955b-5fdbd42c305e)
![image](https://github.com/IceYGO/windbot/assets/4057650/b3dfc66e-e7ed-41e8-9411-319284cb49ed)

Cards in deck's sequence will changes while solving SelectUnselect, so their id should be updated in operation.