### PR TITLE
fix SelectSum for Mandatory Cards with Level-Changing effects

### DIFF
--- a/Game/GameBehavior.cs
+++ b/Game/GameBehavior.cs
@@ -1601,12 +1601,25 @@ namespace WindBot.Game
                 }
             }
 
-            for (int k = 0; k < mandatoryCards.Count; ++k)
+            IList<ClientCard> selected = SelectSumRecursive(0, sumval);
+
+            IList<ClientCard> SelectSumRecursive(int cardIndex, int sumVal)
             {
-                sumval -= mandatoryCards[k].OpParam1;
+                ClientCard card = mandatoryCards[cardIndex];
+                for (int opParam = 0; opParam < 2; opParam++)
+                {
+                    int opParamValue = opParam == 0 ? card.OpParam1 : card.OpParam2;
+                    int tempSumVal = sumVal - opParamValue;
+
+                    IList<ClientCard> tempResult = cardIndex == mandatoryCards.Count - 1
+                                                       ? _ai.OnSelectSum(cards, tempSumVal, min, max, _select_hint, mode)
+                                                       : SelectSumRecursive(cardIndex + 1, tempSumVal);
+                    if (tempResult.Count >= min) return tempResult;
+                }
+
+                return new List<ClientCard>();
             }
 
-            IList<ClientCard> selected = _ai.OnSelectSum(cards, sumval, min, max, _select_hint, mode);
             _select_hint = 0;
 
             byte[] result = new byte[mandatoryCards.Count + selected.Count + 1];

--- a/Game/GameBehavior.cs
+++ b/Game/GameBehavior.cs
@@ -1605,15 +1605,15 @@ namespace WindBot.Game
 
             IList<ClientCard> SelectSumRecursive(int cardIndex, int sumVal)
             {
+                if (cardIndex >= mandatoryCards.Count) return _ai.OnSelectSum(cards, sumVal, min, max, _select_hint, mode);
+
                 ClientCard card = mandatoryCards[cardIndex];
                 for (int opParam = 0; opParam < 2; opParam++)
                 {
                     int opParamValue = opParam == 0 ? card.OpParam1 : card.OpParam2;
                     int tempSumVal = sumVal - opParamValue;
 
-                    IList<ClientCard> tempResult = cardIndex == mandatoryCards.Count - 1
-                                                       ? _ai.OnSelectSum(cards, tempSumVal, min, max, _select_hint, mode)
-                                                       : SelectSumRecursive(cardIndex + 1, tempSumVal);
+                    IList<ClientCard> tempResult = SelectSumRecursive(cardIndex + 1, tempSumVal);
                     if (tempResult.Count >= min) return tempResult;
                 }
 


### PR DESCRIPTION
I opened an Issue explaining the Bug I encountered and how this would fix it: #206 
This is a recursive fix for that. There is probably a more efficient way to do this, but I cannot think of one right now.
Also this probably does not need to be a local function in the middle of the Method but I put it there for demonstration purposes