### PR TITLE
Minor Yubel Bot Improvements

### DIFF
--- a/Game/AI/Decks/YubelExecutor.cs
+++ b/Game/AI/Decks/YubelExecutor.cs
@@ -1528,6 +1528,7 @@ namespace WindBot.Game.AI.Decks
             // Use Requiem to enable Engraver to send opponent monster to GY
             else if (Bot.HasInMonstersZone(CardId.FIENDSMITH_ENGRAVER))
             {
+                AI.SelectCard(CardId.FIENDSMITH_ENGRAVER);
                 return true;
             }
             return false;

--- a/Game/AI/Decks/YubelExecutor.cs
+++ b/Game/AI/Decks/YubelExecutor.cs
@@ -247,6 +247,7 @@ namespace WindBot.Game.AI.Decks
         int _gateDiscardPreferredId = 0;  // จะทิ้งใบไหนเป็น cost
         bool _gateWantsRecycle = false;   // กำลังจะกดโหมดเก็บ Continuous
         bool _spQuickMode = false;
+        bool engraverGYActivated = false;
         bool moonSummoned = false;
         bool requiemSummoned = false;
         bool thronePending = false;      // we're in a Throne activation flow
@@ -1036,6 +1037,7 @@ namespace WindBot.Game.AI.Decks
             _gateDiscardPreferredId = 0;
             _gateWantsRecycle = false;
             _spQuickMode = false;
+            engraverGYActivated = false;
             
             base.OnNewTurn();
         }
@@ -1497,8 +1499,8 @@ namespace WindBot.Game.AI.Decks
 
         private bool ActRequiemEQ()
         {
-            if (!HasInExtra(CardId.NECROQUIP)) { return false; }
             if (Card.Location != CardLocation.Grave) { return false; }
+            if (!HasInExtra(CardId.NECROQUIP)) { return false; }            
             if (Bot.HasInMonstersZone(CardId.LACRIMA_CT))
             {   
                 AI.SelectCard(CardId.LACRIMA_CT);
@@ -1509,23 +1511,44 @@ namespace WindBot.Game.AI.Decks
                 AI.SelectCard(CardId.FIENDSMITH_ENGRAVER);
                 return true;
             }
+            else if (Bot.HasInMonstersZone(CardId.FABLED_LURRIE))
+            {
+                AI.SelectCard(CardId.FABLED_LURRIE);
+                return true;
+            }
             return false;
         }
 
         private bool SSNecroquip()
         {
-            if (Bot.HasInSpellZone(CardId.FIENDSMITHS_REQUIEM) && Bot.HasInMonstersZone(CardId.LACRIMA_CT))
+            if (!Bot.HasInSpellZone(CardId.FIENDSMITHS_REQUIEM)) return false;
+
+            bool engraverOnField = Bot.HasInMonstersZone(CardId.FIENDSMITH_ENGRAVER);
+            if (Bot.HasInMonstersZone(CardId.LACRIMA_CT))
             {
                 AI.SelectCard(CardId.FIENDSMITHS_REQUIEM);
                 AI.SelectNextCard(CardId.LACRIMA_CT);
                 return true;
             }
-            else if (Bot.HasInSpellZone(CardId.FIENDSMITHS_REQUIEM) && Bot.HasInMonstersZone(CardId.FIENDSMITH_ENGRAVER))
+            else if (engraverOnField && (!engraverGYActivated || DefaultCheckWhetherCardIdIsNegated(CardId.FIENDSMITH_ENGRAVER)))
             {
                 AI.SelectCard(CardId.FIENDSMITHS_REQUIEM);
                 AI.SelectNextCard(CardId.FIENDSMITH_ENGRAVER);
                 return true;
             }
+            else if (Bot.HasInMonstersZone(CardId.FABLED_LURRIE))
+            {
+                AI.SelectCard(CardId.FIENDSMITHS_REQUIEM);
+                AI.SelectNextCard(CardId.FABLED_LURRIE);
+                return true;
+            }
+            else if (engraverOnField)
+            {
+                AI.SelectCard(CardId.FIENDSMITHS_REQUIEM);
+                AI.SelectNextCard(CardId.FIENDSMITH_ENGRAVER);
+                return true;
+            }
+
             return false;
         }
 
@@ -1578,8 +1601,18 @@ namespace WindBot.Game.AI.Decks
         private bool ActEngraverGY()
         {
             if (Card.Location != CardLocation.Grave) return false;
-            if (Bot.HasInGraveyard(CardId.FABLED_LURRIE)) { AI.SelectCard(CardId.FABLED_LURRIE); return true; }
-            else if (Bot.HasInGraveyard(CardId.MOON_OF_THE_CLOSED_HEAVEN)) { AI.SelectCard(CardId.MOON_OF_THE_CLOSED_HEAVEN); return true; }
+            if (Bot.HasInGraveyard(CardId.FABLED_LURRIE)) 
+            {
+                engraverGYActivated = true;
+                AI.SelectCard(CardId.FABLED_LURRIE); 
+                return true; 
+            }
+            else if (Bot.HasInGraveyard(CardId.MOON_OF_THE_CLOSED_HEAVEN)) 
+            {
+                engraverGYActivated = true;
+                AI.SelectCard(CardId.MOON_OF_THE_CLOSED_HEAVEN); 
+                return true; 
+            }
             return false;
         }
 

--- a/Game/AI/Decks/YubelExecutor.cs
+++ b/Game/AI/Decks/YubelExecutor.cs
@@ -159,6 +159,7 @@ namespace WindBot.Game.AI.Decks
             AddExecutor(ExecutorType.Activate, CardId.UNCHAINED_SOUL_OF_RAGE, ActRageQuickLink);
             AddExecutor(ExecutorType.Activate, CardId.FIENDSMITHS_PARADISE, ActParadise);
 
+            // ===== Fiendsmith Line =====
             AddExecutor(ExecutorType.Activate, CardId.FIENDSMITH_ENGRAVER, ActEngraverHand);
             AddExecutor(ExecutorType.Activate, CardId.FIENDSMITH_TRACT, ActTract);
             AddExecutor(ExecutorType.SpSummon, CardId.FABLED_LURRIE);
@@ -170,6 +171,7 @@ namespace WindBot.Game.AI.Decks
             AddExecutor(ExecutorType.Activate, CardId.FIENDSMITH_ENGRAVER, ActEngraverGY);
             AddExecutor(ExecutorType.SpSummon, CardId.DDD_WAVE_HIGH_KING_CAESAR);
 
+            AddExecutor(ExecutorType.Activate, CardId.FIENDSMITH_ENGRAVER, ActEngraverField);
             AddExecutor(ExecutorType.Activate, CardId.LACRIMA_CT, ActLacimaCTGY);
 
             // Field & search line
@@ -247,6 +249,7 @@ namespace WindBot.Game.AI.Decks
         int _gateDiscardPreferredId = 0;  // จะทิ้งใบไหนเป็น cost
         bool _gateWantsRecycle = false;   // กำลังจะกดโหมดเก็บ Continuous
         bool _spQuickMode = false;
+        bool engraverFieldActivated = false;
         bool engraverGYActivated = false;
         bool moonSummoned = false;
         bool requiemSummoned = false;
@@ -1037,6 +1040,9 @@ namespace WindBot.Game.AI.Decks
             _gateDiscardPreferredId = 0;
             _gateWantsRecycle = false;
             _spQuickMode = false;
+
+            // reset Fiendsmith effects
+            engraverFieldActivated = false;
             engraverGYActivated = false;
             
             base.OnNewTurn();
@@ -1500,20 +1506,28 @@ namespace WindBot.Game.AI.Decks
         private bool ActRequiemEQ()
         {
             if (Card.Location != CardLocation.Grave) { return false; }
-            if (!HasInExtra(CardId.NECROQUIP)) { return false; }            
-            if (Bot.HasInMonstersZone(CardId.LACRIMA_CT))
-            {   
-                AI.SelectCard(CardId.LACRIMA_CT);
-                return true; 
+            // Use Requiem to go into Necroquip for Caesar
+            if (HasInExtra(CardId.NECROQUIP)) 
+            {
+                if (Bot.HasInMonstersZone(CardId.LACRIMA_CT))
+                {
+                    AI.SelectCard(CardId.LACRIMA_CT);
+                    return true;
+                }
+                else if (Bot.HasInMonstersZone(CardId.FIENDSMITH_ENGRAVER))
+                {
+                    AI.SelectCard(CardId.FIENDSMITH_ENGRAVER);
+                    return true;
+                }
+                else if (Bot.HasInMonstersZone(CardId.FABLED_LURRIE))
+                {
+                    AI.SelectCard(CardId.FABLED_LURRIE);
+                    return true;
+                }
             }
+            // Use Requiem to enable Engraver to send opponent monster to GY
             else if (Bot.HasInMonstersZone(CardId.FIENDSMITH_ENGRAVER))
             {
-                AI.SelectCard(CardId.FIENDSMITH_ENGRAVER);
-                return true;
-            }
-            else if (Bot.HasInMonstersZone(CardId.FABLED_LURRIE))
-            {
-                AI.SelectCard(CardId.FABLED_LURRIE);
                 return true;
             }
             return false;
@@ -1595,6 +1609,23 @@ namespace WindBot.Game.AI.Decks
                 AI.SelectCard(CardId.FIENDSMITH_TRACT);
                 return true;
             }
+            return false;
+        }
+
+        private bool ActEngraverField()
+        {
+            if (Card.Location != CardLocation.MonsterZone) return false;
+            if (!Bot.HasInSpellZone(CardId.FIENDSMITHS_REQUIEM)) return false;
+
+            ClientCard target = GetBestEnemyMonster(onlyFaceup: false, canBeTarget: true);
+            if (target != null)
+            {
+                engraverFieldActivated = true;
+                AI.SelectCard(CardId.FIENDSMITHS_REQUIEM);
+                AI.SelectNextCard(target);
+                return true;
+            }
+
             return false;
         }
 

--- a/Game/AI/Decks/YubelExecutor.cs
+++ b/Game/AI/Decks/YubelExecutor.cs
@@ -1632,17 +1632,30 @@ namespace WindBot.Game.AI.Decks
         private bool ActEngraverGY()
         {
             if (Card.Location != CardLocation.Grave) return false;
-            if (Bot.HasInGraveyard(CardId.FABLED_LURRIE)) 
+            bool requiemInGrave = Bot.HasInGraveyard(CardId.FIENDSMITHS_REQUIEM);
+            if (requiemInGrave && !requiemSummoned)
             {
                 engraverGYActivated = true;
-                AI.SelectCard(CardId.FABLED_LURRIE); 
-                return true; 
+                AI.SelectCard(CardId.FIENDSMITHS_REQUIEM);
+                return true;
             }
-            else if (Bot.HasInGraveyard(CardId.MOON_OF_THE_CLOSED_HEAVEN)) 
+            else if (Bot.HasInGraveyard(CardId.FABLED_LURRIE))
             {
                 engraverGYActivated = true;
-                AI.SelectCard(CardId.MOON_OF_THE_CLOSED_HEAVEN); 
-                return true; 
+                AI.SelectCard(CardId.FABLED_LURRIE);
+                return true;
+            }
+            else if (Bot.HasInGraveyard(CardId.MOON_OF_THE_CLOSED_HEAVEN))
+            {
+                engraverGYActivated = true;
+                AI.SelectCard(CardId.MOON_OF_THE_CLOSED_HEAVEN);
+                return true;
+            }
+            else if (requiemInGrave && !Bot.HasInGraveyard(CardId.LACRIMA_CT))
+            {
+                engraverGYActivated = true;
+                AI.SelectCard(CardId.FIENDSMITHS_REQUIEM);
+                return true;
             }
             return false;
         }


### PR DESCRIPTION
- Allow more options for Necroquip Princess summon
- Allow Fiendsmith Engraver to use its effect on field
- Allow Fiendsmith Requiem to be returned by Fiendsmith Engraver if it wasn't summoned yet