### PR TITLE
Fix

### DIFF
--- a/Game/AI/DefaultExecutor.cs
+++ b/Game/AI/DefaultExecutor.cs
@@ -1579,7 +1579,7 @@ namespace WindBot.Game.AI
             if (originId == 0) originId = card.Data.Id;
             return crossoutDesignatorIdList.Contains(originId)
                 || (calledbytheGraveIdCountMap.ContainsKey(originId) && calledbytheGraveIdCountMap[originId] > 0)
-                || card.IsDisabled();
+                || (card.IsDisabled() && ((int)card.Location & (int)CardLocation.Onfield) > 0);
         }
         
         protected bool DefaultCheckWhetherCardIdIsNegated(int cardId)

--- a/Game/GameAI.cs
+++ b/Game/GameAI.cs
@@ -1162,6 +1162,7 @@ namespace WindBot.Game
 
         private bool ShouldExecute(CardExecutor exec, ClientCard card, ExecutorType type, int desc = -1, int timing = -1)
         {
+            Executor.SetCard(type, card, desc, timing);
             if (card.Id != 0 && type == ExecutorType.Activate)
             {
                 if (_activatedCards.ContainsKey(card.Id) && _activatedCards[card.Id] >= 9)
@@ -1169,7 +1170,6 @@ namespace WindBot.Game
                 if (!Executor.OnPreActivate(card))
                     return false;
             }
-            Executor.SetCard(type, card, desc, timing);
             bool result = card != null && exec.Type == type &&
                 (exec.CardId == -1 || exec.CardId == card.Id) &&
                 (exec.Func == null || exec.Func());

--- a/Game/GameBehavior.cs
+++ b/Game/GameBehavior.cs
@@ -1024,7 +1024,7 @@ namespace WindBot.Game
                     card.Controller = player;
                 }
                 if (card == null) continue;
-                if (card.Id == 0)
+                if (card.Id == 0 || card.Location == CardLocation.Deck)
                     card.SetId(id);
                 cards.Add(card);
             }


### PR DESCRIPTION
* Fix deck card's update, like #198 
* * Usually occurs when you send cards to the bottom of the deck, like **Pot of Prosperity**
* Fix DefaultCheckWhetherCardIsNegated
* * When card leaves field, Card.Disabled won't update, maybe it's better to update again when card is moved.