### PR TITLE
add servermode deck exist check, remove deckfile

### DIFF
--- a/Game/AI/DecksManager.cs
+++ b/Game/AI/DecksManager.cs
@@ -73,5 +73,10 @@ namespace WindBot.Game.AI
             executor.Deck = infos.Deck;
             return executor;
         }
+
+        public static bool HasDeck(string name)
+        {
+            return _decks.ContainsKey(name);
+        }
     }
 }

--- a/Program.cs
+++ b/Program.cs
@@ -108,9 +108,7 @@ namespace WindBot
                     string port = queryParams.Get("port");
                     if (port != null)
                         Info.Port = Int32.Parse(port);
-                    string deckfile = queryParams.Get("deckfile");
-                    if (deckfile != null)
-                        Info.DeckFile = deckfile;
+                    string deckfile = queryParams.Get("deckfile"); // Obsoleted
                     string dialog = queryParams.Get("dialog");
                     if (dialog != null)
                         Info.Dialog = dialog;
@@ -130,9 +128,14 @@ namespace WindBot
                     if (chat != null)
                         Info.Chat = bool.Parse(chat);
 
-                    if (Info.Name == null || Info.Host == null || port == null)
+                    if (Info.Name == null || Info.Host == null || port == null || deckfile != null)
                     {
                         ctx.Response.StatusCode = 400;
+                        ctx.Response.Close();
+                    }
+                    else if (Info.Deck != null && !DecksManager.HasDeck(Info.Deck))
+                    {
+                        ctx.Response.StatusCode = 404;
                         ctx.Response.Close();
                     }
                     else

--- a/README.md
+++ b/README.md
@@ -152,7 +152,7 @@ eg. `http://127.0.0.1:2399/?name=%E2%91%A8&deck=Blue-Eyes&host=127.0.0.1&port=79
 
 In this situation, it will be multi-threaded. This can be useful for servers, since it don't use large amount memory.
 
-The parameters are same as commandlines, but low cased.
+The parameters are same as commandlines, but low cased. `deckfile` is not supported in server mode.
 
 Note: Currently the server bind to all interfaces, so it requires elevated privileges to run. You can otherwise use the following command to add a URL ACL for your port (2399 for example), which allows all users to access it:
 ```


### PR DESCRIPTION
In `ServerMode`:

- Validate that the requested `deck` corresponds to a registered deck.
  - Previously, an unknown deck name would silently fall back to a random deck.
- No longer support the `deckfile` parameter.
  - Allowing an HTTP client to make the server open an arbitrary local file is an anti-pattern and creates a potential privilege-boundary file access risk.
  - `deckfile` was designed to let players use their own decks with `DoEveryThingExecutor` and `LuckyExecutor`, which is not applicable in server mode.
  - If `deckfile` is currently being used to support multiple deck variants or similar use cases, consider deriving separate executors and assigning a different deck file to each one.