### PR TITLE
Prefer ChainInfo activation snapshot over GetCurrentSolvingChainCard

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -92,9 +92,9 @@ server 模式会为每个 HTTP 请求创建独立线程和独立的 `GameClient`
 - 必发效果可能由服务器直接强制发动，尤其是只有一个强制候选时，牌组注册的 `Activate` 执行器及其条件函数不会被调用。因此不要依赖发动条件函数为必发效果排入 `AI.Select*`、设置状态或完成其他副作用；通常只需让服务器发动，并在实际选择回调中处理选卡。
 - 也就是说，`AddExecutor(ExecutorType.Activate, CardId.Sangan, SanganActivate);` 中在 `SanganActivate` 调用 `AI.SelectCard` 等方法基本是无意义的；必发效果的 `ExecutorType.Activate` 的意义应仅限于多个同时发动候选的优先级。
 - 卡片发动时选择支付代价或选择指定目标，发生在连锁建立阶段。此时该卡已经加入 `Duel.CurrentChain`，但尚未进入连锁处理，应在 `OnSelectCard` 中用 `Duel.GetCurrentChainCard()` 识别最新连锁卡；同时检查控制者、卡号和 `hint`，再从服务器给出的候选中返回对象。
-- 效果处理时才进行的选卡，例如从卡组检索、特殊召唤或效果处理中的丢弃，发生在连锁处理阶段，应在 `OnSelectCard` 中用 `Duel.GetCurrentSolvingChainCard()` 识别正在处理的连锁卡。该方法在发动、支付代价和指定目标时会返回 `null`。
+- 效果处理时才进行的选卡，例如从卡组检索、特殊召唤或效果处理中的丢弃，发生在连锁处理阶段，应在 `OnSelectCard` 中用 `Duel.GetCurrentSolvingChainInfo()` 识别正在处理的连锁。优先用发动快照字段判断：`ActivatePlayer`（发动者）、`IsActivateCode` / `ActivateId`（发动卡号）、`ActivateSequence` / `ActivateLocation` 等。该方法在发动、支付代价和指定目标时会返回 `null`。仅当需要活卡引用比较（如 `Enemy.SpellZone[i] == info.RelatedCard`）或调试日志时再使用 `RelatedCard`；一般不要用 `GetCurrentSolvingChainCard()` 做卡号/控制者判断。
 - 注意，**以上问题仅限于必发效果**，即满足条件必定强制发动的 `EFFECT_TYPE_TRIGGER_F` 的效果。效果文本中写“〇〇的场合才能发动”通常不是必发效果，写“〇〇的场合发动”通常是必发效果。普通可选发动的效果一般应使用 `AI.SelectCard` 等方法预先选择，仅在选择目标难以预测时改用 `OnSelectCard` 处理。
-- `GetCurrentChainCard()` 只表示尚未开始处理时的最新连锁卡，连锁开始处理后返回 `null`；`GetCurrentSolvingChainCard()` 只表示当前正在处理的连锁卡。不要用 `CurrentChain.LastOrDefault()` 或 `AIUtil.GetLastChainCard()` 代替这一区分，否则多段连锁倒序处理时可能把选卡归给错误的连锁卡。
+- `GetCurrentChainCard()` 只表示尚未开始处理时的最新连锁卡，连锁开始处理后返回 `null`；`GetCurrentSolvingChainInfo()` / `GetCurrentSolvingChainCard()` 只表示当前正在处理的连锁（Info 为发动快照，Card 为活卡引用）。识别处理中的连锁源时优先用 Info。不要用 `CurrentChain.LastOrDefault()` 或 `AIUtil.GetLastChainCard()` 代替这一区分，否则多段连锁倒序处理时可能把选卡归给错误的连锁卡。
 - 如果同一张卡同时具有发动时目标、处理时选卡或多个不同效果，必须结合 `hint`、候选区域和必要的效果描述进一步区分。不要让 `OnSelectCard` 返回选择的同时还保留同一流程的预选队列，否则残留选择可能污染下一次选卡。
 
 ## 新增或修改牌组

--- a/Game/AI/Decks/AlbazExecutor.cs
+++ b/Game/AI/Decks/AlbazExecutor.cs
@@ -617,10 +617,10 @@ namespace WindBot.Game.AI.Decks
 
         public override IList<ClientCard> OnSelectCard(IList<ClientCard> cards, int min, int max, int hint, bool cancelable)
         {
-            ClientCard currentSolvingChain = Duel.GetCurrentSolvingChainCard();
+            ChainInfo currentSolvingChain = Duel.GetCurrentSolvingChainInfo();
             if (currentSolvingChain != null)
             {
-                if (currentSolvingChain.Controller == 1 && currentSolvingChain.IsCode(_CardId.EvenlyMatched))
+                if (currentSolvingChain.ActivatePlayer == 1 && currentSolvingChain.IsActivateCode(_CardId.EvenlyMatched))
                 {
                     Logger.DebugWriteLine("=== Evenly Matched activated.");
                     List<ClientCard> banishList = new List<ClientCard>();
@@ -663,7 +663,7 @@ namespace WindBot.Game.AI.Decks
                 {
                     Dictionary<int, Func<bool>> checkDict = new Dictionary<int, Func<bool>>();
 
-                    switch (currentSolvingChain.Id)
+                    switch (currentSolvingChain.ActivateId)
                     {
                         case CardId.AluberTheJesterOfDespia:
                         case CardId.AluberTheJesterOfDespia + 1:
@@ -747,7 +747,7 @@ namespace WindBot.Game.AI.Decks
                     }
                 }
 
-                switch (currentSolvingChain.Id)
+                switch (currentSolvingChain.ActivateId)
                 {
                     // for lubellion
                     case CardId.TheBystialLubellion:
@@ -1989,7 +1989,7 @@ namespace WindBot.Game.AI.Decks
             bool handToDeck = hint == HintMsg.ToDeck && cards.All(c => c.Location == CardLocation.Hand);
             if (min == 1 && max == 1 && (discardHand || handToDeck))
             {
-                if (currentSolvingChain != null && currentSolvingChain.IsCode(CardId.BrandedOpening))
+                if (currentSolvingChain != null && currentSolvingChain.IsActivateCode(CardId.BrandedOpening))
                 {
                     ClientCard tragedy = cards.FirstOrDefault(card => card.IsCode(CardId.DespianTragedy));
                     if (tragedy != null)
@@ -2104,7 +2104,7 @@ namespace WindBot.Game.AI.Decks
             }
 
             // for shrouded/saronir
-            if (albionTheShroudedDragonSelecting || (currentSolvingChain != null && currentSolvingChain.IsCode(CardId.BystialSaronir)))
+            if (albionTheShroudedDragonSelecting || (currentSolvingChain != null && currentSolvingChain.IsActivateCode(CardId.BystialSaronir)))
             {
                 // send retribution first
                 ClientCard retribution = cards.FirstOrDefault(c => c.IsCode(CardId.BrandedRetribution));
@@ -2192,15 +2192,15 @@ namespace WindBot.Game.AI.Decks
                 // 1190=Add to Hand, 1152=Special Summon
                 if (options.Count == 2 && options.Contains(1190) && options.Contains(1152))
                 {
-                    if (currentSolvingChain.IsCode(CardId.BrandedOpening))
+                    if (currentSolvingChain.IsActivateCode(CardId.BrandedOpening))
                     {
                         return (CheckShouldNoMoreSpSummon() && !summoned && Duel.Player == 0) ? options.IndexOf(1190) : options.IndexOf(1152);
                     }
 
                     if (fusionTarget != null && (
-                        currentSolvingChain.IsCode(CardId.DespianQuaeritis)
-                        || currentSolvingChain.IsCode(CardId.TitanikladTheAshDragon)
-                        || currentSolvingChain.IsCode(CardId.SprindTheIrondashDragon)
+                        currentSolvingChain.IsActivateCode(CardId.DespianQuaeritis)
+                        || currentSolvingChain.IsActivateCode(CardId.TitanikladTheAshDragon)
+                        || currentSolvingChain.IsActivateCode(CardId.SprindTheIrondashDragon)
                         ))
                     {
                         if (fusionTarget.IsCode(CardId.FallenOfAlbaz))
@@ -2220,7 +2220,7 @@ namespace WindBot.Game.AI.Decks
                 }
 
                 // 1190=Add to Hand, 1153=Set
-                if (currentSolvingChain.IsCode(CardId.AlbionTheBrandedDragon) && fusionTarget != null)
+                if (currentSolvingChain.IsActivateCode(CardId.AlbionTheBrandedDragon) && fusionTarget != null)
                 {
                     if (fusionTarget.IsOriginalCode(CardId.BrandedInHighSpirits) && Duel.Player == 0)
                     {
@@ -2247,7 +2247,7 @@ namespace WindBot.Game.AI.Decks
         public override int OnSelectPlace(int cardId, int player, CardLocation location, int available)
         {
             ChainInfo currentSovingChain = Duel.GetCurrentSolvingChainInfo();
-            if (currentSovingChain != null && currentSovingChain.ActivatePlayer == 0 && currentSovingChain.IsCode(CardId.SprindTheIrondashDragon))
+            if (currentSovingChain != null && currentSovingChain.ActivatePlayer == 0 && currentSovingChain.IsActivateCode(CardId.SprindTheIrondashDragon))
             {
                 return SprindTheIrondashDragonMoveZone(available, null);
             }
@@ -2317,10 +2317,10 @@ namespace WindBot.Game.AI.Decks
 
             if (desc == Util.GetStringId(CardId.SprindTheIrondashDragon, 2))
             {
-                ClientCard currentSolvingChain = Duel.GetCurrentSolvingChainCard();
+                ChainInfo currentSolvingChain = Duel.GetCurrentSolvingChainInfo();
                 if (currentSolvingChain != null)
                 {
-                    int value = SprindTheIrondashDragonDestroyValue(currentSolvingChain.Sequence);
+                    int value = SprindTheIrondashDragonDestroyValue(currentSolvingChain.RelatedCard.Sequence);
                     return value > 0;
                 }
             }
@@ -2330,8 +2330,8 @@ namespace WindBot.Game.AI.Decks
 
         public override CardPosition OnSelectPosition(int cardId, IList<CardPosition> positions)
         {
-            ClientCard currentSolvingChain = Duel.GetCurrentSolvingChainCard();
-            if (currentSolvingChain != null && currentSolvingChain.IsCode(CardId.AlbionTheSanctifireDragon))
+            ChainInfo currentSolvingChain = Duel.GetCurrentSolvingChainInfo();
+            if (currentSolvingChain != null && currentSolvingChain.IsActivateCode(CardId.AlbionTheSanctifireDragon))
             {
                 sanctifireSelectPositionCount++;
                 if (sanctifireSelectPositionCount >= 2)
@@ -2435,30 +2435,30 @@ namespace WindBot.Game.AI.Decks
 
         public override void OnChainSolved(int chainIndex)
         {
-            ChainInfo currentCard = Duel.GetCurrentSolvingChainInfo();
-            if (currentCard != null)
+            ChainInfo currentChain = Duel.GetCurrentSolvingChainInfo();
+            if (currentChain != null)
             {
                 // if activation is negated, it can activate again.
-                if (currentCard.ActivatePlayer == 0)
+                if (currentChain.ActivatePlayer == 0)
                 {
                     List<int> activateCheck = new List<int> { CardId.NadirServant, CardId.FusionDeployment, CardId.BrandedFusion, CardId.BrandedInRed };
-                    if (currentCard.IsCode(activateCheck))
+                    if (currentChain.IsActivateCode(activateCheck))
                     {
-                        activatedCardIdList.Add(currentCard.ActivateId);
+                        activatedCardIdList.Add(currentChain.ActivateId);
                     }
                 }
                 if (!Duel.IsCurrentSolvingChainNegated())
                 {
-                    if (currentCard.ActivatePlayer == 1)
+                    if (currentChain.ActivatePlayer == 1)
                     {
-                        if (currentCard.IsCode(_CardId.MaxxC))
+                        if (currentChain.IsActivateCode(_CardId.MaxxC))
                             enemyActivateMaxxC = true;
-                        if (currentCard.IsCode(_CardId.LockBird))
+                        if (currentChain.IsActivateCode(_CardId.LockBird))
                             enemyActivateLockBird = true;
-                        if (currentCard.IsCode(CardId.DimensionShifter))
+                        if (currentChain.IsActivateCode(CardId.DimensionShifter))
                             dimensionShifterCount = 2;
                     }
-                    if (currentCard.ActivatePlayer == 0 && currentCard.IsCode(CardId.NadirServant))
+                    if (currentChain.ActivatePlayer == 0 && currentChain.IsActivateCode(CardId.NadirServant))
                     {
                         nadirActivated = true;
                     }
@@ -2512,7 +2512,6 @@ namespace WindBot.Game.AI.Decks
                 }
                 if (currentControler == 0)
                 {
-                    ClientCard currentSolvingChain = Duel.GetCurrentSolvingChainCard();
                     if (previousLocation == (int)CardLocation.Grave && currentLocation != (int)CardLocation.Grave)
                     {
                         sendToGYThisTurn.Remove(card);

--- a/Game/AI/Decks/BE2025Executor.cs
+++ b/Game/AI/Decks/BE2025Executor.cs
@@ -267,17 +267,12 @@ namespace WindBot.Game.AI.Decks
         }
         public override IList<ClientCard> OnSelectCard(IList<ClientCard> cards, int min, int max, int hint, bool cancelable)
         {
-            ChainInfo currentSolvingChain =
-        Duel.GetCurrentSolvingChainInfo();
-
-            ClientCard solving =
-                Duel.GetCurrentSolvingChainCard();
-
+            ChainInfo solving = Duel.GetCurrentSolvingChainInfo();
             Logger.DebugWriteLine(
                 $"OnSelectCard count={cards?.Count ?? 0}, " +
                 $"min={min}, max={max}, hint={hint}");
 
-            if (solving != null && solving.Controller == 1 && solving.IsCode(CardId.AmeNoMurakumoNoMitsurugi)
+            if (solving != null && solving.ActivatePlayer == 1 && solving.IsActivateCode(CardId.AmeNoMurakumoNoMitsurugi)
                 && cards != null && cards.Count > 0 && (hint == HintMsg.Discard || hint == HintMsg.ToGrave)
                 && cards.All(c => c != null && c.Controller == 0 && c.Location == CardLocation.Hand))
             {
@@ -293,7 +288,7 @@ namespace WindBot.Game.AI.Decks
         public override void OnSpSummoned()
         {
             // not special summoned by chain
-            if (Duel.GetCurrentSolvingChainCard() == null)
+            if (Duel.GetCurrentSolvingChainInfo() == null)
             {
                 /*foreach (ClientCard card in Duel.LastSummonedCards)
                 {
@@ -1133,9 +1128,9 @@ namespace WindBot.Game.AI.Decks
         private bool BlueEyesSpiritDragonEffect()
         {
             if (!DontSelfNG()) return false;
-            ClientCard currentCard = Duel.GetCurrentSolvingChainCard();
+            ChainInfo currentChain = Duel.GetCurrentSolvingChainInfo();
             if ((ActivateDescription == -1 || ActivateDescription == Util.GetStringId(CardId.BlueEyesSpiritDragon, 0)) &&
-                ((Duel.LastChainPlayer == 1) || (Duel.LastChainPlayer == 0 && currentCard != null && currentCard.IsCode(CardId.TrueLight))))
+                ((Duel.LastChainPlayer == 1) || (Duel.LastChainPlayer == 0 && currentChain != null && currentChain.IsActivateCode(CardId.TrueLight))))
             {
                 Logger.DebugWriteLine("Spirit 1 negate");
                 return true;

--- a/Game/AI/Decks/BlueEyesExecutor.cs
+++ b/Game/AI/Decks/BlueEyesExecutor.cs
@@ -182,7 +182,7 @@ namespace WindBot.Game.AI.Decks
         public override void OnSpSummoned()
         {
             // not special summoned by chain
-            if (Duel.GetCurrentSolvingChainCard() == null)
+            if (Duel.GetCurrentSolvingChainInfo() == null)
             {
                 foreach (ClientCard card in Duel.LastSummonedCards)
                 {

--- a/Game/AI/Decks/Chaos408Executor.cs
+++ b/Game/AI/Decks/Chaos408Executor.cs
@@ -111,11 +111,11 @@ namespace WindBot.Game.AI.Decks
             IList<ClientCard> cards, int min, int max, int hint, bool cancelable)
         {
             ClientCard currentChainCard = Duel.GetCurrentChainCard();
-            ClientCard solvingChainCard = Duel.GetCurrentSolvingChainCard();
+            ChainInfo solvingChain = Duel.GetCurrentSolvingChainInfo();
 
-            if (solvingChainCard != null &&
-                solvingChainCard.Controller == 0 &&
-                solvingChainCard.IsCode(CardId.GracefulCharity) &&
+            if (solvingChain != null &&
+                solvingChain.ActivatePlayer == 0 &&
+                solvingChain.IsActivateCode(CardId.GracefulCharity) &&
                 hint == HintMsg.Discard)
             {
                 List<ClientCard> selected = new List<ClientCard>();
@@ -196,9 +196,9 @@ namespace WindBot.Game.AI.Decks
                 return Util.CheckSelectCount(selected, cards, min, max);
             }
 
-            if (solvingChainCard != null &&
-                solvingChainCard.Controller == 0 &&
-                solvingChainCard.IsCode(CardId.Confiscation) &&
+            if (solvingChain != null &&
+                solvingChain.ActivatePlayer == 0 &&
+                solvingChain.IsActivateCode(CardId.Confiscation) &&
                 hint == HintMsg.Discard)
             {
                 List<ClientCard> targets = new List<ClientCard>();
@@ -317,9 +317,9 @@ namespace WindBot.Game.AI.Decks
                 return Util.CheckSelectCount(targets, cards, min, max);
             }
 
-            if (solvingChainCard != null &&
-                solvingChainCard.Controller == 0 &&
-                solvingChainCard.IsCode(CardId.Sangan) &&
+            if (solvingChain != null &&
+                solvingChain.ActivatePlayer == 0 &&
+                solvingChain.IsActivateCode(CardId.Sangan) &&
                 hint == HintMsg.AddToHand)
             {
                 List<int> priority = Duel.Player == 0

--- a/Game/AI/Decks/DogmatikaExecutor.cs
+++ b/Game/AI/Decks/DogmatikaExecutor.cs
@@ -1153,20 +1153,20 @@ namespace WindBot.Game.AI.Decks
 
         public override void OnChainSolved(int chainIndex)
         {
-            ChainInfo currentCard = Duel.GetCurrentSolvingChainInfo();
-            if (currentCard != null && !Duel.IsCurrentSolvingChainNegated() && currentCard.ActivatePlayer == 1)
+            ChainInfo currentChain = Duel.GetCurrentSolvingChainInfo();
+            if (currentChain != null && !Duel.IsCurrentSolvingChainNegated() && currentChain.ActivatePlayer == 1)
             {
-                if (currentCard.IsCode(_CardId.MaxxC))
+                if (currentChain.IsActivateCode(_CardId.MaxxC))
                     enemyActivateMaxxC = true;
-                if (currentCard.IsCode(_CardId.LockBird))
+                if (currentChain.IsActivateCode(_CardId.LockBird))
                     enemyActivateLockBird = true;
-                if (currentCard.IsCode(CardId.DimensionShifter))
+                if (currentChain.IsActivateCode(CardId.DimensionShifter))
                     dimensionShifterCount = 2;
-                if (currentCard.IsCode(_CardId.InfiniteImpermanence))
+                if (currentChain.IsActivateCode(_CardId.InfiniteImpermanence))
                 {
                     for (int i = 0; i < 5; ++i)
                     {
-                        if (Enemy.SpellZone[i] == currentCard.RelatedCard)
+                        if (Enemy.SpellZone[i] == currentChain.RelatedCard)
                         {
                             infiniteImpermanenceList.Add(4 - i);
                             break;

--- a/Game/AI/Decks/DragunExecutor.cs
+++ b/Game/AI/Decks/DragunExecutor.cs
@@ -148,10 +148,10 @@ namespace WindBot.Game.AI.Decks
         public override IList<ClientCard> OnSelectCard(
             IList<ClientCard> cards, int min, int max, int hint, bool cancelable)
         {
-            ClientCard solvingChainCard = Duel.GetCurrentSolvingChainCard();
-            if (solvingChainCard != null &&
-                solvingChainCard.Controller == 0 &&
-                solvingChainCard.IsCode(CardId.Sangan) &&
+            ChainInfo solvingChain = Duel.GetCurrentSolvingChainInfo();
+            if (solvingChain != null &&
+                solvingChain.ActivatePlayer == 0 &&
+                solvingChain.IsActivateCode(CardId.Sangan) &&
                 hint == HintMsg.AddToHand)
             {
                 List<int> priority = new List<int>();

--- a/Game/AI/Decks/ExosisterExecutor.cs
+++ b/Game/AI/Decks/ExosisterExecutor.cs
@@ -771,18 +771,18 @@ namespace WindBot.Game.AI.Decks
 
         public override void OnChainSolved(int chainIndex)
         {
-            ChainInfo currentCard = Duel.GetCurrentSolvingChainInfo();
-            if (currentCard != null && !Duel.IsCurrentSolvingChainNegated() && currentCard.ActivatePlayer == 1)
+            ChainInfo currentChain = Duel.GetCurrentSolvingChainInfo();
+            if (currentChain != null && !Duel.IsCurrentSolvingChainNegated() && currentChain.ActivatePlayer == 1)
             {
-                if (currentCard.IsCode(_CardId.MaxxC))
+                if (currentChain.IsActivateCode(_CardId.MaxxC))
                     enemyActivateMaxxC = true;
-                if (currentCard.IsCode(_CardId.LockBird))
+                if (currentChain.IsActivateCode(_CardId.LockBird))
                     enemyActivateLockBird = true;
-                if (currentCard.IsCode(_CardId.InfiniteImpermanence))
+                if (currentChain.IsActivateCode(_CardId.InfiniteImpermanence))
                 {
                     for (int i = 0; i < 5; ++i)
                     {
-                        if (Enemy.SpellZone[i] == currentCard.RelatedCard)
+                        if (Enemy.SpellZone[i] == currentChain.RelatedCard)
                         {
                             infiniteImpermanenceList.Add(4 - i);
                             break;

--- a/Game/AI/Decks/GravekeeperExecutor.cs
+++ b/Game/AI/Decks/GravekeeperExecutor.cs
@@ -83,12 +83,12 @@ namespace WindBot.Game.AI.Decks
         public override IList<ClientCard> OnSelectCard(
             IList<ClientCard> cards, int min, int max, int hint, bool cancelable)
         {
-            ClientCard solvingChainCard = Duel.GetCurrentSolvingChainCard();
-            if (solvingChainCard != null &&
-                solvingChainCard.Controller == 0 &&
-                ((solvingChainCard.IsCode(CardId.GravekeepersSpy) &&
+            ChainInfo solvingChain = Duel.GetCurrentSolvingChainInfo();
+            if (solvingChain != null &&
+                solvingChain.ActivatePlayer == 0 &&
+                ((solvingChain.IsActivateCode(CardId.GravekeepersSpy) &&
                 hint == HintMsg.SpSummon) ||
-                (solvingChainCard.IsCode(CardId.GravekeepersRecruiter) &&
+                (solvingChain.IsActivateCode(CardId.GravekeepersRecruiter) &&
                 hint == HintMsg.AddToHand)))
             {
                 IList<ClientCard> targets = Util.SelectPreferredCards(

--- a/Game/AI/Decks/LabrynthExecutor.cs
+++ b/Game/AI/Decks/LabrynthExecutor.cs
@@ -653,10 +653,10 @@ namespace WindBot.Game.AI.Decks
 
         public override IList<ClientCard> OnSelectCard(IList<ClientCard> cards, int min, int max, int hint, bool cancelable)
         {
-            ClientCard currentSolvingChain = Duel.GetCurrentSolvingChainCard();
+            ChainInfo currentSolvingChain = Duel.GetCurrentSolvingChainInfo();
             if (currentSolvingChain != null)
             {
-                if (currentSolvingChain.Controller == 1 && currentSolvingChain.IsCode(_CardId.EvenlyMatched))
+                if (currentSolvingChain.ActivatePlayer == 1 && currentSolvingChain.IsActivateCode(_CardId.EvenlyMatched))
                 {
                     Logger.DebugWriteLine("=== Evenly Matched activated.");
                     List<ClientCard> banishList = new List<ClientCard>();
@@ -691,7 +691,7 @@ namespace WindBot.Game.AI.Decks
                     return Util.CheckSelectCount(banishList, cards, min, max);
                 }
             
-                if (currentSolvingChain.IsCode(CardId.LadyLabrynthOfTheSilverCastle) && min == 1 && max == 1 && hint == HintMsg.Set)
+                if (currentSolvingChain.IsActivateCode(CardId.LadyLabrynthOfTheSilverCastle) && min == 1 && max == 1 && hint == HintMsg.Set)
                 {
                     SortedDictionary<int, Func<bool>> trapCheckDict = new SortedDictionary<int, Func<bool>>{
                         {_CardId.DimensionalBarrier, DimensionalBarrierActivate},
@@ -776,12 +776,12 @@ namespace WindBot.Game.AI.Decks
                     }
                 }
 
-                if (currentSolvingChain.IsCode(CardId.WelcomeLabrynth))
+                if (currentSolvingChain.IsActivateCode(CardId.WelcomeLabrynth))
                 {
                     banSpSummonExceptFiendCount = 2;
                 }
 
-                if (currentSolvingChain.IsCode(CardId.WelcomeLabrynth) || (currentSolvingChain.IsCode(CardId.TransactionRollback) && rollbackCopyCardId == CardId.WelcomeLabrynth))
+                if (currentSolvingChain.IsActivateCode(CardId.WelcomeLabrynth) || (currentSolvingChain.IsActivateCode(CardId.TransactionRollback) && rollbackCopyCardId == CardId.WelcomeLabrynth))
                 {
                     Logger.DebugWriteLine("rewrite welcome's select.");
                     List<ClientCard> selection = new List<ClientCard>();
@@ -895,8 +895,8 @@ namespace WindBot.Game.AI.Decks
                     if (selection.Count() > 0) return Util.CheckSelectCount(selection, cards, min, max);
                 }
 
-                bool searchFlag = currentSolvingChain.IsCode(CardId.AriannaTheLabrynthServant) && hint == HintMsg.AddToHand;
-                bool bigwelcomeSoving = currentSolvingChain.IsCode(CardId.BigWelcomeLabrynth) || (currentSolvingChain.IsCode(CardId.TransactionRollback) && rollbackCopyCardId == CardId.BigWelcomeLabrynth);
+                bool searchFlag = currentSolvingChain.IsActivateCode(CardId.AriannaTheLabrynthServant) && hint == HintMsg.AddToHand;
+                bool bigwelcomeSoving = currentSolvingChain.IsActivateCode(CardId.BigWelcomeLabrynth) || (currentSolvingChain.IsActivateCode(CardId.TransactionRollback) && rollbackCopyCardId == CardId.BigWelcomeLabrynth);
                 searchFlag |= bigwelcomeSoving && hint == HintMsg.SpSummon && Bot.GetMonsterCount() == 0;
                 if (searchFlag)
                 {
@@ -1646,19 +1646,19 @@ namespace WindBot.Game.AI.Decks
 
         public override void OnChainSolved(int chainIndex)
         {
-            ChainInfo currentCard = Duel.GetCurrentSolvingChainInfo();
-            if (currentCard != null && !Duel.IsCurrentSolvingChainNegated())
+            ChainInfo currentChain = Duel.GetCurrentSolvingChainInfo();
+            if (currentChain != null && !Duel.IsCurrentSolvingChainNegated())
             {
-                if (currentCard.ActivatePlayer == 1)
+                if (currentChain.ActivatePlayer == 1)
                 {
-                    if (currentCard.IsCode(_CardId.MaxxC))
+                    if (currentChain.IsActivateCode(_CardId.MaxxC))
                         enemyActivateMaxxC = true;
-                    if (currentCard.IsCode(CardId.DimensionShifter))
+                    if (currentChain.IsActivateCode(CardId.DimensionShifter))
                         dimensionShifterCount = 2;
                 }
-                if (currentCard.ActivatePlayer == 0)
+                if (currentChain.ActivatePlayer == 0)
                 {
-                    if (currentCard.IsCode(CardId.LabrynthCooclock))
+                    if (currentChain.IsActivateCode(CardId.LabrynthCooclock))
                         cooclockAffected = true;
                 }
             }
@@ -1720,8 +1720,8 @@ namespace WindBot.Game.AI.Decks
                 }
                 if (currentControler == 0)
                 {
-                    ClientCard currentSolvingChain = Duel.GetCurrentSolvingChainCard();
-                    if (currentLocation == (int)CardLocation.SpellZone && (currentSolvingChain == null || !currentSolvingChain.IsCode(CardId.AriasTheLabrynthButler))
+                    ChainInfo currentSolvingChain = Duel.GetCurrentSolvingChainInfo();
+                    if (currentLocation == (int)CardLocation.SpellZone && (currentSolvingChain == null || !currentSolvingChain.IsActivateCode(CardId.AriasTheLabrynthButler))
                         && (card.HasType(CardType.Trap) || card.IsCode(CardId.WelcomeLabrynth, CardId.BigWelcomeLabrynth))
                     )
                     {

--- a/Game/AI/Decks/LightswornExecutor.cs
+++ b/Game/AI/Decks/LightswornExecutor.cs
@@ -149,14 +149,14 @@ namespace WindBot.Game.AI.Decks
         {
             if (card != null)
             {
-                ClientCard solvingCard = Duel.GetCurrentSolvingChainCard();
+                ChainInfo solvingChain = Duel.GetCurrentSolvingChainInfo();
                 if (previousControler == 1 &&
                     previousLocation == (int)CardLocation.Hand &&
                     currentControler == 1 &&
                     currentLocation == (int)CardLocation.Removed &&
-                    solvingCard != null &&
-                    solvingCard.Controller == 0 &&
-                    solvingCard.IsCode(CardId.PSYFramelordOmega))
+                    solvingChain != null &&
+                    solvingChain.ActivatePlayer == 0 &&
+                    solvingChain.IsActivateCode(CardId.PSYFramelordOmega))
                 {
                     _omegaBanishedEnemyCard = card;
                 }
@@ -173,12 +173,12 @@ namespace WindBot.Game.AI.Decks
         public override IList<ClientCard> OnSelectCard(
             IList<ClientCard> cards, int min, int max, int hint, bool cancelable)
         {
-            ClientCard solvingCard = Duel.GetCurrentSolvingChainCard();
-            if (solvingCard != null && solvingCard.Controller == 0)
+            ChainInfo solvingChain = Duel.GetCurrentSolvingChainInfo();
+            if (solvingChain != null && solvingChain.ActivatePlayer == 0)
             {
-                if (solvingCard.IsCode(CardId.MinervaTheExalted) && hint == HintMsg.Destroy ||
-                    solvingCard.IsCode(CardId.Ryko) && hint == HintMsg.Destroy ||
-                    solvingCard.IsCode(CardId.TrishulaDragonOfTheIceBarrier) && hint == HintMsg.Remove)
+                if (solvingChain.IsActivateCode(CardId.MinervaTheExalted) && hint == HintMsg.Destroy ||
+                    solvingChain.IsActivateCode(CardId.Ryko) && hint == HintMsg.Destroy ||
+                    solvingChain.IsActivateCode(CardId.TrishulaDragonOfTheIceBarrier) && hint == HintMsg.Remove)
                 {
                     List<ClientCard> targets = GetEnemyTargetPriority(cards);
                     if (targets.Count > 0)
@@ -191,9 +191,9 @@ namespace WindBot.Game.AI.Decks
 
         public override bool OnSelectYesNo(int desc)
         {
-            ClientCard solvingCard = Duel.GetCurrentSolvingChainCard();
-            if (solvingCard != null && solvingCard.Controller == 0 &&
-                solvingCard.IsCode(CardId.MinervaTheExalted, CardId.Ryko))
+            ChainInfo solvingChain = Duel.GetCurrentSolvingChainInfo();
+            if (solvingChain != null && solvingChain.ActivatePlayer == 0 &&
+                solvingChain.IsActivateCode(CardId.MinervaTheExalted, CardId.Ryko))
             {
                 return Enemy.GetFieldCount() > 0;
             }

--- a/Game/AI/Decks/MalissExecutor.cs
+++ b/Game/AI/Decks/MalissExecutor.cs
@@ -1306,35 +1306,29 @@ namespace WindBot.Game.AI.Decks
         #region work space #1
         public override void OnChainSolved(int chainIndex)
         {
-            ClientCard currentCard = Duel.GetCurrentSolvingChainCard();
-            var solving = Duel.GetCurrentSolvingChainCard();
-            bool neg = Duel.IsCurrentSolvingChainNegated();
-            if (currentCard != null && !Duel.IsCurrentSolvingChainNegated() && currentCard.Controller == 1)
+            ChainInfo currentChain = Duel.GetCurrentSolvingChainInfo();
+            if (currentChain != null && !Duel.IsCurrentSolvingChainNegated() && currentChain.ActivatePlayer == 1)
             {
-                if (currentCard.IsCode(CardId.Lancea)) enemyActivateLancea = true;
-                if (currentCard.IsCode(_CardId.MaxxC)) enemyActivateMaxxC = true;
-                if (currentCard.IsCode(CardId.Fuwalos)) enemyActivateFuwalos = true;
-                if (currentCard.IsCode(_CardId.LockBird)) enemyActivateLockBird = true;
-                if (currentCard.IsCode(_CardId.InfiniteImpermanence))
+                if (currentChain.IsActivateCode(CardId.Lancea)) enemyActivateLancea = true;
+                if (currentChain.IsActivateCode(_CardId.MaxxC)) enemyActivateMaxxC = true;
+                if (currentChain.IsActivateCode(CardId.Fuwalos)) enemyActivateFuwalos = true;
+                if (currentChain.IsActivateCode(_CardId.LockBird)) enemyActivateLockBird = true;
+                if (currentChain.IsActivateCode(_CardId.InfiniteImpermanence))
                 {
                     for (int i = 0; i < 5; ++i)
                     {
-                        if (Enemy.SpellZone[i] == currentCard)
+                        if (Enemy.SpellZone[i] == currentChain.RelatedCard)
                         {
                             infiniteImpermanenceList.Add(4 - i);
                             break;
                         }
                     }
                 }
-                var last = Duel.GetCurrentSolvingChainCard();
-                if (last != null)
-                {
-                    if (last.IsSpell() && (last.HasType(CardType.Field) || last.HasType(CardType.Continuous) || last.HasType(CardType.Equip)))
-                        _oppJustActivatedPersistentSpell = true;
-                    _prefWindowTTL = Math.Max(_prefWindowTTL, 2);
-                }
+                if (currentChain.IsSpell() && (currentChain.HasType(CardType.Field) || currentChain.HasType(CardType.Continuous) || currentChain.HasType(CardType.Equip)))
+                    _oppJustActivatedPersistentSpell = true;
+                _prefWindowTTL = Math.Max(_prefWindowTTL, 2);
             }
-            if (currentCard != null && currentCard.Controller == 0 && currentCard.IsCode(CardId.SplashMage))
+            if (currentChain != null && currentChain.ActivatePlayer == 0 && currentChain.IsActivateCode(CardId.SplashMage))
             {
                 if (Duel.IsCurrentSolvingChainNegated())
                     splashNegatedThisTurn = true;
@@ -1439,8 +1433,8 @@ namespace WindBot.Game.AI.Decks
 
         public override IList<ClientCard> OnSelectCard(IList<ClientCard> cards, int min, int max, int hint, bool cancelable)
         {
-            var solving = Duel.GetCurrentSolvingChainCard();
-            if (solving != null && solving.Controller == 1 && solving.IsCode(CardId.AmeNoMurakumoNoMitsurugi) && cards != null && cards.Count > 0
+            var solving = Duel.GetCurrentSolvingChainInfo();
+            if (solving != null && solving.ActivatePlayer == 1 && solving.IsActivateCode(CardId.AmeNoMurakumoNoMitsurugi) && cards != null && cards.Count > 0
                 && (hint == HintMsg.Discard || hint == HintMsg.ToGrave) && cards.All(c => c != null && c.Controller == 0 && c.Location == CardLocation.Hand))
             {
                 List<ClientCard> discardOrder = cards.OrderBy(ScoreMalissMurakumoDiscard).ToList();
@@ -1452,7 +1446,7 @@ namespace WindBot.Game.AI.Decks
             }
             if (cards != null && cards.Count > 0 && solving != null)
             {
-                if (solving.IsCode(CardId.MalissQ_RedRansom))
+                if (solving.IsActivateCode(CardId.MalissQ_RedRansom))
                 {
                     var searchPool = cards
                         .Where(c => c != null &&
@@ -1479,7 +1473,7 @@ namespace WindBot.Game.AI.Decks
                         }
                     }
                 }
-                if (hint == HintMsg.Set && solving.IsCode(CardId.MalissQ_WhiteBinder))
+                if (hint == HintMsg.Set && solving.IsActivateCode(CardId.MalissQ_WhiteBinder))
                 {
                     ClientCard pick = null;
                     pick = cards.FirstOrDefault(c => c.Id == CardId.MalissC_GWC06 && c.Location == CardLocation.Deck);

--- a/Game/AI/Decks/MalissOCGExecutor.cs
+++ b/Game/AI/Decks/MalissOCGExecutor.cs
@@ -703,7 +703,7 @@ namespace WindBot.Game.AI.Decks
                 case CardId.Backup_Ignister:
                     if (hint == HintMsg.AddToHand)
                     {
-                        if (card.Id == CardId.Dimension_Shifter || card.Id == CardId.Artifact_Lancea)
+                        if (solvingId == CardId.Dimension_Shifter || solvingId == CardId.Artifact_Lancea)
                         {
                             if (!Bot.Hand.Any(i => i.HasSetcode(SetCode.Maliss) && i.HasType(CardType.Monster) && Count.CheckCardRemoved(i.Id) && Count.CheckCard(i.Id) && !i.IsCode(CardId.Maliss_March_Hare))
                                 && cards.Any(i => i.HasSetcode(SetCode.Maliss) && i.HasType(CardType.Monster) && Count.CheckCardRemoved(i.Id) && Count.CheckCard(i.Id) && !i.IsCode(CardId.Maliss_March_Hare))
@@ -743,7 +743,7 @@ namespace WindBot.Game.AI.Decks
                     }
                     else if (hint == HintMsg.Discard)
                     {
-                        if (card.Id == CardId.Dimension_Shifter || card.Id == CardId.Artifact_Lancea)
+                        if (solvingId == CardId.Dimension_Shifter || solvingId == CardId.Artifact_Lancea)
                         {
                             if (cards.Any(i => i.HasSetcode(SetCode.Maliss) && i.HasType(CardType.Monster) && Count.CheckCardRemoved(i.Id) && Count.CheckCard(i.Id) && !i.IsCode(CardId.Maliss_March_Hare)))
                                 return Util.CheckSelectCount(cards.Where(i => i.HasSetcode(SetCode.Maliss) && i.HasType(CardType.Monster) && Count.CheckCardRemoved(i.Id) && Count.CheckCard(i.Id) && !i.IsCode(CardId.Maliss_March_Hare)).ToList(), cards, min, max);

--- a/Game/AI/Decks/MalissOCGExecutor.cs
+++ b/Game/AI/Decks/MalissOCGExecutor.cs
@@ -322,10 +322,10 @@ namespace WindBot.Game.AI.Decks
         public override IList<ClientCard> OnSelectCard(IList<ClientCard> cards, int min, int max, int hint, bool cancelable)
         {
             if (AI.HaveSelectedCards()) return null;
-            ClientCard card = Duel.GetCurrentSolvingChainCard();
-            if (card == null)
-                card = Card;
-            switch (card.Id)
+            // 有连锁时用发动快照卡号；无连锁回退到当前 Card.Id
+            ChainInfo chainInfo = Duel.GetCurrentSolvingChainInfo();
+            int solvingId = chainInfo != null ? chainInfo.ActivateId : (Card != null ? Card.Id : 0);
+            switch (solvingId)
             {
                 case CardId.Maliss_White_Rabbit:
                     if (cards.Any(i => i.Id == CardId.Maliss_TB_11) && Count.CheckCard(CardId.Maliss_TB_11))

--- a/Game/AI/Decks/Monarch506Executor.cs
+++ b/Game/AI/Decks/Monarch506Executor.cs
@@ -174,7 +174,7 @@ namespace WindBot.Game.AI.Decks
             IList<ClientCard> cards, int min, int max, int hint, bool cancelable)
         {
             ClientCard currentChainCard = Duel.GetCurrentChainCard();
-            ClientCard solvingChainCard = Duel.GetCurrentSolvingChainCard();
+            ChainInfo solvingChain = Duel.GetCurrentSolvingChainInfo();
 
             if (currentChainCard != null &&
                 currentChainCard.Controller == 0 &&
@@ -284,9 +284,9 @@ namespace WindBot.Game.AI.Decks
                 return Util.CheckSelectCount(targets, cards, min, max);
             }
 
-            if (solvingChainCard != null &&
-                solvingChainCard.Controller == 0 &&
-                solvingChainCard.IsCode(CardId.TrapDustshoot) &&
+            if (solvingChain != null &&
+                solvingChain.ActivatePlayer == 0 &&
+                solvingChain.IsActivateCode(CardId.TrapDustshoot) &&
                 hint == HintMsg.ToDeck)
             {
                 List<ClientCard> targets = cards
@@ -299,9 +299,9 @@ namespace WindBot.Game.AI.Decks
                 return Util.CheckSelectCount(targets, cards, min, max);
             }
 
-            if (solvingChainCard != null &&
-                solvingChainCard.Controller == 0 &&
-                solvingChainCard.IsCode(CardId.GravekeepersSpy) &&
+            if (solvingChain != null &&
+                solvingChain.ActivatePlayer == 0 &&
+                solvingChain.IsActivateCode(CardId.GravekeepersSpy) &&
                 hint == HintMsg.SpSummon)
             {
                 List<ClientCard> targets = cards
@@ -310,9 +310,9 @@ namespace WindBot.Game.AI.Decks
                 return Util.CheckSelectCount(targets, cards, min, max);
             }
 
-            if (solvingChainCard != null &&
-                solvingChainCard.Controller == 0 &&
-                solvingChainCard.IsCode(CardId.Sangan) &&
+            if (solvingChain != null &&
+                solvingChain.ActivatePlayer == 0 &&
+                solvingChain.IsActivateCode(CardId.Sangan) &&
                 hint == HintMsg.AddToHand)
             {
                 List<int> priority = new List<int>();

--- a/Game/AI/Decks/NekoExecutor.cs
+++ b/Game/AI/Decks/NekoExecutor.cs
@@ -275,8 +275,8 @@ namespace WindBot.Game.AI.Decks
                         CardId.Neko_Sycro_Lollipop
                     };
                 if (Duel.CurrentChain.Any(i => i.Controller == 0 && i.IsCode(cards))
-                    && Duel.GetCurrentSolvingChainCard() != null
-                    && !Duel.GetCurrentSolvingChainCard().IsCode(cards)
+                    && Duel.GetCurrentSolvingChainInfo() != null
+                    && !Duel.GetCurrentSolvingChainInfo().IsActivateCode(cards)
                     && Bot.GetMonstersInMainZone().Count() > 3
                 )
                 {
@@ -289,9 +289,10 @@ namespace WindBot.Game.AI.Decks
         public override IList<ClientCard> OnSelectCard(IList<ClientCard> cards, int min, int max, int hint, bool cancelable)
         {
             if (AI.HaveSelectedCards()) return null;
-            ClientCard card = Duel.GetCurrentSolvingChainCard();
-            if (card == null)
-                card = Card;
+            // 有连锁时用发动快照；无连锁回退到当前 Card
+            ChainInfo chainInfo = Duel.GetCurrentSolvingChainInfo();
+            int solvingId = chainInfo != null ? chainInfo.ActivateId : (Card != null ? Card.Id : 0);
+            CardLocation solvingLocation = chainInfo != null ? chainInfo.ActivateLocation : (Card != null ? Card.Location : 0);
             switch (hint)
             {
                 case HintMsg.Discard:
@@ -378,7 +379,7 @@ namespace WindBot.Game.AI.Decks
                     }
                     break;
             }
-            switch (card.Id)
+            switch (solvingId)
             {
                 case CardId.Neko_Cake:
                     if (cards.Any(i => i.IsCode(CardId.Neko_Quick)) && !Bot.HasInHand(CardId.Neko_Quick))
@@ -485,7 +486,7 @@ namespace WindBot.Game.AI.Decks
                         return Util.CheckSelectCount(result, cards, min, max);
                     }
                 case CardId.Neko_Sycro_Lollipop:
-                    if (card.Location == CardLocation.MonsterZone)
+                    if (solvingLocation == CardLocation.MonsterZone)
                     {
                         List<ClientCard> result = new List<ClientCard>();
                         if (Bot.GetMonsters().Any(i => i.IsCode(CardId.Neko_Link) && !DefaultCheckWhetherCardIsNegated(i))

--- a/Game/AI/Decks/PhantasmExecutor.cs
+++ b/Game/AI/Decks/PhantasmExecutor.cs
@@ -121,10 +121,10 @@ namespace WindBot.Game.AI.Decks
         public override IList<ClientCard> OnSelectCard(
             IList<ClientCard> cards, int min, int max, int hint, bool cancelable)
         {
-            ClientCard solvingChainCard = Duel.GetCurrentSolvingChainCard();
-            if (solvingChainCard != null &&
-                solvingChainCard.Controller == 0 &&
-                solvingChainCard.IsCode(CardId.PacifisThePhantasmCity) &&
+            ChainInfo solvingChain = Duel.GetCurrentSolvingChainInfo();
+            if (solvingChain != null &&
+                solvingChain.ActivatePlayer == 0 &&
+                solvingChain.IsActivateCode(CardId.PacifisThePhantasmCity) &&
                 hint == HintMsg.AddToHand)
             {
                 IList<ClientCard> targets = Util.SelectPreferredCards(

--- a/Game/AI/Decks/RyzealExecutor.cs
+++ b/Game/AI/Decks/RyzealExecutor.cs
@@ -953,7 +953,7 @@ namespace WindBot.Game.AI.Decks
                     }
                 }
 
-                if (currentSolvingChain.ActivatePlayer == 1 && currentSolvingChain.IsCode(_CardId.EvenlyMatched))
+                if (currentSolvingChain.ActivatePlayer == 1 && currentSolvingChain.IsActivateCode(_CardId.EvenlyMatched))
                 {
                     Logger.DebugWriteLine("=== Evenly Matched activated.");
                     List<ClientCard> banishList = new List<ClientCard>();
@@ -999,7 +999,7 @@ namespace WindBot.Game.AI.Decks
                 {
                     if (hint == HintMsg.AddToHand)
                     {
-                        if (currentSolvingChain.IsCode(CardId.ThodeRyzeal))
+                        if (currentSolvingChain.IsActivateCode(CardId.ThodeRyzeal))
                         {
                             ClientCard ice = cards.FirstOrDefault(c => c.IsCode(CardId.IceRyzeal));
                             ClientCard ex = cards.FirstOrDefault(c => c.IsCode(CardId.ExRyzeal));
@@ -1033,7 +1033,7 @@ namespace WindBot.Game.AI.Decks
                             }
                         }
 
-                        if (currentSolvingChain.IsCode(CardId.ExRyzeal))
+                        if (currentSolvingChain.IsActivateCode(CardId.ExRyzeal))
                         {
                             ClientCard thode = cards.FirstOrDefault(c => c.IsCode(CardId.ThodeRyzeal));
                             ClientCard node = cards.FirstOrDefault(c => c.IsCode(CardId.NodeRyzeal));
@@ -1062,7 +1062,7 @@ namespace WindBot.Game.AI.Decks
                             }
                         }
 
-                        if (currentSolvingChain.IsCode(CardId.Bonfire) || currentSolvingChain.IsCode(CardId.SeventhTachyon))
+                        if (currentSolvingChain.IsActivateCode(CardId.Bonfire) || currentSolvingChain.IsActivateCode(CardId.SeventhTachyon))
                         {
                             if (!Bot.HasInHand(CardId.ExRyzeal) && !spSummonedCardIdList.Contains(CardId.ExRyzeal) && !CheckWhetherWillbeRemoved())
                             {
@@ -1096,7 +1096,7 @@ namespace WindBot.Game.AI.Decks
                             }
                         }
 
-                        if (currentSolvingChain.IsCode(CardId.RyzealDuodrive))
+                        if (currentSolvingChain.IsActivateCode(CardId.RyzealDuodrive))
                         {
                             // search spells
                             if (!CheckWhetherNegated(true, true, CardType.Spell))
@@ -1163,7 +1163,7 @@ namespace WindBot.Game.AI.Decks
 
                     if (hint == HintMsg.SpSummon)
                     {
-                        if (currentSolvingChain.IsCode(CardId.IceRyzeal))
+                        if (currentSolvingChain.IsActivateCode(CardId.IceRyzeal))
                         {
                             ClientCard thode = cards.FirstOrDefault(c => c.IsCode(CardId.ThodeRyzeal));
                             ClientCard ex = cards.FirstOrDefault(c => c.IsCode(CardId.ExRyzeal));
@@ -1194,7 +1194,7 @@ namespace WindBot.Game.AI.Decks
                             }
                         }
 
-                        if (currentSolvingChain.IsCode(CardId.TwinsOfTheEclipse))
+                        if (currentSolvingChain.IsActivateCode(CardId.TwinsOfTheEclipse))
                         {
                             ClientCard target = TwinsOfTheEclipseRebornTarget(new List<ClientCard>(cards));
 
@@ -1204,7 +1204,7 @@ namespace WindBot.Game.AI.Decks
 
                     if (hint == HintMsg.ToDeck)
                     {
-                        if (currentSolvingChain.IsCode(CardId.TripleTacticsTalent))
+                        if (currentSolvingChain.IsActivateCode(CardId.TripleTacticsTalent))
                         {
                             foreach (ClientCard hand in cards)
                             {
@@ -1222,7 +1222,7 @@ namespace WindBot.Game.AI.Decks
 
                     if (hint == HintMsg.XyzMaterial)
                     {
-                        if (currentSolvingChain.IsCode(CardId.RyzealDeadnader, CardId.RyzealDuodrive, CardId.RyzealPlugIn))
+                        if (currentSolvingChain.IsActivateCode(CardId.RyzealDeadnader, CardId.RyzealDuodrive, CardId.RyzealPlugIn))
                         {
                             // material that have effect
                             ClientCard effectTarget = cards.FirstOrDefault(c => c.IsCode(CardId.TwinsOfTheEclipse, CardId.MereologicAggregator));
@@ -1250,7 +1250,7 @@ namespace WindBot.Game.AI.Decks
 
                     if (hint == HintMsg.RemoveXyz)
                     {
-                        if (currentSolvingChain.IsCode(CardId.RyzealDuodrive))
+                        if (currentSolvingChain.IsActivateCode(CardId.RyzealDuodrive))
                         {
                             List<ClientCard> resultList = new List<ClientCard>();
 
@@ -1301,7 +1301,7 @@ namespace WindBot.Game.AI.Decks
                     }
 
                     // gain material by plugin
-                    if (currentSolvingChain.IsCode(CardId.RyzealPlugIn) && cards.All(c => c.Location == CardLocation.MonsterZone))
+                    if (currentSolvingChain.IsActivateCode(CardId.RyzealPlugIn) && cards.All(c => c.Location == CardLocation.MonsterZone))
                     {
                         ClientCard abyssDweller = cards.FirstOrDefault(c => c != null && !c.IsDisabled() && c.IsCode(CardId.AbyssDweller) && c.Overlays.Count() < 2);
                         if (abyssDweller != null && AbyssDwellerSummonCheck())
@@ -1350,7 +1350,7 @@ namespace WindBot.Game.AI.Decks
                     }
 
                     // double attack
-                    if (currentSolvingChain.IsCode(CardId.Number60DugaresTheTimeless) && cards.All(c => c.Location == CardLocation.MonsterZone))
+                    if (currentSolvingChain.IsActivateCode(CardId.Number60DugaresTheTimeless) && cards.All(c => c.Location == CardLocation.MonsterZone))
                     {
                         ClientCard maxAttackMonster = cards.Where(c => c != null && (c.HasPosition(CardPosition.FaceUpAttack) || !summonThisTurn.Contains(c)))
                             .OrderByDescending(c => c.Attack).FirstOrDefault();
@@ -1706,26 +1706,26 @@ namespace WindBot.Game.AI.Decks
             {
                 if (!Duel.IsCurrentSolvingChainNegated())
                 {
-                    if (currentChain.IsCode(_CardId.LockBird))
+                    if (currentChain.IsActivateCode(_CardId.LockBird))
                         lockBirdSolved = true;
-                    if (currentChain.IsCode(_CardId.DimensionShifter))
+                    if (currentChain.IsActivateCode(_CardId.DimensionShifter))
                         dimensionShifterCount = 2;
                     if (currentChain.ActivatePlayer == 1)
                     {
-                        if (currentChain.IsCode(_CardId.MaxxC))
+                        if (currentChain.IsActivateCode(_CardId.MaxxC))
                             enemyActivateMaxxC = true;
-                        if (currentChain.IsCode(_CardId.MulcharmyPurulia))
+                        if (currentChain.IsActivateCode(_CardId.MulcharmyPurulia))
                             enemyActivatePurulia = true;
-                        if (currentChain.IsCode(_CardId.MulcharmyFuwalos))
+                        if (currentChain.IsActivateCode(_CardId.MulcharmyFuwalos))
                             enemyActivateFuwalos = true;
-                        if (currentChain.IsCode(_CardId.MulcharmyNyalus))
+                        if (currentChain.IsActivateCode(_CardId.MulcharmyNyalus))
                             enemyActivateNyalus = true;
                     }
                     if (currentChain.ActivatePlayer == 0)
                     {
                         foreach (int checkId in CheckBotSolvedList)
                         {
-                            if (currentChain.IsCode(checkId))
+                            if (currentChain.IsActivateCode(checkId))
                             {
                                 botSolvedCardIdList.Add(checkId);
                             }
@@ -1830,7 +1830,7 @@ namespace WindBot.Game.AI.Decks
         public override void OnSpSummoned()
         {
             // not special summoned by chain
-            if (Duel.GetCurrentSolvingChainCard() == null)
+            if (Duel.GetCurrentSolvingChainInfo() == null)
             {
                 foreach (ClientCard card in Duel.LastSummonedCards)
                 {

--- a/Game/AI/Decks/RyzealExecutor.cs
+++ b/Game/AI/Decks/RyzealExecutor.cs
@@ -1538,7 +1538,7 @@ namespace WindBot.Game.AI.Decks
                 }
             }
 
-            ClientCard currentSolvingChain = Duel.GetCurrentSolvingChainCard();
+            ChainInfo currentSolvingChain = Duel.GetCurrentSolvingChainInfo();
             if (currentSolvingChain != null)
             {
                 // TODO

--- a/Game/AI/Decks/SacredBeastExecutor.cs
+++ b/Game/AI/Decks/SacredBeastExecutor.cs
@@ -286,9 +286,8 @@ namespace WindBot.Game.AI.Decks
         {
             ChainInfo currentSolvingChain = Duel.GetCurrentSolvingChainInfo();
             Logger.DebugWriteLine("OnSelectCard " + cards.Count + " " + min + " " + max + " hint=" + hint + " cancelable=" + cancelable + " cards=[" + string.Join(", ", cards.Select(c => c == null ? "null" : $"{c.Name}({c.Id}) C{c.Controller} L{c.Location}")) + "]");
-            ClientCard solving = Duel.GetCurrentSolvingChainCard();
 
-            if (solving != null && solving.Controller == 1 && solving.IsCode(CardId.AmeNoMurakumoNoMitsurugi) && cards != null && cards.Count > 0
+            if (currentSolvingChain != null && currentSolvingChain.ActivatePlayer == 1 && currentSolvingChain.IsActivateCode(CardId.AmeNoMurakumoNoMitsurugi) && cards != null && cards.Count > 0
                 && (hint == HintMsg.Discard || hint == HintMsg.ToGrave) && cards.All(c => c != null && c.Controller == 0 && c.Location == CardLocation.Hand))
             {
                 HashSet<int> protect = new HashSet<int>();

--- a/Game/AI/Decks/SwordsoulExecutor.cs
+++ b/Game/AI/Decks/SwordsoulExecutor.cs
@@ -695,18 +695,18 @@ namespace WindBot.Game.AI.Decks
 
         public override void OnChainSolved(int chainIndex)
         {
-            ChainInfo currentCard = Duel.GetCurrentSolvingChainInfo();
-            if (currentCard != null && !Duel.IsCurrentSolvingChainNegated() && currentCard.ActivatePlayer == 1)
+            ChainInfo currentChain = Duel.GetCurrentSolvingChainInfo();
+            if (currentChain != null && !Duel.IsCurrentSolvingChainNegated() && currentChain.ActivatePlayer == 1)
             {
-                if (currentCard.IsCode(_CardId.MaxxC))
+                if (currentChain.IsActivateCode(_CardId.MaxxC))
                     enemyActivateMaxxC = true;
-                if (currentCard.IsCode(_CardId.LockBird))
+                if (currentChain.IsActivateCode(_CardId.LockBird))
                     enemyActivateLockBird = true;
-                if (currentCard.IsCode(_CardId.InfiniteImpermanence) && !enemyActivateInfiniteImpermanenceFromHand)
+                if (currentChain.IsActivateCode(_CardId.InfiniteImpermanence) && !enemyActivateInfiniteImpermanenceFromHand)
                 {
                     for (int i = 0; i < 5; ++i)
                     {
-                        if (Enemy.SpellZone[i] == currentCard.RelatedCard)
+                        if (Enemy.SpellZone[i] == currentChain.RelatedCard)
                         {
                             infiniteImpermanenceList.Add(4 - i);
                             break;

--- a/Game/AI/Decks/TimeThiefExecutor.cs
+++ b/Game/AI/Decks/TimeThiefExecutor.cs
@@ -140,7 +140,7 @@ namespace WindBot.Game.AI.Decks
         public override IList<ClientCard> OnSelectCard(IList<ClientCard> cards, int min, int max, int hint, bool cancelable)
         {
             ClientCard currentChainCard = Duel.GetCurrentChainCard();
-            ClientCard solvingChainCard = Duel.GetCurrentSolvingChainCard();
+            ChainInfo solvingChain = Duel.GetCurrentSolvingChainInfo();
 
             if (currentChainCard != null && currentChainCard.Controller == 0)
             {
@@ -217,9 +217,9 @@ namespace WindBot.Game.AI.Decks
                 }
             }
 
-            if (solvingChainCard != null && solvingChainCard.Controller == 0)
+            if (solvingChain != null && solvingChain.ActivatePlayer == 0)
             {
-                if (solvingChainCard.IsCode(Monsters.TimeThiefRegulator) &&
+                if (solvingChain.IsActivateCode(Monsters.TimeThiefRegulator) &&
                     hint == HintMsg.SpSummon && min == 2)
                 {
                     int[] summonOrder =
@@ -248,7 +248,7 @@ namespace WindBot.Game.AI.Decks
                     return Util.CheckSelectCount(selected, cards, min, max);
                 }
 
-                if (solvingChainCard.IsCode(Monsters.TimeThiefWinder) && hint == HintMsg.AddToHand)
+                if (solvingChain.IsActivateCode(Monsters.TimeThiefWinder) && hint == HintMsg.AddToHand)
                 {
                     int[] searchOrder = Bot.HasInMonstersZone(XYZs.TimeThiefRedoer)
                         ? new[]
@@ -275,7 +275,7 @@ namespace WindBot.Game.AI.Decks
                     return SelectOneCard(target, cards, min, max);
                 }
 
-                if (solvingChainCard.IsCode(Spells.TimeThiefStartup))
+                if (solvingChain.IsActivateCode(Spells.TimeThiefStartup))
                 {
                     if (hint == HintMsg.SpSummon)
                     {
@@ -326,7 +326,7 @@ namespace WindBot.Game.AI.Decks
                     }
                 }
 
-                if (solvingChainCard.IsCode(XYZs.TimeThiefRedoer))
+                if (solvingChain.IsActivateCode(XYZs.TimeThiefRedoer))
                 {
                     if (hint == HintMsg.RemoveXyz)
                     {
@@ -334,7 +334,7 @@ namespace WindBot.Game.AI.Decks
                         ClientCard trap = cards.FirstOrDefault(card => card.IsTrap());
                         ClientCard spell = cards.FirstOrDefault(card => card.IsSpell());
                         ClientCard monster = cards.FirstOrDefault(card => card.IsMonster());
-                        bool needsProtection = ShouldUseRedoerMonsterMaterial(solvingChainCard);
+                        bool needsProtection = ShouldUseRedoerMonsterMaterial(solvingChain.RelatedCard);
                         if (trap != null)
                             selected.Add(trap);
                         if (spell != null)
@@ -357,7 +357,7 @@ namespace WindBot.Game.AI.Decks
                     }
                 }
 
-                if (hint == HintMsg.XyzMaterial && solvingChainCard.IsCode(
+                if (hint == HintMsg.XyzMaterial && solvingChain.IsActivateCode(
                     XYZs.TimeThiefPerpetua,
                     Traps.TimeThiefFlyBack,
                     Monsters.TimeThiefBezelShip))
@@ -383,7 +383,7 @@ namespace WindBot.Game.AI.Decks
                     return SelectMaterialToAttach(cards, min, max);
                 }
 
-                if (solvingChainCard.IsCode(Traps.TimeThiefRetrograte) && hint == HintMsg.Faceup)
+                if (solvingChain.IsActivateCode(Traps.TimeThiefRetrograte) && hint == HintMsg.Faceup)
                 {
                     return SelectXyzToReceiveMaterial(cards, min, max);
                 }

--- a/Game/AI/Decks/WitchcraftExecutor.cs
+++ b/Game/AI/Decks/WitchcraftExecutor.cs
@@ -201,42 +201,42 @@ namespace WindBot.Game.AI.Decks
 
         public override void OnChainSolved(int chainIndex)
         {
-            ChainInfo currentCard = Duel.GetCurrentSolvingChainInfo();
-            if (currentCard != null && currentCard.ActivatePlayer == 1)
+            ChainInfo currentChain = Duel.GetCurrentSolvingChainInfo();
+            if (currentChain != null && currentChain.ActivatePlayer == 1)
             {
                 if (Duel.IsCurrentSolvingChainNegated())
                 {
                     // MagiciansLeftHand / MagicianRightHand
-                    if (!MagicianRightHand_used && currentCard.IsSpell())
+                    if (!MagicianRightHand_used && currentChain.IsSpell())
                     {
                         if (Bot.MonsterZone.GetFirstMatchingCard(c => c.HasRace(CardRace.SpellCaster) && c.IsFaceup()) != null
                             && Bot.HasInSpellZone(CardId.MagicianRightHand, true))
                         {
-                            Logger.DebugWriteLine("MagicianRightHand negate: " + currentCard.RelatedCard.Name ?? "???");
+                            Logger.DebugWriteLine("MagicianRightHand negate: " + currentChain.RelatedCard.Name ?? "???");
                             MagicianRightHand_used = true;
                         }
                     }
-                    if (!MagiciansLeftHand_used && currentCard.IsTrap() && currentCard.ActivatePlayer == 1)
+                    if (!MagiciansLeftHand_used && currentChain.IsTrap() && currentChain.ActivatePlayer == 1)
                     {
                         if (Bot.MonsterZone.GetFirstMatchingCard(c => c.HasRace(CardRace.SpellCaster) && c.IsFaceup()) != null
                             && Bot.HasInSpellZone(CardId.MagiciansLeftHand, true))
                         {
-                            Logger.DebugWriteLine("MagiciansLeftHand negate: " + currentCard.RelatedCard.Name ?? "???");
+                            Logger.DebugWriteLine("MagiciansLeftHand negate: " + currentChain.RelatedCard.Name ?? "???");
                             MagiciansLeftHand_used = true;
                         }
                     }
                 }
                 if (!Duel.IsCurrentSolvingChainNegated())
                 {
-                    if (currentCard.IsCode(_CardId.MaxxC))
+                    if (currentChain.IsActivateCode(_CardId.MaxxC))
                         enemy_activate_MaxxC = true;
-                    if (currentCard.IsCode(CardId.DimensionShifter))
+                    if (currentChain.IsActivateCode(CardId.DimensionShifter))
                         enemy_activate_DimensionShifter = true;
-                    if (currentCard.IsCode(_CardId.InfiniteImpermanence))
+                    if (currentChain.IsActivateCode(_CardId.InfiniteImpermanence))
                     {
                         for (int i = 0; i < 5; ++i)
                         {
-                            if (Enemy.SpellZone[i] == currentCard.RelatedCard)
+                            if (Enemy.SpellZone[i] == currentChain.RelatedCard)
                             {
                                 Impermanence_list.Add(4 - i);
                                 break;

--- a/Game/AI/Decks/YubelExecutor.cs
+++ b/Game/AI/Decks/YubelExecutor.cs
@@ -962,20 +962,19 @@ namespace WindBot.Game.AI.Decks
 
         public override void OnChainSolved(int chainIndex)
         {
-            ClientCard currentCard = Duel.GetCurrentSolvingChainCard();
-            var solving = Duel.GetCurrentSolvingChainCard();
+            ChainInfo currentChain = Duel.GetCurrentSolvingChainInfo();
             bool neg = Duel.IsCurrentSolvingChainNegated();
-            Logger.DebugWriteLine($"[CHAIN] Solved idx={chainIndex} negated={neg} solving={CardStr(solving)}");
-            if (currentCard != null && !Duel.IsCurrentSolvingChainNegated() && currentCard.Controller == 1)
+            Logger.DebugWriteLine($"[CHAIN] Solved idx={chainIndex} negated={neg} solving={CardStr(currentChain?.RelatedCard)}");
+            if (currentChain != null && !Duel.IsCurrentSolvingChainNegated() && currentChain.ActivatePlayer == 1)
             {
-                if (currentCard.IsCode(_CardId.MaxxC)) enemyActivateMaxxC = true;
-                if (currentCard.IsCode(CardId.Fuwalos)) enemyActivateMaxxC = true;
-                if (currentCard.IsCode(_CardId.LockBird)) enemyActivateLockBird = true;
-                if (currentCard.IsCode(_CardId.InfiniteImpermanence))
+                if (currentChain.IsActivateCode(_CardId.MaxxC)) enemyActivateMaxxC = true;
+                if (currentChain.IsActivateCode(CardId.Fuwalos)) enemyActivateMaxxC = true;
+                if (currentChain.IsActivateCode(_CardId.LockBird)) enemyActivateLockBird = true;
+                if (currentChain.IsActivateCode(_CardId.InfiniteImpermanence))
                 {
                     for (int i = 0; i < 5; ++i)
                     {
-                        if (Enemy.SpellZone[i] == currentCard)
+                        if (Enemy.SpellZone[i] == currentChain.RelatedCard)
                         {
                             infiniteImpermanenceList.Add(4 - i);
                             break;
@@ -2011,18 +2010,16 @@ namespace WindBot.Game.AI.Decks
         private bool YesNoFor(int desc, int cardId, int idx)
         {
             var info = Duel.GetCurrentSolvingChainInfo();
-            var card = Duel.GetCurrentSolvingChainCard();
             // ต้องทั้ง: คำอธิบายตรง + การ์ดบน chain ตอนนี้ตรง
             return desc == Util.GetStringId(cardId, idx)
-                   && ((info != null && info.IsCode(cardId)) || (card != null && card.IsCode(cardId)));
+                   && info != null && info.IsActivateCode(cardId);
         }
         public override bool OnSelectYesNo(int desc)
         {
             Logger.DebugWriteLine($"[DEBUG] OnSelectYesNo: desc={desc}");
             var info = Duel.GetCurrentSolvingChainInfo();
-            var solving = Duel.GetCurrentSolvingChainCard();
             DumpChain("OnSelectYesNo");
-            Logger.DebugWriteLine($"[THRONE] OnSelectYesNo desc={desc} stage={_throneStage} solving={CardStr(solving)}");
+            Logger.DebugWriteLine($"[THRONE] OnSelectYesNo desc={desc} stage={_throneStage} solving={CardStr(info?.RelatedCard)}");
             if (IsEnemyMurakumoSolving())
             {
                 bool discard = ShouldDiscardForMurakumo();
@@ -2036,7 +2033,7 @@ namespace WindBot.Game.AI.Decks
             { return false; }
             // --- Nightmare Throne ---
             // idx อาจต่างกันตามสคริปต์ แต่แนวคิดคือ anchor กับ desc+solving เสมอ
-            if (solving != null && solving.IsCode(CardId.NIGHTMARE_THRONE))
+            if (info != null && info.IsActivateCode(CardId.NIGHTMARE_THRONE))
             {
                 // เปิด map ช่วย debug ให้เห็นว่า desc ตรง index ไหนจริง ๆ
                 DebugThroneDescMap(desc);
@@ -2074,8 +2071,8 @@ namespace WindBot.Game.AI.Decks
                 var best = GetBestEnemyCard();
                 return best != null && ShouldVarudrasDetachForPop(best);
             }
-            if (solving != null
-                && solving.IsCode(CardId.VARUDASN_FINAL_BRINGER)
+            if (info != null
+                && info.IsActivateCode(CardId.VARUDASN_FINAL_BRINGER)
                 && Duel.CurrentChain.Count > 0) // แปลว่าอยู่ใน e1 ไม่ใช่ e2
             {
                 // มีเป้าศัตรูให้ทำลายไหม?
@@ -2107,8 +2104,8 @@ namespace WindBot.Game.AI.Decks
             bool isReleasePrompt =
             hint == (long)HintMsg.Release ||
             hint.ToString().ToLower().Contains("release"); // กันเหนียว
-            var solving = Duel.GetCurrentSolvingChainCard();
-            if (IsEnemyMurakumoSolving() && cards != null && cards.Count > 0 && (hint == HintMsg.Discard || 
+            var solving = Duel.GetCurrentSolvingChainInfo();
+            if (IsEnemyMurakumoSolving() && cards != null && cards.Count > 0 && (hint == HintMsg.Discard ||
                 hint == HintMsg.ToGrave) && cards.All(c => c != null && c.Controller == 0 && c.Location == CardLocation.Hand))
             {
                 var discardOrder = cards
@@ -2130,7 +2127,7 @@ namespace WindBot.Game.AI.Decks
             if (cards != null && cards.Count > 0)
             {
                 // === Throne ===
-                if (_throneStage == ThroneStage.Searching && solving != null && solving.IsCode(CardId.NIGHTMARE_THRONE) && !throneSearched && cards != null && cards.Count > 0)
+                if (_throneStage == ThroneStage.Searching && solving != null && solving.IsActivateCode(CardId.NIGHTMARE_THRONE) && !throneSearched && cards != null && cards.Count > 0)
                 {
                     throneSearched = true;
                     _throneStage = ThroneStage.AwaitDestroyPrompt;
@@ -2147,7 +2144,7 @@ namespace WindBot.Game.AI.Decks
                     return new[] { chosen };
                 }
                 // === SPIRIT GATES selections ===
-                if (solving != null && solving.Id == CardId.SPIRIT_GATES && cards != null && cards.Count > 0)
+                if (solving != null && solving.ActivateId == CardId.SPIRIT_GATES && cards != null && cards.Count > 0)
                 {
                     // 2.1: เลือก Continuous Spell จากสุสาน (Recycle)
                     if (_gateWantsRecycle)
@@ -2220,7 +2217,7 @@ namespace WindBot.Game.AI.Decks
                     }
                 }
                 // === Throne: เลือกการ์ดที่ค้นเจอ ===
-                if (solving != null && solving.Id == CardId.NIGHTMARE_THRONE && _throneStage == ThroneStage.Searching && thronePending && !throneSearched)
+                if (solving != null && solving.ActivateId == CardId.NIGHTMARE_THRONE && _throneStage == ThroneStage.Searching && thronePending && !throneSearched)
                 {
                     throneSearched = true;
                     _throneStage = ThroneStage.AwaitDestroyPrompt;
@@ -2245,7 +2242,7 @@ namespace WindBot.Game.AI.Decks
                     // ปล่อยให้ base ตัดสินใจ หรือจะ return null ก็ได้ตามฐานของคุณ
                 }
                 // --- Varudras: เลือกเป้าหมายทำลาย ---
-                if (solving != null && solving.Id == CardId.VARUDASN_FINAL_BRINGER && hint == 502 && cards != null && cards.Count > 0)
+                if (solving != null && solving.ActivateId == CardId.VARUDASN_FINAL_BRINGER && hint == 502 && cards != null && cards.Count > 0)
                 {
                     // พยายามเลือกฝั่งศัตรูก่อน (คัดใบที่อันตราย/ป่วนที่สุด)
                     var enemyPick = cards
@@ -2257,7 +2254,7 @@ namespace WindBot.Game.AI.Decks
                     return new[] { cards[0] }; // fallback
                 }
                 // --- Abomination: เลือกเป้าหมายทำลาย ---
-                if (solving != null && solving.Id == CardId.UNCHAINDEDABOMINATION && hint == 502 && cards != null && cards.Count > 0)
+                if (solving != null && solving.ActivateId == CardId.UNCHAINDEDABOMINATION && hint == 502 && cards != null && cards.Count > 0)
                 {
                     // พยายามเลือกฝั่งศัตรูก่อน (คัดใบที่อันตราย/ป่วนที่สุด)
                     var enemyPick = cards
@@ -2269,7 +2266,7 @@ namespace WindBot.Game.AI.Decks
                     return new[] { cards[0] }; // fallback
                 }
                 // --- Rage Quick Link ---
-                if (solving != null && solving.IsCode(CardId.UNCHAINED_SOUL_OF_RAGE) && cards.Any(c => c != null && c.Location == CardLocation.Extra))
+                if (solving != null && solving.IsActivateCode(CardId.UNCHAINED_SOUL_OF_RAGE) && cards.Any(c => c != null && c.Location == CardLocation.Extra))
                 {
                     // 1) เลือก S:P Little Knight ก่อนเสมอ ถ้ามี
                     var pickSP = cards.FirstOrDefault(c => c != null && c.Id == CardId.SP_LITTLE_KNIGHT);
@@ -2326,12 +2323,9 @@ namespace WindBot.Game.AI.Decks
         private bool IsEnemyMurakumoSolving()
         {
             var info = Duel.GetCurrentSolvingChainInfo();
-            var solving = Duel.GetCurrentSolvingChainCard();
-
             return info != null
                 && info.ActivatePlayer == 1
-                && solving != null
-                && solving.IsCode(CardId.AME_NO_MURAKUMO_NO_MITSURUGI);
+                && info.IsActivateCode(CardId.AME_NO_MURAKUMO_NO_MITSURUGI);
         }
 
         private bool ShouldDiscardForMurakumo()
@@ -2357,10 +2351,10 @@ namespace WindBot.Game.AI.Decks
                 var c = Duel.CurrentChain[i];
                 Logger.DebugWriteLine($"  [{i}] {CardStr(c)}");
             }
-            var solving = Duel.GetCurrentSolvingChainCard();
+            var solving = Duel.GetCurrentSolvingChainInfo();
             if (solving != null)
             {
-                Logger.DebugWriteLine($"  -> Solving: {CardStr(solving)}  ActivateDescription={ActivateDescription}");
+                Logger.DebugWriteLine($"  -> Solving: {CardStr(solving.RelatedCard)}  ActivateDescription={ActivateDescription}");
             }
             if (Duel.ChainTargets != null && Duel.ChainTargets.Count > 0)
             {

--- a/Game/AI/DefaultExecutor.cs
+++ b/Game/AI/DefaultExecutor.cs
@@ -638,7 +638,7 @@ namespace WindBot.Game.AI
             base.OnHintZone(player, zone);
             ChainInfo currentChainInfo = Duel.GetCurrentSolvingChainInfo();
             if (currentChainInfo != null) {
-                if (currentChainInfo.IsCode(_CardId.InfiniteImpermanence)) {
+                if (currentChainInfo.IsActivateCode(_CardId.InfiniteImpermanence)) {
                     // Zone bit mapping: 0x100=col0, 0x200=col1, 0x400=col2, 0x800=col3, 0x1000=col4.
                     for (int i = 0; i <= 4; i++)
                     {
@@ -737,7 +737,8 @@ namespace WindBot.Game.AI
         {
             if (card != null)
             {
-                ClientCard currentSolvingChain = Duel.GetCurrentSolvingChainCard();
+                // 用发动快照识别卡名，避免 RelatedCard 离场后 Id 变化
+                ChainInfo currentSolvingChain = Duel.GetCurrentSolvingChainInfo();
                 if (currentSolvingChain != null && currentLocation == (int)CardLocation.Removed)
                 {
                     int originId = card.Id;
@@ -746,11 +747,11 @@ namespace WindBot.Game.AI
                         if (card.Data.Alias > 0) originId = card.Data.Alias;
                         else originId = card.Id;
                     }
-                    if (currentSolvingChain.IsCode(_CardId.CalledByTheGrave))
+                    if (currentSolvingChain.IsActivateCode(_CardId.CalledByTheGrave))
                     {
                         calledbytheGraveIdCountMap[originId] = 2;
                     }
-                    if (currentSolvingChain.IsCode(_CardId.CrossoutDesignator))
+                    if (currentSolvingChain.IsActivateCode(_CardId.CrossoutDesignator))
                     {
                         crossoutDesignatorIdList.Add(originId);
                     }

--- a/Game/ChainInfo.cs
+++ b/Game/ChainInfo.cs
@@ -70,6 +70,31 @@ namespace WindBot.Game
             return ActivateId == id || Math.Abs(ActivateAlias - ActivateId) <= 20 && ActivateAlias == id;
         }
 
+        public bool IsActivateCode(IList<int> ids)
+        {
+            if (ids == null)
+                return false;
+            // 对每个 id 走发动快照匹配，规则与单参 IsActivateCode 一致
+            foreach (int id in ids)
+            {
+                if (IsActivateCode(id))
+                    return true;
+            }
+            return false;
+        }
+
+        public bool IsActivateCode(params int[] ids)
+        {
+            if (ids == null)
+                return false;
+            foreach (int id in ids)
+            {
+                if (IsActivateCode(id))
+                    return true;
+            }
+            return false;
+        }
+
         public bool IsCode(int id)
         {
             return RelatedCard != null && RelatedCard.IsCode(id);


### PR DESCRIPTION
# migrate(chain): 用 ChainInfo 发动快照替代 GetCurrentSolvingChainCard

## Summary

- 扩展 `ChainInfo.IsActivateCode`，补充 `IList<int>` / `params int[]` 重载，统一用发动快照识别连锁源卡。
- 将各 Executor 中基于 `GetCurrentSolvingChainCard` / `ChainInfo.IsCode`（活卡）的判断，迁移为 `GetCurrentSolvingChainInfo` + `IsActivateCode` / `ActivateId` / `ActivatePlayer` / `ActivateSequence`。
- 无限泡影列匹配、调试日志等仍使用 `RelatedCard`；无连锁时选牌逻辑（Neko / MalissOCG）回退到当前 `Card`。
- 将误命名为 `currentCard` 的 `ChainInfo` 变量统一重命名为 `currentChain`。

---

# migrate(chain): prefer ChainInfo activation snapshot over GetCurrentSolvingChainCard

## Summary

- Extend `ChainInfo.IsActivateCode` with `IList<int>` / `params int[]` overloads so chain-source identification consistently uses the activation snapshot.
- Migrate Executor logic that used `GetCurrentSolvingChainCard` / `ChainInfo.IsCode` (live card) to `GetCurrentSolvingChainInfo` plus `IsActivateCode` / `ActivateId` / `ActivatePlayer` / `ActivateSequence`.
- Keep `RelatedCard` for Infinite Impermanence column matching and debug logging; keep falling back to the current `Card` when there is no resolving chain (Neko / MalissOCG).
- Rename `ChainInfo` locals previously called `currentCard` to `currentChain`.
