### PR TITLE
关于超重武者的修复

### DIFF
--- a/Game/AI/Decks/SuperheavySamuraiExecutor.cs
+++ b/Game/AI/Decks/SuperheavySamuraiExecutor.cs
@@ -944,6 +944,8 @@ namespace WindBot.Game.AI.Decks
         }
         private bool SoulpiercerEquipFunction()
         {
+            if (DefaultCheckWhetherCardIdIsNegated(Card.Id))
+                return false;
             if (Card.Location != CardLocation.Hand)
                 return false;
             int tributeId = -1;


### PR DESCRIPTION
在墓穴的指明者效果对卡名超重武者岩融适用中的情况下，bot会多次尝试将岩融装备在怪兽上，影响玩家体验，对此做了修复