### PR TITLE
Fix Highest and Lowest Attack/Defense being flipped

### DIFF
--- a/Game/AI/CardContainer.cs
+++ b/Game/AI/CardContainer.cs
@@ -55,28 +55,32 @@ namespace WindBot.Game.AI
         {
             return cards
                 .Where(card => card?.Data != null && card.HasType(CardType.Monster) && card.IsFaceup() && !(canBeTarget && card.IsShouldNotBeTarget()))
-                .OrderBy(card => card.Attack).FirstOrDefault();
+                .OrderByDescending(card => card.Attack)
+                .FirstOrDefault();
         }
 
         public static ClientCard GetHighestDefenseMonster(this IEnumerable<ClientCard> cards, bool canBeTarget = false)
         {
             return cards
                 .Where(card => card?.Data != null && card.HasType(CardType.Monster) && card.IsFaceup() && !(canBeTarget && card.IsShouldNotBeTarget()))
-                .OrderBy(card => card.Defense).FirstOrDefault();
+                .OrderByDescending(card => card.Defense)
+                .FirstOrDefault();
         }
 
         public static ClientCard GetLowestAttackMonster(this IEnumerable<ClientCard> cards, bool canBeTarget = false)
         {
             return cards
                 .Where(card => card?.Data != null && card.HasType(CardType.Monster) && card.IsFaceup() && !(canBeTarget && card.IsShouldNotBeTarget()))
-                .OrderByDescending(card => card.Attack).FirstOrDefault();
+                .OrderBy(card => card.Attack)
+                .FirstOrDefault();
         }
 
         public static ClientCard GetLowestDefenseMonster(this IEnumerable<ClientCard> cards, bool canBeTarget = false)
         {
             return cards
                 .Where(card => card?.Data != null && card.HasType(CardType.Monster) && card.IsFaceup() && !(canBeTarget && card.IsShouldNotBeTarget()))
-                .OrderByDescending(card => card.Defense).FirstOrDefault();
+                .OrderBy(card => card.Defense)
+                .FirstOrDefault();
         }
 
         public static bool ContainsMonsterWithLevel(this IEnumerable<ClientCard> cards, int level)


### PR DESCRIPTION
I am writing a YGO-Simulator, that simulates a lot of Duels as fast as possible and I am using WindBot for that.
While going through the code, I noticed that the highest and lowest Attack/Defense Monster helper-methods are flipped.

Is that intended?
It does not seem like it is...

If it is intended, this PR can be closed immediately.