### PR TITLE
add Bot.GetCardCountInDeck, Bot.HasInDeck

### DIFF
--- a/Game/AI/Decks/AlbazExecutor.cs
+++ b/Game/AI/Decks/AlbazExecutor.cs
@@ -580,7 +580,7 @@ namespace WindBot.Game.AI.Decks
                     List<ClientCard> faceDownMonsters = botMonsters.Where(card => card.IsFacedown()).ToList();
                     banishList.AddRange(faceDownMonsters);
                     List<ClientCard> dumpMainMonsterList = botMonsters.Where(card => !banishList.Contains(card)
-                        && Bot.HasInDeck(card.Id)).ToList();
+                        && Bot.HasInDeck(card.GetNonAltartCode())).ToList();
                     dumpMainMonsterList.Sort(CardContainer.CompareCardAttack);
                     banishList.AddRange(dumpMainMonsterList);
 
@@ -591,7 +591,7 @@ namespace WindBot.Game.AI.Decks
                     banishList.AddRange(Util.ShuffleList(faceDownSpells));
 
                     List<ClientCard> uniqueMainMonster = botMonsters.Where(card => !banishList.Contains(card)
-                        && !card.HasType(CardType.Fusion | CardType.Synchro | CardType.Xyz | CardType.Link) && !Bot.HasInDeck(card.Id)).ToList();
+                        && !card.HasType(CardType.Fusion | CardType.Synchro | CardType.Xyz | CardType.Link) && !Bot.HasInDeck(card.GetNonAltartCode())).ToList();
                     uniqueMainMonster.Sort(CardContainer.CompareCardAttack);
                     banishList.AddRange(uniqueMainMonster);
 

--- a/Game/AI/Decks/AlbazExecutor.cs
+++ b/Game/AI/Decks/AlbazExecutor.cs
@@ -3995,7 +3995,7 @@ namespace WindBot.Game.AI.Decks
                         }
                     } else
                     {
-                        if (Bot.GetRemainingCount(CardId.FallenOfAlbaz) >= albazCountCheck)
+                        if (Bot.GetCardCountInDeck(CardId.FallenOfAlbaz) >= albazCountCheck)
                         {
                             target = null;
                             return CardId.FallenOfAlbaz;

--- a/Game/AI/Decks/AlbazExecutor.cs
+++ b/Game/AI/Decks/AlbazExecutor.cs
@@ -188,15 +188,6 @@ namespace WindBot.Game.AI.Decks
             CardId.TitanikladTheAshDragon, CardId.SprindTheIrondashDragon, CardId.AlbionTheBrandedDragon, CardId.LubellionTheSearingDragon, CardId.AlbaLenatusTheAbyssDragon,
             CardId.MirrorjadeTheIcebladeDragon, CardId.RindbrummTheStrikingDragon, CardId.AlbionTheSanctifireDragon
         };
-        Dictionary<int, List<int>> DeckCountTable = new Dictionary<int, List<int>>{
-            {3, new List<int> { CardId.AluberTheJesterOfDespia, _CardId.AshBlossom, _CardId.MaxxC, _CardId.InfiniteImpermanence }},
-            {2, new List<int> { CardId.FallenOfAlbaz, CardId.NadirServant, CardId.FusionDeployment, _CardId.CalledByTheGrave }},
-            {1, new List<int> { CardId.TheBystialLubellion, CardId.AlbionTheShroudedDragon, CardId.BystialSaronir, CardId.SpringansKitt, CardId.GuidingQuemTheVirtuous,
-                                CardId.BlazingCartesiaTheVirtuous, CardId.TriBrigadeMercourier, CardId.DespianTragedy, CardId.BrandedInWhite,
-                                CardId.BrandedFusion, CardId.GoldSarcophagus, CardId.FoolishBurial, CardId.BrandedInHighSpirits, CardId.BrandedOpening,
-                                _CardId.CrossoutDesignator, CardId.BrandedInRed, CardId.BrandedLost, CardId.BrightestBlazingBrandedKing,
-                                CardId.BrandedBeast, CardId.BrandedRetribution }}
-        };
         List<int> dangerousDragonIdList = new List<int> { 27548199, 92892239, 98630720, 9753964, 99585850, 24361622, 27572350, 69120785, 96402918, 74294676, 42752141, 18511599, 35103106, 26268488 };
         List<int> notToDestroySpellTrap = new List<int> { 50005218, 6767771 };
         List<int> targetNegateIdList = new List<int> {
@@ -242,30 +233,7 @@ namespace WindBot.Game.AI.Decks
             return true;
         }
 
-        /// <summary>
-        /// Check remain cards in deck
-        /// </summary>
-        /// <param name="id">Card's ID</param>
-        public int CheckRemainInDeck(int id)
-        {
-            for (int count = 1; count < 4; ++count)
-            {
-                if (DeckCountTable[count].Contains(id)) {
-                    return Bot.GetRemainingCount(id, count);
-                }
-            }
-            return 0;
-        }
 
-        public int CheckRemainInDeck(params int[] ids)
-        {
-            int sum = 0;
-            foreach (int id in ids)
-            {
-                sum += CheckRemainInDeck(id);
-            }
-            return sum;
-        }
 
         /// <summary>
         /// Check whether'll be negated
@@ -612,7 +580,7 @@ namespace WindBot.Game.AI.Decks
                     List<ClientCard> faceDownMonsters = botMonsters.Where(card => card.IsFacedown()).ToList();
                     banishList.AddRange(faceDownMonsters);
                     List<ClientCard> dumpMainMonsterList = botMonsters.Where(card => !banishList.Contains(card)
-                        && CheckRemainInDeck(card.Id) > 0).ToList();
+                        && Bot.HasInDeck(card.Id)).ToList();
                     dumpMainMonsterList.Sort(CardContainer.CompareCardAttack);
                     banishList.AddRange(dumpMainMonsterList);
 
@@ -623,7 +591,7 @@ namespace WindBot.Game.AI.Decks
                     banishList.AddRange(Util.ShuffleList(faceDownSpells));
 
                     List<ClientCard> uniqueMainMonster = botMonsters.Where(card => !banishList.Contains(card)
-                        && !card.HasType(CardType.Fusion | CardType.Synchro | CardType.Xyz | CardType.Link) && CheckRemainInDeck(card.Id) == 0).ToList();
+                        && !card.HasType(CardType.Fusion | CardType.Synchro | CardType.Xyz | CardType.Link) && !Bot.HasInDeck(card.Id)).ToList();
                     uniqueMainMonster.Sort(CardContainer.CompareCardAttack);
                     banishList.AddRange(uniqueMainMonster);
 
@@ -741,7 +709,7 @@ namespace WindBot.Game.AI.Decks
                                     bool fusionFlag = Bot.HasInHandOrHasInMonstersZone(CardId.BlazingCartesiaTheVirtuous);
                                     if (!activatedCardIdList.Contains(CardId.BrandedFusion))
                                     {
-                                        if (Bot.HasInHand(CardId.BrandedFusion) || (!summoned && CheckRemainInDeck(CardId.BrandedFusion) > 0 && Bot.HasInHand(new int[] {
+                                        if (Bot.HasInHand(CardId.BrandedFusion) || (!summoned && Bot.HasInDeck(CardId.BrandedFusion) && Bot.HasInHand(new int[] {
                                     CardId.AluberTheJesterOfDespia, CardId.SpringansKitt
                                 })))
                                         {
@@ -812,7 +780,7 @@ namespace WindBot.Game.AI.Decks
                         {
                             Dictionary<int, Func<bool>> quemCheckDict = new Dictionary<int, Func<bool>>
                             {
-                                {CardId.BlazingCartesiaTheVirtuous, () => sendToGYThisTurn.Any(c => c.IsCode(CardId.AlbionTheBrandedDragon)) && CheckRemainInDeck(CardId.BrandedInHighSpirits) > 0 },
+                                {CardId.BlazingCartesiaTheVirtuous, () => sendToGYThisTurn.Any(c => c.IsCode(CardId.AlbionTheBrandedDragon)) && Bot.HasInDeck(CardId.BrandedInHighSpirits) },
                                 {CardId.BrandedFusion, () => Bot.HasInGraveyard(CardId.BrandedRetribution) },
                                 {CardId.FallenOfAlbaz, () => !Bot.HasInGraveyard(CardId.FallenOfAlbaz) },
                                 {CardId.TriBrigadeMercourier, () => Bot.HasInHandOrInSpellZone(CardId.BrandedInWhite) },
@@ -880,7 +848,7 @@ namespace WindBot.Game.AI.Decks
                             ClientCard lubellion = cards.FirstOrDefault(c => c != null && c.IsCode(CardId.TheBystialLubellion) && c.Location == CardLocation.MonsterZone);
                             if (lubellion != null && !Bot.HasInHandOrInSpellZone(CardId.BrandedBeast))
                             {
-                                if (activatedCardIdList.Contains(CardId.TheBystialLubellion + 1) || CheckRemainInDeck(CardId.BrandedLost, CardId.BrandedBeast) == 0)
+                                if (activatedCardIdList.Contains(CardId.TheBystialLubellion + 1) || !Bot.HasInDeck(CardId.BrandedLost, CardId.BrandedBeast))
                                 {
                                     if (Util.IsTurn1OrMain2() || Enemy.MonsterZone.Count(c => c != null && c.GetDefensePower() < 2500) > 0)
                                     {
@@ -916,7 +884,7 @@ namespace WindBot.Game.AI.Decks
                         {
                             if (summoned)
                             {
-                                if (CheckRemainInDeck(CardId.BlazingCartesiaTheVirtuous) > 0)
+                                if (Bot.HasInDeck(CardId.BlazingCartesiaTheVirtuous))
                                 {
                                     ClientCard lulu = cards.FirstOrDefault(c => c.IsOriginalCode(CardId.DespianLuluwalilith));
                                     if (lulu != null)
@@ -924,7 +892,7 @@ namespace WindBot.Game.AI.Decks
                                         return Util.CheckSelectCount(new List<ClientCard> { lulu }, cards, min, max);
                                     }
                                 }
-                                if (!Bot.MonsterZone.Any(c => c != null && c.HasType(CardType.Fusion)) && CheckRemainInDeck(CardId.SpringansKitt) > 0)
+                                if (!Bot.MonsterZone.Any(c => c != null && c.HasType(CardType.Fusion)) && Bot.HasInDeck(CardId.SpringansKitt))
                                 {
                                     ClientCard ironDragon = cards.FirstOrDefault(c => c.IsOriginalCode(CardId.SprindTheIrondashDragon));
                                     if (ironDragon != null)
@@ -1050,7 +1018,7 @@ namespace WindBot.Game.AI.Decks
                                                     return Util.CheckSelectCount(new List<ClientCard> { mercourier }, cards, min, max);
                                                 }
                                             }
-                                            if (!activatedCardIdList.Contains(CardId.DespianTragedy) && CheckRemainInDeck(CardId.AluberTheJesterOfDespia, CardId.GuidingQuemTheVirtuous) > 0)
+                                            if (!activatedCardIdList.Contains(CardId.DespianTragedy) && Bot.HasInDeck(CardId.AluberTheJesterOfDespia, CardId.GuidingQuemTheVirtuous))
                                             {
                                                 ClientCard tragedy = cardsInLoc.FirstOrDefault(c => c.IsCode(CardId.DespianTragedy));
                                                 if (tragedy != null)
@@ -1133,7 +1101,7 @@ namespace WindBot.Game.AI.Decks
                             Dictionary<int, Func<bool>> brandedFusionCheckDict = new Dictionary<int, Func<bool>>
                             {
                                 {CardId.TitanikladTheAshDragon, () => Enemy.HasInMonstersZone(CardId.KashtiraAriseHeart) },
-                                {CardId.RindbrummTheStrikingDragon,  () => CheckWhetherWillbeRemoved() && CheckRemainInDeck(CardId.TriBrigadeMercourier) > 0},
+                                {CardId.RindbrummTheStrikingDragon,  () => CheckWhetherWillbeRemoved() && Bot.HasInDeck(CardId.TriBrigadeMercourier)},
                                 {CardId.AlbionTheSanctifireDragon, () => CheckShouldNoMoreSpSummon()},
                                 {CardId.AlbionTheBrandedDragon, () => {
                                     bool checkFlag = Bot.Graveyard.Any(c => c != null && c.IsMonster() && c.HasAttribute(CardAttribute.Dark) && !c.IsCode(cannotBeFusionMaterialIdList));
@@ -1262,7 +1230,7 @@ namespace WindBot.Game.AI.Decks
                                 {
                                     // lubellion check
                                     if (discardId == CardId.TheBystialLubellion && Duel.Player == 0 && (Duel.Phase <= DuelPhase.Main1 || Duel.Phase == DuelPhase.Main2)
-                                        && CheckRemainInDeck(CardId.BystialSaronir) > 0 && !activatedCardIdList.Contains(CardId.TheBystialLubellion))
+                                        && Bot.HasInDeck(CardId.BystialSaronir) && !activatedCardIdList.Contains(CardId.TheBystialLubellion))
                                     {
                                         continue;
                                     }
@@ -1842,7 +1810,7 @@ namespace WindBot.Game.AI.Decks
                                                     return Util.CheckSelectCount(new List<ClientCard> { mercourier }, cards, min, max);
                                                 }
                                             }
-                                            if (!activatedCardIdList.Contains(CardId.DespianTragedy) && CheckRemainInDeck(CardId.AluberTheJesterOfDespia, CardId.GuidingQuemTheVirtuous) > 0)
+                                            if (!activatedCardIdList.Contains(CardId.DespianTragedy) && Bot.HasInDeck(CardId.AluberTheJesterOfDespia, CardId.GuidingQuemTheVirtuous))
                                             {
                                                 ClientCard tragedy = cardsInLoc.FirstOrDefault(c => c.IsCode(CardId.DespianTragedy));
                                                 if (tragedy != null)
@@ -1907,7 +1875,7 @@ namespace WindBot.Game.AI.Decks
                                 {CardId.BrightestBlazingBrandedKing, () => Bot.MonsterZone.Any(c => c != null && c.IsFaceup() && c.IsCode(albazFusionMonster)) },
                                 {CardId.BrandedInRed, () => Bot.Graveyard.Any(c => c != null && (c.HasSetcode(SetcodeDespain) || c.IsCode(CardId.FallenOfAlbaz))) },
                                 {CardId.BrandedRetribution, () => Bot.Graveyard.Where(c => c != null && c.IsCode(albazFusionMonster)).Count() > 1 },
-                                {CardId.BrandedFusion, () => CheckRemainInDeck(CardId.FallenOfAlbaz) > 0 },
+                                {CardId.BrandedFusion, () => Bot.HasInDeck(CardId.FallenOfAlbaz) },
                                 {CardId.BrandedBeast, () => Bot.MonsterZone.Any(c => c != null && c.IsFaceup() && c.HasSetcode(SetcodeBystial)) },
                                 {CardId.BrandedLost, () => true },
                                 {CardId.BrandedInWhite, () => true }
@@ -2583,7 +2551,7 @@ namespace WindBot.Game.AI.Decks
                 {CardId.TitanikladTheAshDragon, (card) => Util.IsTurn1OrMain2() || card.GetDefensePower() < 2500 },
                 {CardId.AlbaLenatusTheAbyssDragon, (card) => Util.IsTurn1OrMain2() || card.IsDisabled() || card.GetDefensePower() < 2500 },
                 {CardId.AlbionTheShroudedDragon, (card) => Util.IsTurn1OrMain2() || card.GetDefensePower() < 2500 },
-                {CardId.BorreloadFuriousDragon, (card) => card.IsDisabled() && CheckRemainInDeck(CardId.BrandedBeast, CardId.BrandedLost) > 0 },
+                {CardId.BorreloadFuriousDragon, (card) => card.IsDisabled() && Bot.HasInDeck(CardId.BrandedBeast, CardId.BrandedLost) },
             };
 
             foreach (KeyValuePair<int, Func<ClientCard, bool>> pair in checkDict)
@@ -2616,18 +2584,18 @@ namespace WindBot.Game.AI.Decks
         public bool AlbionTheShroudedDragonActivate()
         {
             if (CheckWhetherNegated(true, false, CardType.Monster) || CheckWhetherWillbeRemoved()) return false;
-            bool checkFlag = CheckRemainInDeck(CardId.BrandedRetribution, CardId.BrandedOpening, CardId.BrightestBlazingBrandedKing, CardId.BrandedInHighSpirits) > 0;
+            bool checkFlag = Bot.HasInDeck(CardId.BrandedRetribution, CardId.BrandedOpening, CardId.BrightestBlazingBrandedKing, CardId.BrandedInHighSpirits);
             if (Bot.HasInGraveyard(CardId.BrandedRetribution))
             {
-                checkFlag |= CheckRemainInDeck(CardId.BrandedFusion, CardId.BrandedBeast, CardId.BrandedInRed, CardId.BrandedInWhite, CardId.BrandedLost) > 0;
+                checkFlag |= Bot.HasInDeck(CardId.BrandedFusion, CardId.BrandedBeast, CardId.BrandedInRed, CardId.BrandedInWhite, CardId.BrandedLost);
             }
             if (Bot.HasInSpellZone(CardId.BrandedBeast))
             {
-                checkFlag |= CheckRemainInDeck(CardId.BrandedLost) > 0;
+                checkFlag |= Bot.HasInDeck(CardId.BrandedLost);
             }
             if (Card.Location == CardLocation.Grave)
             {
-                checkFlag |= CheckRemainInDeck(CardId.BrandedInWhite) > 0;
+                checkFlag |= Bot.HasInDeck(CardId.BrandedInWhite);
             }
             // for abyss dragon
             if (FallenOfAlbazSetCheck() && (summoned || !Bot.HasInHand(new List<int> { CardId.FallenOfAlbaz, CardId.BrandedInHighSpirits })))
@@ -2693,7 +2661,7 @@ namespace WindBot.Game.AI.Decks
                         return true;
                     }
                     if (Bot.HasInGraveyard(CardId.TheBystialLubellion) && !activatedCardIdList.Contains(CardId.TheBystialLubellion)
-                        && Duel.Player == 0 && CheckRemainInDeck(CardId.BrandedLost, CardId.BrandedBeast) > 0
+                        && Duel.Player == 0 && Bot.HasInDeck(CardId.BrandedLost, CardId.BrandedBeast)
                         && CurrentTiming == -1)
                     {
                         List<ClientCard> targetList = Enemy.Graveyard.Where(c => c != null && CheckBystialCanBanish(c)).OrderByDescending(card => card.Attack).ToList();
@@ -2753,7 +2721,7 @@ namespace WindBot.Game.AI.Decks
                 {
                     activatedCardIdList.Add(Card.Id + 1);
                     return true;
-                } else if (CheckRemainInDeck(CardId.TheBystialLubellion, CardId.BrandedRetribution, CardId.BrandedInHighSpirits, CardId.BrightestBlazingBrandedKing, CardId.BrandedOpening) > 0)
+                } else if (Bot.HasInDeck(CardId.TheBystialLubellion, CardId.BrandedRetribution, CardId.BrandedInHighSpirits, CardId.BrightestBlazingBrandedKing, CardId.BrandedOpening))
                 {
                     activatedCardIdList.Add(Card.Id + 1);
                     return true;
@@ -3024,12 +2992,12 @@ namespace WindBot.Game.AI.Decks
         {
             if (CheckWhetherNegated(true, true, CardType.Monster) || CheckWhetherWillbeRemoved()) return false;
             if (activatedCardIdList.Contains(Card.Id)) return false;
-            if (Bot.HasInGraveyard(CardId.BrandedRetribution) && CheckRemainInDeck(CardId.BrandedFusion, CardId.BrandedLost, CardId.BrandedInWhite, CardId.BrandedInRed) > 0)
+            if (Bot.HasInGraveyard(CardId.BrandedRetribution) && Bot.HasInDeck(CardId.BrandedFusion, CardId.BrandedLost, CardId.BrandedInWhite, CardId.BrandedInRed))
             {
                 summoned = true;
                 return true;
             }
-            if (Bot.HasInGraveyard(new[] { CardId.BrandedFusion, CardId.BrandedLost, CardId.BrandedBeast }) && CheckRemainInDeck(CardId.BrandedRetribution) > 0)
+            if (Bot.HasInGraveyard(new[] { CardId.BrandedFusion, CardId.BrandedLost, CardId.BrandedBeast }) && Bot.HasInDeck(CardId.BrandedRetribution))
             {
                 summoned = true;
                 return true;
@@ -3108,7 +3076,7 @@ namespace WindBot.Game.AI.Decks
         public bool BlazingCartesiaTheVirtuousSummon()
         {
             if (CheckWhetherNegated(true, true, CardType.Monster)) return false;
-            bool checkFlag = Bot.HasInHandOrInSpellZone(CardId.BrandedOpening) && !activatedCardIdList.Contains(CardId.AluberTheJesterOfDespia) && CheckRemainInDeck(CardId.AluberTheJesterOfDespia) > 0;
+            bool checkFlag = Bot.HasInHandOrInSpellZone(CardId.BrandedOpening) && !activatedCardIdList.Contains(CardId.AluberTheJesterOfDespia) && Bot.HasInDeck(CardId.AluberTheJesterOfDespia);
             checkFlag |= Bot.HasInHand(CardId.AlbionTheShroudedDragon) && !activatedCardIdList.Contains(CardId.AlbionTheShroudedDragon);
             checkFlag |= Bot.HasInHandOrHasInMonstersZone(CardId.BystialSaronir) && !activatedCardIdList.Contains(CardId.BystialSaronir + 1);
             if (Bot.HasInExtra(CardId.GranguignolTheDuskDragon))
@@ -3549,11 +3517,11 @@ namespace WindBot.Game.AI.Decks
             Dictionary<int, Func<bool>> checkDict = new Dictionary<int, Func<bool>>
             {
                 {CardId.AlbionTheBrandedDragon, () => !sendToGYThisTurn.Any(c => c.IsCode(CardId.AlbionTheBrandedDragon)) },
-                {CardId.DespianLuluwalilith, () => CheckRemainInDeck(CardId.BlazingCartesiaTheVirtuous, CardId.GuidingQuemTheVirtuous) > 0 },
-                {CardId.TitanikladTheAshDragon, () => CheckRemainInDeck(CardId.GuidingQuemTheVirtuous) > 0 },
-                {CardId.SprindTheIrondashDragon, () => CheckRemainInDeck(CardId.SpringansKitt) > 0 },
+                {CardId.DespianLuluwalilith, () => Bot.HasInDeck(CardId.BlazingCartesiaTheVirtuous, CardId.GuidingQuemTheVirtuous) },
+                {CardId.TitanikladTheAshDragon, () => Bot.HasInDeck(CardId.GuidingQuemTheVirtuous) },
+                {CardId.SprindTheIrondashDragon, () => Bot.HasInDeck(CardId.SpringansKitt) },
                 {CardId.RindbrummTheStrikingDragon, () => Bot.Graveyard.Any(c => c != null && c.IsOriginalCode(CardId.FallenOfAlbaz)) },
-                {CardId.AlbaLenatusTheAbyssDragon, () => force && CheckRemainInDeck(CardId.FusionDeployment, CardId.BrandedFusion) > 0 },
+                {CardId.AlbaLenatusTheAbyssDragon, () => force && Bot.HasInDeck(CardId.FusionDeployment, CardId.BrandedFusion) },
                 {CardId.GranguignolTheDuskDragon, () => force},
             };
 
@@ -3595,11 +3563,11 @@ namespace WindBot.Game.AI.Decks
 
         public int FusionDeploymentSpSummonTarget()
         {
-            if (CheckRemainInDeck(CardId.FallenOfAlbaz) > 0 && CheckAlbazFusion(Card) && GetProblematicEnemyMonster(0, false, false, CardType.Monster) != null)
+            if (Bot.HasInDeck(CardId.FallenOfAlbaz) && CheckAlbazFusion(Card) && GetProblematicEnemyMonster(0, false, false, CardType.Monster) != null)
             {
                 return CardId.FallenOfAlbaz;
             }
-            if (CheckRemainInDeck(CardId.BlazingCartesiaTheVirtuous) > 0 && Bot.HasInExtra(CardId.GranguignolTheDuskDragon))
+            if (Bot.HasInDeck(CardId.BlazingCartesiaTheVirtuous) && Bot.HasInExtra(CardId.GranguignolTheDuskDragon))
             {
                 if (Bot.Hand.Any(c => c.IsMonster() && c.HasAttribute(CardAttribute.Light | CardAttribute.Dark))
                     || Bot.GetMonsters().Any(c => c.IsMonster() && c.HasAttribute(CardAttribute.Light | CardAttribute.Dark) && !c.IsCode(cannotBeFusionMaterialIdList)))
@@ -3607,7 +3575,7 @@ namespace WindBot.Game.AI.Decks
                     return CardId.BlazingCartesiaTheVirtuous;
                 }
             }
-            if (CheckRemainInDeck(CardId.FallenOfAlbaz) > 0 && CheckAlbazFusion(Card))
+            if (Bot.HasInDeck(CardId.FallenOfAlbaz) && CheckAlbazFusion(Card))
             {
                 return CardId.FallenOfAlbaz;
             }
@@ -3896,7 +3864,7 @@ namespace WindBot.Game.AI.Decks
         public bool BrandedFusionActivateCheck(bool endPhaseCheck = true)
         {
             if (CheckWhetherNegated(true, true, CardType.Spell) || activatedCardIdList.Contains(CardId.BrandedFusion)) return false;
-            if (!Bot.HasInHandOrHasInMonstersZone(CardId.FallenOfAlbaz) && CheckRemainInDeck(CardId.FallenOfAlbaz) == 0) return false;
+            if (!Bot.HasInHandOrHasInMonstersZone(CardId.FallenOfAlbaz) && !Bot.HasInDeck(CardId.FallenOfAlbaz)) return false;
             if (endPhaseCheck && Duel.Phase >= DuelPhase.End) return false;
             return true;
         }
@@ -3932,7 +3900,7 @@ namespace WindBot.Game.AI.Decks
                             return cardId;
                         }
                     }
-                    else if (CheckRemainInDeck(cardId) > 0)
+                    else if (Bot.HasInDeck(cardId))
                     {
                         target = null;
                         return cardId;
@@ -3969,7 +3937,7 @@ namespace WindBot.Game.AI.Decks
                     }
                 } else
                 {
-                    if (CheckRemainInDeck(CardId.DespianTragedy) > 0)
+                    if (Bot.HasInDeck(CardId.DespianTragedy))
                     {
                         target = null;
                         return CardId.DespianTragedy;
@@ -3978,8 +3946,8 @@ namespace WindBot.Game.AI.Decks
             }
 
             // send to GY check
-            bool sendToGYFlag = CheckRemainInDeck(CardId.BrandedRetribution) > 0;
-            sendToGYFlag |= Bot.HasInGraveyard(CardId.BrandedRetribution) && CheckRemainInDeck(CardId.BrandedFusion) > 0;
+            bool sendToGYFlag = Bot.HasInDeck(CardId.BrandedRetribution);
+            sendToGYFlag |= Bot.HasInGraveyard(CardId.BrandedRetribution) && Bot.HasInDeck(CardId.BrandedFusion);
             if (sendToGYFlag)
             {
                 Dictionary<int, Func<bool>> checkDict = new Dictionary<int, Func<bool>>
@@ -4000,7 +3968,7 @@ namespace WindBot.Game.AI.Decks
                             {
                                 return cardId;
                             }
-                        } else if (CheckRemainInDeck(cardId) > 0)
+                        } else if (Bot.HasInDeck(cardId))
                         {
                             target = null;
                             return cardId;
@@ -4027,7 +3995,7 @@ namespace WindBot.Game.AI.Decks
                         }
                     } else
                     {
-                        if (CheckRemainInDeck(CardId.FallenOfAlbaz) >= albazCountCheck)
+                        if (Bot.GetRemainingCount(CardId.FallenOfAlbaz) >= albazCountCheck)
                         {
                             target = null;
                             return CardId.FallenOfAlbaz;
@@ -4143,7 +4111,7 @@ namespace WindBot.Game.AI.Decks
 
         public bool BrandedInHighSpiritsActivateCheck()
         {
-            bool lubellionCheck = Bot.HasInHand(CardId.TheBystialLubellion) && CheckRemainInDeck(CardId.BystialSaronir) > 0 && !activatedCardIdList.Contains(CardId.TheBystialLubellion)
+            bool lubellionCheck = Bot.HasInHand(CardId.TheBystialLubellion) && Bot.HasInDeck(CardId.BystialSaronir) && !activatedCardIdList.Contains(CardId.TheBystialLubellion)
                 && Duel.Player == 0 && (Duel.Phase <= DuelPhase.Main1 || Duel.Phase == DuelPhase.Main2) && !CheckWhetherWillbeRemoved();
 
             if (CheckWhetherNegated(true, true, CardType.Spell) || activatedCardIdList.Contains(CardId.BrandedInHighSpirits) || CheckWhetherWillbeRemoved()) return false;
@@ -4153,7 +4121,7 @@ namespace WindBot.Game.AI.Decks
                     && Bot.Hand.Any(c => BrandedInHighSpiritDiscardDragonCheck(c) ) },
                 {CardId.TitanikladTheAshDragon, () => !sendToGYThisTurn.Any(c => c.IsCode(CardId.TitanikladTheAshDragon)) && !lubellionCheck
                     && Bot.Hand.Any(c => BrandedInHighSpiritDiscardDragonCheck(c) )
-                    && CheckRemainInDeck(CardId.GuidingQuemTheVirtuous, CardId.FallenOfAlbaz) > 0},
+                    && Bot.HasInDeck(CardId.GuidingQuemTheVirtuous, CardId.FallenOfAlbaz)},
                 {CardId.GranguignolTheDuskDragon, () => Bot.Hand.Any(c => c.HasRace(CardRace.SpellCaster) && !(CheckWhetherCanSummon() && c.IsOriginalCode(CardId.GuidingQuemTheVirtuous))) },
                 {CardId.RindbrummTheStrikingDragon, () => Bot.Hand.Any(c => c.HasRace(CardRace.WindBeast)
                     && (!c.IsCode(CardId.TriBrigadeMercourier) || !Bot.MonsterZone.Any(c2 => c2 != null && c2.IsFaceup() && c2.IsCode(albazFusionMonster)))) }
@@ -4175,7 +4143,7 @@ namespace WindBot.Game.AI.Decks
             if (Duel.Player == 0 && (Duel.Phase <= DuelPhase.Main1 || Duel.Phase == DuelPhase.Main2))
             {
                 if (card.IsOriginalCode(CardId.AlbionTheShroudedDragon) && !activatedCardIdList.Contains(CardId.AlbionTheShroudedDragon)) return false;
-                if (card.IsOriginalCode(CardId.TheBystialLubellion) && !activatedCardIdList.Contains(CardId.TheBystialLubellion) && CheckRemainInDeck(CardId.BystialSaronir) > 0) return false;
+                if (card.IsOriginalCode(CardId.TheBystialLubellion) && !activatedCardIdList.Contains(CardId.TheBystialLubellion) && Bot.HasInDeck(CardId.BystialSaronir)) return false;
             }
 
             return true;
@@ -4189,11 +4157,11 @@ namespace WindBot.Game.AI.Decks
                 if (Bot.HasInHand(CardId.AlbionTheShroudedDragon) && !CheckWhetherWillbeRemoved() && !activatedCardIdList.Contains(CardId.AlbionTheShroudedDragon)) return false;
                 bool canCallCartesia = Bot.HasInHand(CardId.BlazingCartesiaTheVirtuous) && !summoned;
                 canCallCartesia |= !activatedCardIdList.Contains(CardId.FusionDeployment) && Bot.HasInHandOrInSpellZone(CardId.FusionDeployment)
-                    && !CheckShouldNoMoreSpSummon() && Bot.HasInExtra(CardId.GranguignolTheDuskDragon) && CheckRemainInDeck(CardId.BlazingCartesiaTheVirtuous) > 0;
+                    && !CheckShouldNoMoreSpSummon() && Bot.HasInExtra(CardId.GranguignolTheDuskDragon) && Bot.HasInDeck(CardId.BlazingCartesiaTheVirtuous);
                 if (canCallCartesia) return false;
             }
-            bool goal = CheckRemainInDeck(CardId.AluberTheJesterOfDespia) > 0 && !activatedCardIdList.Contains(CardId.AluberTheJesterOfDespia) && !enemyActivateLockBird;
-            goal |= CheckRemainInDeck(CardId.GuidingQuemTheVirtuous) > 0;
+            bool goal = Bot.HasInDeck(CardId.AluberTheJesterOfDespia) && !activatedCardIdList.Contains(CardId.AluberTheJesterOfDespia) && !enemyActivateLockBird;
+            goal |= Bot.HasInDeck(CardId.GuidingQuemTheVirtuous);
             if (goal)
             {
                 SelectSTPlace(Card, true);
@@ -4214,7 +4182,7 @@ namespace WindBot.Game.AI.Decks
                 if (alias != 0 && alias - code < 10) code = alias;
                 if (code == 0) return false;
                 if (DefaultCheckWhetherCardIdIsNegated(code)) return false;
-                if (CheckRemainInDeck(code) > 0)
+                if (Bot.HasInDeck(code))
                 {
                     if (!(Card.Location == CardLocation.SpellZone))
                     {
@@ -5042,9 +5010,9 @@ namespace WindBot.Game.AI.Decks
                         {CardId.RindbrummTheStrikingDragon,
                             () => Duel.Player == 1 && Bot.Graveyard.Any(c => c.IsOriginalCode(CardId.FallenOfAlbaz)) && Bot.Hand.Count > 0
                                 && !activatedCardIdList.Contains(CardId.FallenOfAlbaz) && !DefaultCheckWhetherCardIdIsNegated(CardId.FallenOfAlbaz)},
-                        {CardId.TitanikladTheAshDragon, () => CheckRemainInDeck(CardId.GuidingQuemTheVirtuous) > 0},
-                        {CardId.SprindTheIrondashDragon, () => CheckRemainInDeck(CardId.SpringansKitt) > 0},
-                        {CardId.AlbaLenatusTheAbyssDragon, () => CheckRemainInDeck(CardId.FusionDeployment, CardId.BrandedFusion) > 0 },
+                        {CardId.TitanikladTheAshDragon, () => Bot.HasInDeck(CardId.GuidingQuemTheVirtuous)},
+                        {CardId.SprindTheIrondashDragon, () => Bot.HasInDeck(CardId.SpringansKitt)},
+                        {CardId.AlbaLenatusTheAbyssDragon, () => Bot.HasInDeck(CardId.FusionDeployment, CardId.BrandedFusion) },
                         {CardId.LubellionTheSearingDragon, () => true },
                         {CardId.AlbionTheSanctifireDragon, () => true }
                     };
@@ -5281,8 +5249,8 @@ namespace WindBot.Game.AI.Decks
 
         public int GranguignolTheDuskDragonSendToGYTarget(IList<ClientCard> cards, out ClientCard target)
         {
-            bool needSendBranded = Bot.HasInGraveyard(CardId.BrandedRetribution) && CheckRemainInDeck(CardId.BrandedFusion) > 0;
-            if (CheckRemainInDeck(CardId.BrandedRetribution) > 0)
+            bool needSendBranded = Bot.HasInGraveyard(CardId.BrandedRetribution) && Bot.HasInDeck(CardId.BrandedFusion);
+            if (Bot.HasInDeck(CardId.BrandedRetribution))
             {
                 needSendBranded |= Bot.Graveyard.Any(c => c != null && c.HasType(CardType.Spell | CardType.Trap) && c.HasSetcode(SetcodeBranded)
                     && !(fusionToGYFlag && c.IsCode(CardId.BrightestBlazingBrandedKing, CardId.BrandedInHighSpirits)));
@@ -5295,12 +5263,12 @@ namespace WindBot.Game.AI.Decks
                 new KeyValuePair<int, Func<bool>>(CardId.AlbionTheShroudedDragon, () => !activatedCardIdList.Contains(CardId.AlbionTheShroudedDragon) && needSendBranded ),
                 new KeyValuePair<int, Func<bool>>(CardId.AlbionTheBrandedDragon, () => !activatedCardIdList.Contains(CardId.AlbionTheBrandedDragon + 1) && !sendToGYThisTurn.Any(c => c.IsCode(CardId.AlbionTheBrandedDragon)) ),
                 new KeyValuePair<int, Func<bool>>(CardId.TitanikladTheAshDragon, () => !activatedCardIdList.Contains(CardId.TitanikladTheAshDragon) && !sendToGYThisTurn.Any(c => c.IsCode(CardId.TitanikladTheAshDragon))
-                    && CheckRemainInDeck(CardId.GuidingQuemTheVirtuous, CardId.FallenOfAlbaz) > 0),
+                    && Bot.HasInDeck(CardId.GuidingQuemTheVirtuous, CardId.FallenOfAlbaz)),
                 new KeyValuePair<int, Func<bool>>(CardId.TheBystialLubellion, () => Bot.HasInMonstersZone(new[] {CardId.AlbionTheBrandedDragon, CardId.TitanikladTheAshDragon})
-                    && CheckRemainInDeck(CardId.BrandedLost, CardId.BrandedBeast) > 0 ),
+                    && Bot.HasInDeck(CardId.BrandedLost, CardId.BrandedBeast) ),
                 new KeyValuePair<int, Func<bool>>(CardId.SprindTheIrondashDragon, () => !activatedCardIdList.Contains(CardId.SprindTheIrondashDragon) && !sendToGYThisTurn.Any(c => c.IsCode(CardId.SprindTheIrondashDragon)) 
-                    && CheckRemainInDeck(CardId.SpringansKitt) > 0),
-                new KeyValuePair<int, Func<bool>>(CardId.DespianLuluwalilith, () => CheckRemainInDeck(CardId.BlazingCartesiaTheVirtuous, CardId.GuidingQuemTheVirtuous) > 0 ),
+                    && Bot.HasInDeck(CardId.SpringansKitt)),
+                new KeyValuePair<int, Func<bool>>(CardId.DespianLuluwalilith, () => Bot.HasInDeck(CardId.BlazingCartesiaTheVirtuous, CardId.GuidingQuemTheVirtuous) ),
                 new KeyValuePair<int, Func<bool>>(CardId.AlbionTheShroudedDragon, () => true ),
             };
 
@@ -5308,7 +5276,7 @@ namespace WindBot.Game.AI.Decks
             {
                 if (cards == null)
                 {
-                    if ((CheckRemainInDeck(pair.Key) > 0 || Bot.HasInExtra(pair.Key)) && pair.Value())
+                    if ((Bot.HasInDeck(pair.Key) || Bot.HasInExtra(pair.Key)) && pair.Value())
                     {
                         target = null;
                         return pair.Key;
@@ -5657,7 +5625,7 @@ namespace WindBot.Game.AI.Decks
             if (Card.Location == CardLocation.Grave)
             {
                 if (CheckWhetherNegated(true, false, CardType.Monster)) return false;
-                if (CheckRemainInDeck(CardId.GuidingQuemTheVirtuous, CardId.BlazingCartesiaTheVirtuous) > 0)
+                if (Bot.HasInDeck(CardId.GuidingQuemTheVirtuous, CardId.BlazingCartesiaTheVirtuous))
                 {
                     activatedCardIdList.Add(Card.Id + 1);
                     return true;
@@ -5735,13 +5703,13 @@ namespace WindBot.Game.AI.Decks
                 case CardId.BrandedInHighSpirits:
                     {
                         bool checkFlag = (Bot.HasInMonstersZone(CardId.GuidingQuemTheVirtuous)
-                            || (CheckRemainInDeck(CardId.GuidingQuemTheVirtuous) > 0 && sendToGYThisTurn.Any(c => c.IsCode(CardId.TitanikladTheAshDragon))));
+                            || (Bot.HasInDeck(CardId.GuidingQuemTheVirtuous) && sendToGYThisTurn.Any(c => c.IsCode(CardId.TitanikladTheAshDragon))));
                         if (!checkFlag) return false;
                     }
                     break;
                 case CardId.BrandedOpening:
                     {
-                        bool checkFlag = CheckRemainInDeck(CardId.AluberTheJesterOfDespia, CardId.GuidingQuemTheVirtuous) > 0;
+                        bool checkFlag = Bot.HasInDeck(CardId.AluberTheJesterOfDespia, CardId.GuidingQuemTheVirtuous);
                         if (!checkFlag) return false;
                     }
                     break;

--- a/Game/AI/Decks/AltergeistExecutor.cs
+++ b/Game/AI/Decks/AltergeistExecutor.cs
@@ -227,11 +227,13 @@ namespace WindBot.Game.AI.Decks
 
         public bool has_altergeist_left()
         {
-            return (Bot.GetRemainingCount(CardId.Marionetter, 3) > 0
-                || Bot.GetRemainingCount(CardId.Multifaker, 2) > 0
-                || Bot.GetRemainingCount(CardId.Meluseek,3) > 0
-                || Bot.GetRemainingCount(CardId.Silquitous,2) > 0
-                || Bot.GetRemainingCount(CardId.Kunquery,1) > 0);
+            return Bot.HasInDeck(
+                CardId.Marionetter,
+                CardId.Multifaker,
+                CardId.Meluseek,
+                CardId.Silquitous,
+                CardId.Kunquery
+            );
         }
 
         public bool EvenlyMatched_Repos()
@@ -615,7 +617,7 @@ namespace WindBot.Game.AI.Decks
             }
             else if (Enemy.HasInSpellZone(CardId.Anti_Spell, true) || Bot.HasInSpellZone(CardId.Anti_Spell, true))
             {
-                if (Card.IsSpell() && (!Card.IsCode(CardId.OneForOne) || Bot.GetRemainingCount(CardId.Meluseek,3) > 0))
+                if (Card.IsSpell() && (!Card.IsCode(CardId.OneForOne) || Bot.HasInDeck(CardId.Meluseek)))
                 {
                     AI.SelectPlace(SelectSTPlace());
                     return true;
@@ -1125,7 +1127,7 @@ namespace WindBot.Game.AI.Decks
         {
             if (ActivateDescription == -1)
             {
-                if (!Bot.HasInHandOrInSpellZone(CardId.Protocol) && Bot.GetRemainingCount(CardId.Protocol,2) > 0)
+                if (!Bot.HasInHandOrInSpellZone(CardId.Protocol) && Bot.HasInDeck(CardId.Protocol))
                 {
                     AI.SelectCard(CardId.Protocol, CardId.Manifestation);
                     AI.SelectPlace(SelectSetPlace());
@@ -1179,7 +1181,7 @@ namespace WindBot.Game.AI.Decks
                 {
                     if (!Meluseek_searched && !Bot.HasInMonstersZone(CardId.Meluseek) && Bot.HasInGraveyard(CardId.Meluseek))
                     {
-                        if (Multifaker_candeckss() && Bot.HasInGraveyard(CardId.Multifaker) && Bot.GetRemainingCount(CardId.Meluseek,3) > 0)
+                        if (Multifaker_candeckss() && Bot.HasInGraveyard(CardId.Multifaker) && Bot.HasInDeck(CardId.Meluseek))
                         {
                             next_card = CardId.Multifaker;
                         } else
@@ -1280,32 +1282,32 @@ namespace WindBot.Game.AI.Decks
                 return true;
             }
             if (ActivateDescription == Util.GetStringId(CardId.Hexstia,0)) return false;
-            if (Enemy.HasInSpellZone(82732705) && Bot.GetRemainingCount(CardId.Protocol,3) > 0 && !Bot.HasInHandOrInSpellZone(CardId.Protocol))
+            if (Enemy.HasInSpellZone(82732705) && Bot.HasInDeck(CardId.Protocol) && !Bot.HasInHandOrInSpellZone(CardId.Protocol))
             {
                 AI.SelectCard(CardId.Protocol);
                 return true;
             }
-            if (Duel.Player == 0 && !summoned && Bot.GetRemainingCount(CardId.Marionetter, 3) > 0)
+            if (Duel.Player == 0 && !summoned && Bot.HasInDeck(CardId.Marionetter))
             {
                 AI.SelectCard(CardId.Marionetter);
                 return true;
             }
-            if (!Bot.HasInHandOrHasInMonstersZone(CardId.Multifaker) && Bot.GetRemainingCount(CardId.Multifaker, 2) > 0 && Multifaker_can_ss())
+            if (!Bot.HasInHandOrHasInMonstersZone(CardId.Multifaker) && Bot.HasInDeck(CardId.Multifaker) && Multifaker_can_ss())
             {
                 AI.SelectCard(CardId.Multifaker);
                 return true;
             }
-            if (!Bot.HasInHand(CardId.Marionetter) && Bot.GetRemainingCount(CardId.Marionetter,3) > 0)
+            if (!Bot.HasInHand(CardId.Marionetter) && Bot.HasInDeck(CardId.Marionetter))
             {
                 AI.SelectCard(CardId.Marionetter);
                 return true;
             }
-            if (!Bot.HasInHandOrInSpellZone(CardId.Manifestation) && Bot.GetRemainingCount(CardId.Manifestation,2) > 0)
+            if (!Bot.HasInHandOrInSpellZone(CardId.Manifestation) && Bot.HasInDeck(CardId.Manifestation))
             {
                 AI.SelectCard(CardId.Manifestation);
                 return true;
             }
-            if (!Bot.HasInHandOrInSpellZone(CardId.Protocol) && Bot.GetRemainingCount(CardId.Protocol, 2) > 0)
+            if (!Bot.HasInHandOrInSpellZone(CardId.Protocol) && Bot.HasInDeck(CardId.Protocol))
             {
                 AI.SelectCard(CardId.Protocol);
                 return true;
@@ -1357,7 +1359,7 @@ namespace WindBot.Game.AI.Decks
             {
                 if (Duel.Player == 1)
                 {
-                    if (!Bot.HasInHandOrHasInMonstersZone(CardId.Multifaker) && Bot.GetRemainingCount(CardId.Multifaker, 2) > 0 && Multifaker_candeckss() && Multifaker_can_ss())
+                    if (!Bot.HasInHandOrHasInMonstersZone(CardId.Multifaker) && Bot.HasInDeck(CardId.Multifaker) && Multifaker_candeckss() && Multifaker_can_ss())
                     {
                         foreach(ClientCard set_card in Bot.GetSpells())
                         {
@@ -1368,7 +1370,7 @@ namespace WindBot.Game.AI.Decks
                             }
                         }
                     }
-                    if (Bot.GetRemainingCount(CardId.Marionetter, 3) > 0)
+                    if (Bot.HasInDeck(CardId.Marionetter))
                     {
                         AI.SelectCard(CardId.Marionetter);
                         return true;
@@ -1376,17 +1378,17 @@ namespace WindBot.Game.AI.Decks
                 }
                 else
                 {
-                    if (!summoned && !Bot.HasInHand(CardId.Marionetter) && Bot.GetRemainingCount(CardId.Marionetter, 3) > 0)
+                    if (!summoned && !Bot.HasInHand(CardId.Marionetter) && Bot.HasInDeck(CardId.Marionetter))
                     {
                         AI.SelectCard(CardId.Marionetter);
                         return true;
                     }
-                    if (!Bot.HasInHandOrHasInMonstersZone(CardId.Multifaker) && Bot.GetRemainingCount(CardId.Multifaker, 2) > 0 && Multifaker_can_ss())
+                    if (!Bot.HasInHandOrHasInMonstersZone(CardId.Multifaker) && Bot.HasInDeck(CardId.Multifaker) && Multifaker_can_ss())
                     {
                         AI.SelectCard(CardId.Multifaker);
                         return true;
                     }
-                    if (!Bot.HasInHand(CardId.Marionetter) && Bot.GetRemainingCount(CardId.Marionetter,3) > 0)
+                    if (!Bot.HasInHand(CardId.Marionetter) && Bot.HasInDeck(CardId.Marionetter))
                     {
                         AI.SelectCard(CardId.Marionetter);
                         return true;
@@ -1416,26 +1418,26 @@ namespace WindBot.Game.AI.Decks
             if (Card.Location != CardLocation.Hand)
             {
                 ClientCard Silquitous_target = GetProblematicEnemyCard_Alter(true);
-                if (Duel.Player == 1 && Duel.Phase >= DuelPhase.Main2 && GetProblematicEnemyCard_Alter(true) == null && Bot.GetRemainingCount(CardId.Meluseek,3) > 0)
+                if (Duel.Player == 1 && Duel.Phase >= DuelPhase.Main2 && GetProblematicEnemyCard_Alter(true) == null && Bot.HasInDeck(CardId.Meluseek))
                 {
                     AI.SelectCard(CardId.Meluseek);
                     Multifaker_ssfromdeck = true;
                     return true;
                 }
-                else if (!Silquitous_bounced && !Bot.HasInMonstersZone(CardId.Silquitous) && Bot.GetRemainingCount(CardId.Silquitous,2) > 0
+                else if (!Silquitous_bounced && !Bot.HasInMonstersZone(CardId.Silquitous) && Bot.HasInDeck(CardId.Silquitous)
                     && !(Duel.Player == 0 && Silquitous_target==null))
                 {
                     AI.SelectCard(CardId.Silquitous);
                     Multifaker_ssfromdeck = true;
                     return true;
                 }
-                else if (!Meluseek_searched && !Bot.HasInMonstersZone(CardId.Meluseek) && Bot.GetRemainingCount(CardId.Meluseek, 3) > 0)
+                else if (!Meluseek_searched && !Bot.HasInMonstersZone(CardId.Meluseek) && Bot.HasInDeck(CardId.Meluseek))
                 {
                     AI.SelectCard(CardId.Meluseek);
                     Multifaker_ssfromdeck = true;
                     return true;
                 }
-                else if (Bot.GetRemainingCount(CardId.Kunquery,1) > 0)
+                else if (Bot.HasInDeck(CardId.Kunquery))
                 {
                     AI.SelectCard(CardId.Kunquery);
                     Multifaker_ssfromdeck = true;
@@ -1635,7 +1637,7 @@ namespace WindBot.Game.AI.Decks
 
                 if (Multifaker_candeckss() && Bot.HasInGraveyard(CardId.Multifaker) && has_altergeist_left())
                 {
-                    if (Bot.HasInHand(CardId.Multifaker) && Bot.HasInGraveyard(CardId.Silquitous) && Bot.GetRemainingCount(CardId.Silquitous,2) == 0)
+                    if (Bot.HasInHand(CardId.Multifaker) && Bot.HasInGraveyard(CardId.Silquitous) && !Bot.HasInDeck(CardId.Silquitous))
                     {
                         AI.SelectCard(CardId.Silquitous);
                         return true;
@@ -1961,7 +1963,7 @@ namespace WindBot.Game.AI.Decks
                         CardId.Silquitous
                         );
                 }
-                else if (!summoned && !Bot.HasInGraveyard(CardId.Meluseek) && Bot.GetRemainingCount(CardId.Meluseek,3) > 0 && !Bot.HasInHand(CardId.Meluseek)
+                else if (!summoned && !Bot.HasInGraveyard(CardId.Meluseek) && Bot.HasInDeck(CardId.Meluseek) && !Bot.HasInHand(CardId.Meluseek)
                     && (enemy_best != null || enemy_target != null) )
                 {
                     if (Bot.HasInHand(CardId.Silquitous))
@@ -2000,7 +2002,7 @@ namespace WindBot.Game.AI.Decks
                         return true;
                     }
                 }
-                else if (!summoned && !Bot.HasInHand(CardId.Marionetter) && Bot.GetRemainingCount(CardId.Marionetter,3) > 0)
+                else if (!summoned && !Bot.HasInHand(CardId.Marionetter) && Bot.HasInDeck(CardId.Marionetter))
                 {
                     if (Bot.HasInHand(CardId.Silquitous))
                     {
@@ -2391,7 +2393,7 @@ namespace WindBot.Game.AI.Decks
                 }
                 else if (card.IsCode(CardId.Hexstia) && targets.Count < 2 && card.IsFaceup())
                 {
-                    if ((!Hexstia_searched || !Hexstia_selected) && !summoned && !Bot.HasInHand(CardId.Marionetter) && Bot.GetRemainingCount(CardId.Marionetter, 3) > 0)
+                    if ((!Hexstia_searched || !Hexstia_selected) && !summoned && !Bot.HasInHand(CardId.Marionetter) && Bot.HasInDeck(CardId.Marionetter))
                     {
                         Hexstia_selected = true;
                         targets.Add(card);
@@ -2414,7 +2416,7 @@ namespace WindBot.Game.AI.Decks
                     if (GetTotalATK(targets) >= 1500 && (summoned || (!Meluseek_selected && !Hexstia_selected))) return false;
                 }
                 bool can_have_Multifaker = (Bot.HasInHand(CardId.Multifaker) 
-                    || (Bot.GetRemainingCount(CardId.Multifaker, 2) > 0 
+                    || (Bot.HasInDeck(CardId.Multifaker)
                         && ( (Meluseek_selected && !Meluseek_searched) 
                             || (Hexstia_selected && !Hexstia_searched) )));
                 if (can_have_Multifaker && Multifaker_can_ss()) altergeist_count++;
@@ -2785,7 +2787,7 @@ namespace WindBot.Game.AI.Decks
         public override IList<ClientCard> OnSelectCard(IList<ClientCard> cards, int min, int max, int hint, bool cancelable)
         {
             if (max == 1 && cards[0].Location == CardLocation.Deck 
-                && Util.GetLastChainCard() != null && Util.GetLastChainCard().IsCode(23002292) && Bot.GetRemainingCount(CardId.WakingtheDragon,1) > 0)
+                && Util.GetLastChainCard() != null && Util.GetLastChainCard().IsCode(23002292) && Bot.HasInDeck(CardId.WakingtheDragon))
             {
                 IList<ClientCard> result = new List<ClientCard>();
                 foreach (ClientCard card in cards)

--- a/Game/AI/Decks/ApophisExecutor.cs
+++ b/Game/AI/Decks/ApophisExecutor.cs
@@ -1097,7 +1097,7 @@ namespace WindBot.Game.AI.Decks
                             List<ClientCard> faceDownMonsters = botMonsters.Where(card => card.IsFacedown()).ToList();
                             banishList.AddRange(faceDownMonsters);
                             List<ClientCard> dumpMainMonsterList = botMonsters.Where(card => !banishList.Contains(card)
-                                && Bot.HasInDeck(card.Id)).ToList();
+                                && Bot.HasInDeck(card.GetNonAltartCode())).ToList();
                             dumpMainMonsterList.Sort(CardContainer.CompareCardAttack);
                             banishList.AddRange(dumpMainMonsterList);
                             // spells

--- a/Game/AI/Decks/ApophisExecutor.cs
+++ b/Game/AI/Decks/ApophisExecutor.cs
@@ -111,13 +111,6 @@ namespace WindBot.Game.AI.Decks
             _CardId.MysticalSpaceTyphoon, 63166095, 9726840, 5380979, 92714517, 6153210, 32548318, 30271097, 45171524, 81560239
         };
 
-        Dictionary<int, List<int>> DeckCountTable = new Dictionary<int, List<int>>{
-            {3, new List<int> { CardId.TheManWithTheMark, CardId.PrimiteLordlyLode, CardId.TreasuresOfTheKings, CardId.DominusSpark,
-                                _CardId.InfiniteImpermanence, CardId.SongsOfTheDominators, CardId.DominusPurge, CardId.ApophisTheSerpent}},
-            {2, new List<int> { CardId.AnubisTheLastJudge, CardId.PrimiteDragonEtherBeryl, _CardId.PotOfExtravagance, CardId.DominusImpulse,
-                                CardId.ApophisTheSwampDeity, CardId.SolemnReport}},
-            {1, new List<int> { CardId.LabradoriteDragon, CardId.Terraforming, CardId.PrimiteDrillbeam, CardId.VerdictOfAnubis }}
-        };
         const int hintTimingMainEnd = 0x4;
         const int hintToHand = 0x200000;
 
@@ -155,30 +148,7 @@ namespace WindBot.Game.AI.Decks
             return true;
         }
 
-        /// <summary>
-        /// Check remain cards in deck
-        /// </summary>
-        /// <param name="id">Card's ID</param>
-        public int CheckRemainInDeck(int id)
-        {
-            for (int count = 1; count < 4; ++count)
-            {
-                if (DeckCountTable[count].Contains(id)) {
-                    return Bot.GetRemainingCount(id, count);
-                }
-            }
-            return 0;
-        }
 
-        public int CheckRemainInDeck(params int[] ids)
-        {
-            int sum = 0;
-            foreach (int id in ids)
-            {
-                sum += CheckRemainInDeck(id);
-            }
-            return sum;
-        }
 
         /// <summary>
         /// Check whether'll be negated
@@ -1127,7 +1097,7 @@ namespace WindBot.Game.AI.Decks
                             List<ClientCard> faceDownMonsters = botMonsters.Where(card => card.IsFacedown()).ToList();
                             banishList.AddRange(faceDownMonsters);
                             List<ClientCard> dumpMainMonsterList = botMonsters.Where(card => !banishList.Contains(card)
-                                && CheckRemainInDeck(card.Id) > 0).ToList();
+                                && Bot.HasInDeck(card.Id)).ToList();
                             dumpMainMonsterList.Sort(CardContainer.CompareCardAttack);
                             banishList.AddRange(dumpMainMonsterList);
                             // spells
@@ -1680,8 +1650,8 @@ namespace WindBot.Game.AI.Decks
                 // summon to search?
                 if (!CheckWhetherNegated(true, true) && CheckWhetherCanActivateMonsterEffect(CardAttribute.Earth))
                 {
-                    summonFlag |= !activatedCardIdList.Contains(CardId.PrimiteLordlyLode) && !Bot.HasInHandOrInSpellZone(CardId.PrimiteLordlyLode) && CheckRemainInDeck(CardId.PrimiteLordlyLode) > 0;
-                    summonFlag |= CheckRemainInDeck(CardId.PrimiteDrillbeam) > 0;
+                    summonFlag |= !activatedCardIdList.Contains(CardId.PrimiteLordlyLode) && !Bot.HasInHandOrInSpellZone(CardId.PrimiteLordlyLode) && Bot.HasInDeck(CardId.PrimiteLordlyLode);
+                    summonFlag |= Bot.HasInDeck(CardId.PrimiteDrillbeam);
                 }
 
                 // summon to recycle beam
@@ -1699,8 +1669,8 @@ namespace WindBot.Game.AI.Decks
             }
 
             bool canSummonMan = Bot.HasInHand(CardId.TheManWithTheMark);
-            canSummonMan |= Bot.HasInHand(CardId.AnubisTheLastJudge) && DefaultCheckWhetherBotCanSearch() && CheckRemainInDeck(CardId.TheManWithTheMark) > 0 && !activatedCardIdList.Contains(CardId.AnubisTheLastJudge);
-            if (Bot.HasInHandOrInSpellZone(CardId.TreasuresOfTheKings) && !activatedCardIdList.Contains(CardId.TreasuresOfTheKings + 1) && DefaultCheckWhetherBotCanSearch() && CheckRemainInDeck(CardId.TheManWithTheMark) > 0)
+            canSummonMan |= Bot.HasInHand(CardId.AnubisTheLastJudge) && DefaultCheckWhetherBotCanSearch() && Bot.HasInDeck(CardId.TheManWithTheMark) && !activatedCardIdList.Contains(CardId.AnubisTheLastJudge);
+            if (Bot.HasInHandOrInSpellZone(CardId.TreasuresOfTheKings) && !activatedCardIdList.Contains(CardId.TreasuresOfTheKings + 1) && DefaultCheckWhetherBotCanSearch() && Bot.HasInDeck(CardId.TheManWithTheMark))
             {
                 canSummonMan |= Bot.Graveyard.Any(c => c.IsTrap());
                 int facedownCardCount = Bot.GetSpells().Count(c => c.IsFacedown());
@@ -1853,10 +1823,10 @@ namespace WindBot.Game.AI.Decks
             if (Bot.HasInHandOrHasInMonstersZone(CardId.PrimiteDragonEtherBeryl) && DefaultCheckWhetherBotCanSearch())
             {
                 // for search drillbeam
-                activateFlag |= CheckRemainInDeck(CardId.PrimiteDrillbeam) > 0;
+                activateFlag |= Bot.HasInDeck(CardId.PrimiteDrillbeam);
                 activateFlag |= summonCount <= 0 && Card.Location == CardLocation.SpellZone && Card.IsFacedown();
             }
-            if (summonCount > 0 && !Bot.HasInHand(CardId.PrimiteDragonEtherBeryl) && CheckRemainInDeck(CardId.PrimiteDragonEtherBeryl) > 0 && DefaultCheckWhetherBotCanSearch())
+            if (summonCount > 0 && !Bot.HasInHand(CardId.PrimiteDragonEtherBeryl) && Bot.HasInDeck(CardId.PrimiteDragonEtherBeryl) && DefaultCheckWhetherBotCanSearch())
             {
                 // for search ether beryl
                 activateFlag |= Bot.HasInGraveyard(CardId.PrimiteDrillbeam);
@@ -1873,7 +1843,7 @@ namespace WindBot.Game.AI.Decks
                 {
                     loc = CardLocation.Hand;
                 }
-                else if (CheckRemainInDeck(CardId.LabradoriteDragon) > 0)
+                else if (Bot.HasInDeck(CardId.LabradoriteDragon))
                 {
                     loc = CardLocation.Deck;
                 }
@@ -1920,7 +1890,7 @@ namespace WindBot.Game.AI.Decks
             {
                 loc = CardLocation.Hand;
             }
-            else if (CheckRemainInDeck(CardId.LabradoriteDragon) > 0)
+            else if (Bot.HasInDeck(CardId.LabradoriteDragon))
             {
                 loc = CardLocation.Deck;
             }
@@ -1950,7 +1920,7 @@ namespace WindBot.Game.AI.Decks
             if (Bot.GetSpellCountWithoutField() == 5)
             {
                 // for search
-                if (!DefaultCheckWhetherBotCanSearch() || CheckRemainInDeck(CardId.TheManWithTheMark, CardId.AnubisTheLastJudge) == 0)
+                if (!DefaultCheckWhetherBotCanSearch() || !Bot.HasInDeck(CardId.TheManWithTheMark, CardId.AnubisTheLastJudge))
                 {
                     activateFlag = false;
                 }
@@ -1972,7 +1942,7 @@ namespace WindBot.Game.AI.Decks
             else
             {
                 // for set
-                if (CheckRemainInDeck(CardId.ApophisTheSerpent, CardId.ApophisTheSwampDeity) > 0)
+                if (Bot.HasInDeck(CardId.ApophisTheSerpent, CardId.ApophisTheSwampDeity))
                     activateFlag = true;
             }
 
@@ -2770,7 +2740,7 @@ namespace WindBot.Game.AI.Decks
             {
                 return false;
             }
-            int remainApophisCount = CheckRemainInDeck(CardId.ApophisTheSwampDeity);
+            int remainApophisCount = Bot.GetRemainingCount(CardId.ApophisTheSwampDeity);
             if (remainApophisCount == 0)
             {
                 return false;
@@ -2898,7 +2868,7 @@ namespace WindBot.Game.AI.Decks
                 switch (Card.Id)
                 {
                     case CardId.Terraforming:
-                        setFlag |= CheckRemainInDeck(CardId.TreasuresOfTheKings) > 0 && DefaultCheckWhetherBotCanSearch();
+                        setFlag |= Bot.HasInDeck(CardId.TreasuresOfTheKings) && DefaultCheckWhetherBotCanSearch();
                         break;
                     case CardId.PrimiteLordlyLode:
                         setFlag |= PrimiteLordlyLodeActivateCheck() && !canSetSpells.Any(c => c.IsCode(CardId.PrimiteLordlyLode));
@@ -2924,7 +2894,7 @@ namespace WindBot.Game.AI.Decks
                         setFlag |= Bot.GetMonsters().Any(c => c != card && c.HasType(CardType.Continuous) && c.HasType(CardType.Trap));
                         break;
                     case CardId.ApophisTheSerpent:
-                        setFlag |= CheckRemainInDeck(CardId.ApophisTheSwampDeity) > 0;
+                        setFlag |= Bot.HasInDeck(CardId.ApophisTheSwampDeity);
                         setFlag |= Bot.HasInHandOrInSpellZone(CardId.ApophisTheSwampDeity);
                         break;
                     default:

--- a/Game/AI/Decks/ApophisExecutor.cs
+++ b/Game/AI/Decks/ApophisExecutor.cs
@@ -2740,7 +2740,7 @@ namespace WindBot.Game.AI.Decks
             {
                 return false;
             }
-            int remainApophisCount = Bot.GetRemainingCount(CardId.ApophisTheSwampDeity);
+            int remainApophisCount = Bot.GetCardCountInDeck(CardId.ApophisTheSwampDeity);
             if (remainApophisCount == 0)
             {
                 return false;

--- a/Game/AI/Decks/ArchfiendExecutor.cs
+++ b/Game/AI/Decks/ArchfiendExecutor.cs
@@ -989,7 +989,7 @@ namespace WindBot.Game.AI.Decks
                                 List<ClientCard> faceDownMonsters = botMonsters.Where(card => card.IsFacedown()).ToList();
                                 banishList.AddRange(faceDownMonsters);
                                 List<ClientCard> dumpMainMonsterList = botMonsters.Where(card => !banishList.Contains(card)
-                                    && Bot.HasInDeck(card.Id)).ToList();
+                                    && Bot.HasInDeck(card.GetNonAltartCode())).ToList();
                                 dumpMainMonsterList.Sort(CardContainer.CompareCardAttack);
                                 banishList.AddRange(dumpMainMonsterList);
                                 // spells

--- a/Game/AI/Decks/ArchfiendExecutor.cs
+++ b/Game/AI/Decks/ArchfiendExecutor.cs
@@ -63,43 +63,6 @@ namespace WindBot.Game.AI.Decks
         List<int> notToNegateIdList = new List<int> { 58699500, 20343502, 19403423 };
         List<int> notToDestroySpellTrap = new List<int> { 50005218, 6767771 };
 
-        Dictionary<int, List<int>> DeckCountTable = new Dictionary<int, List<int>>
-        {
-            { 3, new List<int>
-                {
-                    CardId.RegenArch,
-                    CardId.Origin,
-                    CardId.Royal,
-                    CardId.Highness,
-                    CardId.PMBeryl,
-                    CardId.Makourai,
-                    CardId.Strategy,
-                    CardId.Usurpation,
-                    CardId.PMLL,
-                }
-            },
-
-            { 2, new List<int>
-                {
-                    _CardId.AshBlossom,
-                    CardId.SMSkull,
-                    _CardId.PotOfExtravagance,
-                    _CardId.InfiniteImpermanence
-                }
-            },
-
-            { 1, new List<int>
-                {
-                    _CardId.MaxxC,
-                    //_CardId.CalledByTheGrave,
-                    CardId.PMDR,
-                    CardId.Simul,
-                    CardId.RegenSage,
-                    CardId.Playtime
-
-                }
-            },
-        };
 
         private static readonly int[] PreferDiscard =
         {
@@ -195,17 +158,6 @@ namespace WindBot.Game.AI.Decks
             return base.OnSelectYesNo(desc);
         }
 
-        public int CheckRemainInDeck(int id)
-        {
-            for (int count = 1; count < 4; ++count)
-            {
-                if (DeckCountTable[count].Contains(id))
-                {
-                    return Bot.GetRemainingCount(id, count);
-                }
-            }
-            return 0;
-        }
         public bool CheckAtAdvantage()
         {
             if (GetProblematicEnemyMonster() == null && Bot.GetMonsters().Any(card => card.IsFaceup()))
@@ -246,7 +198,7 @@ namespace WindBot.Game.AI.Decks
                 if (alias != 0 && alias - code < 10) code = alias;
                 if (code == 0) return false;
                 if (DefaultCheckWhetherCardIdIsNegated(code)) return false;
-                if (CheckRemainInDeck(code) > 0)
+                if (Bot.HasInDeck(code))
                 {
                     if (!(Card.Location == CardLocation.SpellZone))
                     {
@@ -913,7 +865,7 @@ namespace WindBot.Game.AI.Decks
 
                                     foreach (int targetId in targetIdList)
                                     {
-                                        if (CheckRemainInDeck(targetId) <= 0) continue;
+                                        if (!Bot.HasInDeck(targetId)) continue;
 
                                         ClientCard target = cards.FirstOrDefault(c => c.IsCode(targetId));
                                         if (target != null)
@@ -1037,7 +989,7 @@ namespace WindBot.Game.AI.Decks
                                 List<ClientCard> faceDownMonsters = botMonsters.Where(card => card.IsFacedown()).ToList();
                                 banishList.AddRange(faceDownMonsters);
                                 List<ClientCard> dumpMainMonsterList = botMonsters.Where(card => !banishList.Contains(card)
-                                    && CheckRemainInDeck(card.Id) > 0).ToList();
+                                    && Bot.HasInDeck(card.Id)).ToList();
                                 dumpMainMonsterList.Sort(CardContainer.CompareCardAttack);
                                 banishList.AddRange(dumpMainMonsterList);
                                 // spells
@@ -1196,10 +1148,10 @@ namespace WindBot.Game.AI.Decks
             if (Bot.HasInHandOrHasInMonstersZone(CardId.PMBeryl) && DefaultCheckWhetherBotCanSearch())
             {
                 // for search drillbeam
-                activateFlag |= CheckRemainInDeck(CardId.PMDR) > 0;
+                activateFlag |= Bot.HasInDeck(CardId.PMDR);
                 activateFlag |= summonCount <= 0 && Card.Location == CardLocation.SpellZone && Card.IsFacedown();
             }
-            if (summonCount > 0 && !Bot.HasInHand(CardId.PMBeryl) && CheckRemainInDeck(CardId.PMBeryl) > 0 && DefaultCheckWhetherBotCanSearch())
+            if (summonCount > 0 && !Bot.HasInHand(CardId.PMBeryl) && Bot.HasInDeck(CardId.PMBeryl) && DefaultCheckWhetherBotCanSearch())
             {
                 // for search ether beryl
                 activateFlag |= Bot.HasInGraveyard(CardId.PMDR);
@@ -1208,7 +1160,7 @@ namespace WindBot.Game.AI.Decks
             if (Bot.HasInHandOrHasInMonstersZone(CardId.SMSkull) && DefaultCheckWhetherBotCanSearch())
             {
                 // for search drillbeam
-                activateFlag |= CheckRemainInDeck(CardId.PMDR) > 0;
+                activateFlag |= Bot.HasInDeck(CardId.PMDR);
                 activateFlag |= summonCount <= 0 && Card.Location == CardLocation.SpellZone && Card.IsFacedown();
             }
             if (!Bot.HasInSpellZone(CardId.PMLL, true, true))
@@ -1218,7 +1170,7 @@ namespace WindBot.Game.AI.Decks
 
                 // for special summon
                 bool hasSMSkull = Bot.HasInHand(CardId.SMSkull)
-                                 || CheckRemainInDeck(CardId.SMSkull) > 0
+                                 || Bot.HasInDeck(CardId.SMSkull)
                                  || Bot.HasInGraveyard(CardId.SMSkull);
 
                 if (!hasSMSkull)
@@ -1262,7 +1214,7 @@ namespace WindBot.Game.AI.Decks
             {
                 loc = CardLocation.Hand;
             }
-            else if (CheckRemainInDeck(CardId.SMSkull) > 0)
+            else if (Bot.HasInDeck(CardId.SMSkull))
             {
                 loc = CardLocation.Deck;
             }
@@ -1401,8 +1353,8 @@ namespace WindBot.Game.AI.Decks
                 // summon to search?
                 if (!CheckWhetherNegated(true, true))
                 {
-                    summonFlag |= !activatedCardIdList.Contains(CardId.PMLL) && !Bot.HasInHandOrInSpellZone(CardId.PMLL) && CheckRemainInDeck(CardId.PMLL) > 0;
-                    summonFlag |= CheckRemainInDeck(CardId.PMDR) > 0;
+                    summonFlag |= !activatedCardIdList.Contains(CardId.PMLL) && !Bot.HasInHandOrInSpellZone(CardId.PMLL) && Bot.HasInDeck(CardId.PMLL);
+                    summonFlag |= Bot.HasInDeck(CardId.PMDR);
                 }
 
                 // summon to recycle beam
@@ -1446,7 +1398,7 @@ namespace WindBot.Game.AI.Decks
         }
         private bool ShouldPMLLSearchDrillbeam()
         {
-            if (CheckRemainInDeck(CardId.PMDR) <= 0) return false;
+            if (!Bot.HasInDeck(CardId.PMDR)) return false;
 
             if (Bot.HasInHand(CardId.PMDR) || Bot.HasInSpellZone(CardId.PMDR))
                 return false;
@@ -1503,7 +1455,7 @@ namespace WindBot.Game.AI.Decks
         }
         private bool CanPlaytimeSummon(int id)
         {
-            return Bot.HasInHand(id) || CheckRemainInDeck(id) > 0;
+            return Bot.HasInHand(id) || Bot.HasInDeck(id);
         }
         private bool Usurpation()
         {
@@ -1568,7 +1520,7 @@ namespace WindBot.Game.AI.Decks
 
         private bool CanSetArchfiendTrap(int id)
         {
-            return Bot.HasInGraveyard(id) || CheckRemainInDeck(id) > 0;
+            return Bot.HasInGraveyard(id) || Bot.HasInDeck(id);
         }
 
         private bool StrategyActivate()
@@ -1663,7 +1615,7 @@ namespace WindBot.Game.AI.Decks
             foreach (int id in priority)
             {
                 if (id == exceptId) continue;
-                if (CheckRemainInDeck(id) <= 0) continue;
+                if (!Bot.HasInDeck(id)) continue;
                 if (HasUnusedInHand(id)) continue;
 
                 return id;
@@ -1688,7 +1640,7 @@ namespace WindBot.Game.AI.Decks
                 CardId.Royal
             }
             .Where(id => id != CardId.Highness)
-            .Where(id => CheckRemainInDeck(id) > 0)
+            .Where(id => Bot.HasInDeck(id))
             .OrderBy(id => GetHighnessSearchPriority(id))
             .Take(2)
             .ToList();
@@ -1786,7 +1738,7 @@ namespace WindBot.Game.AI.Decks
 
             if (Card.Location == CardLocation.MonsterZone)
             {
-                if (Bot.HasInHand(CardId.SMSkull) || CheckRemainInDeck(CardId.SMSkull) > 0 || Bot.HasInGraveyard(CardId.SMSkull))
+                if (Bot.HasInHand(CardId.SMSkull) || Bot.HasInDeck(CardId.SMSkull) || Bot.HasInGraveyard(CardId.SMSkull))
                 {
                     AI.SelectCard(CardId.SMSkull);
                     return true;

--- a/Game/AI/Decks/BE2025Executor.cs
+++ b/Game/AI/Decks/BE2025Executor.cs
@@ -70,58 +70,6 @@ namespace WindBot.Game.AI.Decks
 
         }
 
-        Dictionary<int, List<int>> DeckCountTable = new Dictionary<int, List<int>>
-        {
-            { 3, new List<int>
-                {
-                    CardId.BlueEyesWhiteDragon,
-                    CardId.DeepEyes,
-                    CardId.MulcharmyFuwalos,
-                    CardId.MaidenOfWhite,
-                    CardId.SageWithEyesOfBlue,
-                    CardId.Wishes,
-                    CardId.Gogo,
-                    CardId.BlueEyesSpiritDragon
-                }
-            },
-
-            { 2, new List<int>
-                {
-                    _CardId.AshBlossom,
-                    CardId.EffectVeiler,
-                    _CardId.InfiniteImpermanence,
-                    CardId.BlueEyesUltimateSpiritDragon,
-                    CardId.SpiritWithEyesOfBlue
-                }
-            },
-
-            { 1, new List<int>
-                {
-                    CardId.BlueEyesJetDragon,
-                    _CardId.MaxxC,
-                    CardId.KaibamanTheLegend,
-                    _CardId.LockBird,
-                    CardId.BlueEyesChaosMAXDragon,
-                    CardId.MausoleumOfWhite,
-                    CardId.RoarOfTheBlueEyedDragons,
-                    CardId.UltimateFusion,
-                    CardId.SynchroRumble,
-                    _CardId.CalledByTheGrave,
-                    _CardId.CrossoutDesignator,
-                    CardId.MajestyOfTheWhiteDragons,
-                    CardId.TrueLight,
-                    CardId.CosmicBlazar,
-                    CardId.BlueEyesUltimateDragon,
-                    CardId.DragonMasterMagia,
-                    CardId.NeoBlueEyesUltimateDragon,
-                    CardId.StardustSifrDivineDragon,
-                    CardId.CrimsonDragon,
-                    CardId.ChaosAngel,
-                    CardId.BaronneDeFleur,
-                    CardId.LightstromDragon
-                }
-            },
-        };
 
         private static readonly int[] PreferDiscard =
         {
@@ -300,17 +248,6 @@ namespace WindBot.Game.AI.Decks
             }
             base.OnSpSummoned();
         }
-        public int CheckRemainInDeck(int id)
-        {
-            for (int count = 1; count < 4; ++count)
-            {
-                if (DeckCountTable[count].Contains(id))
-                {
-                    return Bot.GetRemainingCount(id, count);
-                }
-            }
-            return 0;
-        }
         public bool CheckAtAdvantage()
         {
             if (GetProblematicEnemyMonster() == null && Bot.GetMonsters().Any(card => card.IsFaceup()))
@@ -351,7 +288,7 @@ namespace WindBot.Game.AI.Decks
                 if (alias != 0 && alias - code < 10) code = alias;
                 if (code == 0) return false;
                 if (DefaultCheckWhetherCardIdIsNegated(code)) return false;
-                if (CheckRemainInDeck(code) > 0)
+                if (Bot.HasInDeck(code))
                 {
                     if (!(Card.Location == CardLocation.SpellZone))
                     {
@@ -916,25 +853,25 @@ namespace WindBot.Game.AI.Decks
             if (Card.Location != CardLocation.Hand) return false;
             if (useDeepEyes) return false;
 
-            if (!Bot.HasInHand(CardId.MaidenOfWhite) && !useMaidenSearch && CheckRemainInDeck(CardId.MaidenOfWhite) > 0)
+            if (!Bot.HasInHand(CardId.MaidenOfWhite) && !useMaidenSearch && Bot.HasInDeck(CardId.MaidenOfWhite))
             {
                 AI.SelectCard(CardId.MaidenOfWhite);
                 useDeepEyes = true;
                 return true;
             }
-            else if (!Bot.HasInHand(CardId.SageWithEyesOfBlue) && !nsSage && CheckRemainInDeck(CardId.SageWithEyesOfBlue) > 0)
+            else if (!Bot.HasInHand(CardId.SageWithEyesOfBlue) && !nsSage && Bot.HasInDeck(CardId.SageWithEyesOfBlue))
             {
                 AI.SelectCard(CardId.SageWithEyesOfBlue);
                 useDeepEyes = true;
                 return true;
             }
-            else if (!Bot.HasInHand(CardId.KaibamanTheLegend) && normalSummon < 2 && nsSage && CheckRemainInDeck(CardId.KaibamanTheLegend) > 0)
+            else if (!Bot.HasInHand(CardId.KaibamanTheLegend) && normalSummon < 2 && nsSage && Bot.HasInDeck(CardId.KaibamanTheLegend))
             {
                 AI.SelectCard(CardId.KaibamanTheLegend);
                 useDeepEyes = true;
                 return true;
             }
-            else if (CheckRemainInDeck(CardId.EffectVeiler) > 0)
+            else if (Bot.HasInDeck(CardId.EffectVeiler))
             {
                 AI.SelectCard(CardId.EffectVeiler);
                 useDeepEyes = true;
@@ -982,7 +919,7 @@ namespace WindBot.Game.AI.Decks
                 nsSage = true;
                 return true;
             }
-            else if (Duel.Turn > 2 && Duel.Player == 0 && (CheckRemainInDeck(CardId.KaibamanTheLegend) > 0 || CheckRemainInDeck(CardId.EffectVeiler) > 0))
+            else if (Duel.Turn > 2 && Duel.Player == 0 && (Bot.HasInDeck(CardId.KaibamanTheLegend) || Bot.HasInDeck(CardId.EffectVeiler)))
             {
                 normalSummon += 1;
                 nsSage = true;
@@ -1007,24 +944,24 @@ namespace WindBot.Game.AI.Decks
             if (Card.Location == CardLocation.MonsterZone) { return true; }
             else if (Card.Location == CardLocation.Grave)
             {
-                if (!Bot.HasInSpellZone(CardId.TrueLight) && !Bot.HasInGraveyard(CardId.MaidenOfWhite) && useDeepEyes == false && CheckRemainInDeck(CardId.DeepEyes) > 0)
+                if (!Bot.HasInSpellZone(CardId.TrueLight) && !Bot.HasInGraveyard(CardId.MaidenOfWhite) && useDeepEyes == false && Bot.HasInDeck(CardId.DeepEyes))
                 {
                     AI.SelectCard(CardId.DeepEyes);
                     return true;
                 }
                 else if (!Bot.HasInHand(CardId.BlueEyesChaosMAXDragon) && !Bot.HasInGraveyard(CardId.BlueEyesChaosMAXDragon) &&
-                         CheckRemainInDeck(CardId.BlueEyesChaosMAXDragon) > 0 && !Bot.HasInMonstersZone(CardId.DragonMasterMagia) &&
+                         Bot.HasInDeck(CardId.BlueEyesChaosMAXDragon) && !Bot.HasInMonstersZone(CardId.DragonMasterMagia) &&
                          Bot.HasInGraveyard(CardId.BlueEyesUltimateDragon))
                 {
                     AI.SelectCard(CardId.BlueEyesChaosMAXDragon);
                     return true;
                 }
-                if (useDeepEyes == false && CheckRemainInDeck(CardId.DeepEyes) > 0)
+                if (useDeepEyes == false && Bot.HasInDeck(CardId.DeepEyes))
                 {
                     AI.SelectCard(CardId.DeepEyes);
                     return true;
                 }
-                else if (!Bot.HasInHand(CardId.BlueEyesJetDragon) && !Bot.HasInGraveyard(CardId.BlueEyesJetDragon) && CheckRemainInDeck(CardId.BlueEyesJetDragon) > 0)
+                else if (!Bot.HasInHand(CardId.BlueEyesJetDragon) && !Bot.HasInGraveyard(CardId.BlueEyesJetDragon) && Bot.HasInDeck(CardId.BlueEyesJetDragon))
                 {
                     AI.SelectCard(CardId.BlueEyesJetDragon);
                     return true;
@@ -1042,17 +979,17 @@ namespace WindBot.Game.AI.Decks
         private bool SageWithEyesOfBlueEffect()
         {
             if (Card.Location == CardLocation.Hand) return false;
-            if (!useMaidenSearch && CheckRemainInDeck(CardId.MaidenOfWhite) > 0)
+            if (!useMaidenSearch && Bot.HasInDeck(CardId.MaidenOfWhite))
             {
                 Logger.DebugWriteLine("Sage > Maiden");
                 AI.SelectCard(CardId.MaidenOfWhite);
             }
-            else if (normalSummon < 2 && CheckRemainInDeck(CardId.KaibamanTheLegend) > 0)
+            else if (normalSummon < 2 && Bot.HasInDeck(CardId.KaibamanTheLegend))
             {
                 Logger.DebugWriteLine("Sage > Kaiba");
                 AI.SelectCard(CardId.KaibamanTheLegend);
             }
-            else if (CheckRemainInDeck(CardId.EffectVeiler) > 0)
+            else if (Bot.HasInDeck(CardId.EffectVeiler))
             {
                 Logger.DebugWriteLine("Sage > Veiler");
                 AI.SelectCard(CardId.EffectVeiler);
@@ -1241,7 +1178,7 @@ namespace WindBot.Game.AI.Decks
             bool maidenInGY = Bot.Graveyard.Any(c => c.Id == CardId.MaidenOfWhite);
             bool bewdInHandOrGY = Bot.HasInHand(new[] { CardId.BlueEyesWhiteDragon }) || Bot.Graveyard.Any(c => c.Id == CardId.BlueEyesWhiteDragon);
 
-            if (!Bot.HasInHand(CardId.Wishes) && !useWishes && Duel.Player == 0 && CheckRemainInDeck(CardId.Wishes) > 0)
+            if (!Bot.HasInHand(CardId.Wishes) && !useWishes && Duel.Player == 0 && Bot.HasInDeck(CardId.Wishes))
             {
                 Logger.DebugWriteLine("TrueLight Search Wishes");
                 AI.SelectOption(1);
@@ -1249,7 +1186,7 @@ namespace WindBot.Game.AI.Decks
                 AI.SelectCard(CardId.Wishes);
                 return true;
             }
-            if (useWishes && needBE && Duel.Player == 0 && CheckRemainInDeck(CardId.RoarOfTheBlueEyedDragons) > 0)
+            if (useWishes && needBE && Duel.Player == 0 && Bot.HasInDeck(CardId.RoarOfTheBlueEyedDragons))
             {
                 Logger.DebugWriteLine("TrueLight Search Roar");
                 AI.SelectOption(1);
@@ -1264,7 +1201,7 @@ namespace WindBot.Game.AI.Decks
                 AI.SelectOption(0);
                 return true;
             }
-            else if (Bot.HasInGraveyard(CardId.BlueEyesWhiteDragon) && CheckRemainInDeck(CardId.MajestyOfTheWhiteDragons) > 0 &&
+            else if (Bot.HasInGraveyard(CardId.BlueEyesWhiteDragon) && Bot.HasInDeck(CardId.MajestyOfTheWhiteDragons) &&
                      Bot.GetMonsterCount() >= 2 && Bot.HasInGraveyard(CardId.SpiritWithEyesOfBlue))
             {
                 Logger.DebugWriteLine("TrueLight Search Majesty");
@@ -1301,16 +1238,16 @@ namespace WindBot.Game.AI.Decks
                 }
                 //if not then use system default
                 int st = 0;
-                if ((CheckRemainInDeck(CardId.UltimateFusion) > 0) && Bot.HasInSpellZone(CardId.TrueLight)) st = CardId.UltimateFusion;
-                else if (CheckRemainInDeck(CardId.RoarOfTheBlueEyedDragons) > 0) st = CardId.RoarOfTheBlueEyedDragons;
-                else if (CheckRemainInDeck(CardId.MajestyOfTheWhiteDragons) > 0) st = CardId.MajestyOfTheWhiteDragons;
+                if (Bot.HasInDeck(CardId.UltimateFusion) && Bot.HasInSpellZone(CardId.TrueLight)) st = CardId.UltimateFusion;
+                else if (Bot.HasInDeck(CardId.RoarOfTheBlueEyedDragons)) st = CardId.RoarOfTheBlueEyedDragons;
+                else if (Bot.HasInDeck(CardId.MajestyOfTheWhiteDragons)) st = CardId.MajestyOfTheWhiteDragons;
                 if (st == 0) return false;
                 AI.SelectNextCard(st); //2 Select S/T
                 int tuner = 0;
-                if (CheckRemainInDeck(CardId.SageWithEyesOfBlue) > 0 && !nsSage && !Bot.HasInHand(CardId.SageWithEyesOfBlue)) tuner = CardId.SageWithEyesOfBlue;
-                else if (CheckRemainInDeck(CardId.MaidenOfWhite) > 0 && !useMaidenSearch && !Bot.HasInHand(CardId.MaidenOfWhite)) tuner = CardId.MaidenOfWhite;
-                else if (CheckRemainInDeck(CardId.KaibamanTheLegend) > 0 && normalSummon < 2) tuner = CardId.KaibamanTheLegend;
-                else if (CheckRemainInDeck(CardId.EffectVeiler) > 0) tuner = CardId.EffectVeiler;
+                if (Bot.HasInDeck(CardId.SageWithEyesOfBlue) && !nsSage && !Bot.HasInHand(CardId.SageWithEyesOfBlue)) tuner = CardId.SageWithEyesOfBlue;
+                else if (Bot.HasInDeck(CardId.MaidenOfWhite) && !useMaidenSearch && !Bot.HasInHand(CardId.MaidenOfWhite)) tuner = CardId.MaidenOfWhite;
+                else if (Bot.HasInDeck(CardId.KaibamanTheLegend) && normalSummon < 2) tuner = CardId.KaibamanTheLegend;
+                else if (Bot.HasInDeck(CardId.EffectVeiler)) tuner = CardId.EffectVeiler;
                 if (tuner == 0) return false;
                 AI.SelectNextCard(tuner);//3 Select Tuner
                 SelectSTPlace(null, true);
@@ -1357,7 +1294,7 @@ namespace WindBot.Game.AI.Decks
             if (ActivateDescription == -1)
             {
                 Logger.DebugWriteLine("Link1 on Summon");
-                if (CheckRemainInDeck(CardId.MausoleumOfWhite) <= 0)
+                if (!Bot.HasInDeck(CardId.MausoleumOfWhite))
                     return false;
                 AI.SelectOption(0);
                 return true;
@@ -1405,7 +1342,7 @@ namespace WindBot.Game.AI.Decks
             if (Bot.GetMonsterCount() >= 5) return false;
             if (Card.Location == CardLocation.Grave) return false;
             if (Bot.HasInGraveyard(CardId.MaidenOfWhite) && SSMaiden == false &&
-                CheckRemainInDeck(CardId.BlueEyesWhiteDragon) > 0 && !Bot.HasInMonstersZone(CardId.SpiritWithEyesOfBlue))
+                Bot.HasInDeck(CardId.BlueEyesWhiteDragon) && !Bot.HasInMonstersZone(CardId.SpiritWithEyesOfBlue))
             {
                 AI.SelectCard(CardId.BlueEyesWhiteDragon);
                 SelectSTPlace(null, true);
@@ -1446,7 +1383,7 @@ namespace WindBot.Game.AI.Decks
         }
         private void AddGogoPick(List<int> picks, int cardId, int want = 1)
         {
-            int remain = CheckRemainInDeck(cardId);
+            int remain = Bot.GetRemainingCount(cardId);
             int already = picks.Count(x => x == cardId);
             int canAdd = Math.Max(0, Math.Min(want, remain - already));
 

--- a/Game/AI/Decks/BE2025Executor.cs
+++ b/Game/AI/Decks/BE2025Executor.cs
@@ -1383,7 +1383,7 @@ namespace WindBot.Game.AI.Decks
         }
         private void AddGogoPick(List<int> picks, int cardId, int want = 1)
         {
-            int remain = Bot.GetRemainingCount(cardId);
+            int remain = Bot.GetCardCountInDeck(cardId);
             int already = picks.Count(x => x == cardId);
             int canAdd = Math.Max(0, Math.Min(want, remain - already));
 

--- a/Game/AI/Decks/BlueEyesMaxDragonExecutor.cs
+++ b/Game/AI/Decks/BlueEyesMaxDragonExecutor.cs
@@ -193,13 +193,13 @@ namespace WindBot.Game.AI.Decks
         private bool TheMelodyOfAwakeningDragoneff()
         {
             Count_check();
-            if(TheMelody_count>=2 && Bot.GetRemainingCount(CardId.BlueEyesChaosMaxDragon,3)>0)
+            if(TheMelody_count>=2 && Bot.HasInDeck(CardId.BlueEyesChaosMaxDragon))
             {
                 AI.SelectCard(CardId.TheMelodyOfAwakeningDragon);
                 AI.SelectNextCard(CardId.BlueEyesChaosMaxDragon, CardId.BlueEyesChaosMaxDragon, CardId.BlueEyesAlternativeWhiteDragon);
                 return true;
             }
-            if(Bot.HasInHand(CardId.BlueEyesWhiteDragon) && Bot.GetRemainingCount(CardId.BlueEyesChaosMaxDragon, 3) > 0)
+            if(Bot.HasInHand(CardId.BlueEyesWhiteDragon) && Bot.HasInDeck(CardId.BlueEyesChaosMaxDragon))
             {
                 AI.SelectCard(CardId.BlueEyesWhiteDragon);
                 AI.SelectNextCard(CardId.BlueEyesChaosMaxDragon, CardId.BlueEyesChaosMaxDragon, CardId.BlueEyesAlternativeWhiteDragon);
@@ -210,7 +210,7 @@ namespace WindBot.Game.AI.Decks
         private bool TheMelodyOfAwakeningDragoneffsecond()
         {
             Count_check();
-            if (RitualArtCanUse() && Bot.GetRemainingCount(CardId.BlueEyesChaosMaxDragon, 3) > 0 &&
+            if (RitualArtCanUse() && Bot.HasInDeck(CardId.BlueEyesChaosMaxDragon) &&
                 !Bot.HasInHand(CardId.BlueEyesChaosMaxDragon) && Bot.Hand.Count>=3)
             {
                 if(RitualArt_count>=2)
@@ -234,19 +234,19 @@ namespace WindBot.Game.AI.Decks
         private bool TenTousandHandseff()
         {
             Count_check();
-            if(Talismandra_count>=2 && Bot.GetRemainingCount(CardId.BlueEyesChaosMaxDragon,3)>0)
+            if(Talismandra_count>=2 && Bot.HasInDeck(CardId.BlueEyesChaosMaxDragon))
             {
                 AI.SelectCard(CardId.BlueEyesChaosMaxDragon);
                 return true;
             }
             if(Candoll_count>=2 || MaxDragon_count >= 2)
             {
-                if(RitualArtCanUse() && Bot.GetRemainingCount(CardId.AdvancedRitualArt,3)>0)
+                if(RitualArtCanUse() && Bot.HasInDeck(CardId.AdvancedRitualArt))
                 {
                     AI.SelectCard(CardId.AdvancedRitualArt);
                     return true;
                 }
-                if(ChaosFormCanUse() && Bot.GetRemainingCount(CardId.ChaosForm,1)>0)
+                if(ChaosFormCanUse() && Bot.HasInDeck(CardId.ChaosForm))
                 {
                     AI.SelectCard(CardId.ChaosForm);
                     return true;
@@ -261,12 +261,12 @@ namespace WindBot.Game.AI.Decks
             {
                 if (MaxDragon_count >= 1)
                 {
-                    if (RitualArtCanUse() && Bot.GetRemainingCount(CardId.AdvancedRitualArt, 3) > 0)
+                    if (RitualArtCanUse() && Bot.HasInDeck(CardId.AdvancedRitualArt))
                     {
                         AI.SelectCard(CardId.AdvancedRitualArt);
                         return true;
                     }
-                    if (ChaosFormCanUse() && Bot.GetRemainingCount(CardId.ChaosForm, 1) > 0)
+                    if (ChaosFormCanUse() && Bot.HasInDeck(CardId.ChaosForm))
                     {
                         AI.SelectCard(CardId.ChaosForm);
                         return true;
@@ -280,12 +280,12 @@ namespace WindBot.Game.AI.Decks
             }
             if (ChaosForm_count >= 1)
             {
-                if (RitualArtCanUse() && Bot.GetRemainingCount(CardId.AdvancedRitualArt, 3) > 0)
+                if (RitualArtCanUse() && Bot.HasInDeck(CardId.AdvancedRitualArt))
                 {
                     AI.SelectCard(CardId.AdvancedRitualArt);
                     return true;
                 }
-                if (ChaosFormCanUse() && Bot.GetRemainingCount(CardId.ChaosForm, 1) > 0)
+                if (ChaosFormCanUse() && Bot.HasInDeck(CardId.ChaosForm))
                 {
                     AI.SelectCard(CardId.ChaosForm);
                     return true;
@@ -298,22 +298,22 @@ namespace WindBot.Game.AI.Decks
             }
             if(MaxDragon_count>=1)
             {
-                if (RitualArtCanUse() && Bot.GetRemainingCount(CardId.AdvancedRitualArt, 3) > 0)
+                if (RitualArtCanUse() && Bot.HasInDeck(CardId.AdvancedRitualArt))
                 {
                     AI.SelectCard(CardId.AdvancedRitualArt);
                     return true;
                 }
-                if (ChaosFormCanUse() && Bot.GetRemainingCount(CardId.ChaosForm, 1) > 0)
+                if (ChaosFormCanUse() && Bot.HasInDeck(CardId.ChaosForm))
                 {
                     AI.SelectCard(CardId.ChaosForm);
                     return true;
                 }
             }            
-            if (RitualArtCanUse() && Bot.GetRemainingCount(CardId.AdvancedRitualArt, 3) > 0)
+            if (RitualArtCanUse() && Bot.HasInDeck(CardId.AdvancedRitualArt))
             {
                 AI.SelectCard(CardId.AdvancedRitualArt);                
             }
-            if (ChaosFormCanUse() && Bot.GetRemainingCount(CardId.ChaosForm, 1) > 0)
+            if (ChaosFormCanUse() && Bot.HasInDeck(CardId.ChaosForm))
             {
                 AI.SelectCard(CardId.ChaosForm);                
             }
@@ -322,7 +322,7 @@ namespace WindBot.Game.AI.Decks
 
         private bool RitualArtCanUse()
         {
-            return Bot.GetRemainingCount(CardId.BlueEyesWhiteDragon,2)>0;
+            return Bot.HasInDeck(CardId.BlueEyesWhiteDragon);
         }
 
         private bool ChaosFormCanUse()

--- a/Game/AI/Decks/BraveExecutor.cs
+++ b/Game/AI/Decks/BraveExecutor.cs
@@ -362,7 +362,7 @@ namespace WindBot.Game.AI.Decks
 
         private bool CrossoutDesignatorCheck(ClientCard LastChainCard, int id, int count)
         {
-            if (LastChainCard.IsCode(id) && Bot.GetRemainingCount(id, count) > 0)
+            if (LastChainCard.IsCode(id) && Bot.HasInDeck(id))
             {
                 AI.SelectAnnounceID(id);
                 return true;
@@ -482,7 +482,7 @@ namespace WindBot.Game.AI.Decks
             else
             {
                 // search rider or aquamancer
-                if (Bot.GetRemainingCount(CardId.WanderingGryphonRider, 1) == 0 || Bot.GetHandCount() == 0 || !Bot.HasInMonstersZone(CardId.BraveToken))
+                if (!Bot.HasInDeck(CardId.WanderingGryphonRider) || Bot.GetHandCount() == 0 || !Bot.HasInMonstersZone(CardId.BraveToken))
                 {
                     AI.SelectCard(CardId.AquamancerOfTheSanctuary);
                     if (Bot.HasInHandOrInMonstersZoneOrInGraveyard(CardId.AquamancerOfTheSanctuary))
@@ -764,10 +764,10 @@ namespace WindBot.Game.AI.Decks
 
         private bool PhoenixNotAvail()
         {
-            return Bot.LifePoints <= 2000 || Bot.GetRemainingCount(CardId.FusionDestiny, 3) == 0 || Bot.HasInHand(CardId.FusionDestiny)
+            return Bot.LifePoints <= 2000 || !Bot.HasInDeck(CardId.FusionDestiny) || Bot.HasInHand(CardId.FusionDestiny)
                 || !Bot.HasInExtra(CardId.PredaplantVerteAnaconda) || !Bot.HasInExtra(CardId.DestinyHeroDestroyPhoenixEnforcer)
-                || (Bot.GetRemainingCount(CardId.DestinyHeroCelestial, 1) == 0 && !Bot.HasInHand(CardId.DestinyHeroCelestial))
-                || (Bot.GetRemainingCount(CardId.DestinyHeroDasher, 1) == 0 && !Bot.HasInHand(CardId.DestinyHeroDasher));
+                || (!Bot.HasInDeck(CardId.DestinyHeroCelestial) && !Bot.HasInHand(CardId.DestinyHeroCelestial))
+                || (!Bot.HasInDeck(CardId.DestinyHeroDasher) && !Bot.HasInHand(CardId.DestinyHeroDasher));
         }
 
         private bool PredaplantVerteAnacondaSummon()

--- a/Game/AI/Decks/DarkMagicianExecutor.cs
+++ b/Game/AI/Decks/DarkMagicianExecutor.cs
@@ -1002,7 +1002,7 @@ namespace WindBot.Game.AI.Decks
                 return true;
             }
 
-            if ((Bot.GetRemainingCount(CardId.DarkMagician) >= 2 || Bot.HasInGraveyard(CardId.DarkMagician)) &&
+            if ((Bot.GetCardCountInDeck(CardId.DarkMagician) >= 2 || Bot.HasInGraveyard(CardId.DarkMagician)) &&
                 Bot.HasInSpellZone(CardId.MagicianNavigation) &&
                 (Bot.HasInMonstersZone(CardId.DarkMagician) || Bot.HasInMonstersZone(CardId.ApprenticeLllusionMagician)) &&
                 Duel.Player == 1 && !Bot.HasInHand(CardId.DarkMagician))
@@ -1283,7 +1283,7 @@ namespace WindBot.Game.AI.Decks
                 //AI.SelectPlace(Zones.z2, 2);
                 AI.SelectCard(spell);
                 if (Bot.HasInHandOrInSpellZone(CardId.EternalSoul) && Bot.HasInHandOrInSpellZone(CardId.DarkMagicalCircle))
-                    if (Bot.GetRemainingCount(CardId.DarkMagician) >= 2 && !Bot.HasInHandOrInSpellZoneOrInGraveyard(CardId.LllusionMagic))
+                    if (Bot.GetCardCountInDeck(CardId.DarkMagician) >= 2 && !Bot.HasInHandOrInSpellZoneOrInGraveyard(CardId.LllusionMagic))
                     {
                         AI.SelectNextCard(CardId.LllusionMagic);
                         return true;
@@ -1342,7 +1342,7 @@ namespace WindBot.Game.AI.Decks
             if (Card.Location == CardLocation.MonsterZone)
             {
                 if (Bot.HasInHandOrInSpellZone(CardId.EternalSoul) && Bot.HasInHandOrInSpellZone(CardId.DarkMagicalCircle))
-                    if (Bot.GetRemainingCount(CardId.DarkMagician) >= 2 && Bot.HasInDeck(CardId.LllusionMagic))
+                    if (Bot.GetCardCountInDeck(CardId.DarkMagician) >= 2 && Bot.HasInDeck(CardId.LllusionMagic))
                     {
                         AI.SelectCard(CardId.LllusionMagic);
                         return true;

--- a/Game/AI/Decks/DarkMagicianExecutor.cs
+++ b/Game/AI/Decks/DarkMagicianExecutor.cs
@@ -337,7 +337,7 @@ namespace WindBot.Game.AI.Decks
             if (maxxc_used) return false;
             if (WindwitchGlassBelleff_used) return false;
             //AI.SelectPlace(Zones.z2, 1);
-            if (Bot.GetRemainingCount(CardId.WindwitchGlassBell, 2) >= 1)
+            if (Bot.HasInDeck(CardId.WindwitchGlassBell))
                 AI.SelectCard(CardId.WindwitchGlassBell);
             else if (Bot.HasInHand(CardId.WindwitchGlassBell))
                 AI.SelectCard(CardId.WindwitchSnowBell);
@@ -1002,7 +1002,7 @@ namespace WindBot.Game.AI.Decks
                 return true;
             }
 
-            if ((Bot.GetRemainingCount(CardId.DarkMagician, 3) > 1 || Bot.HasInGraveyard(CardId.DarkMagician)) &&
+            if ((Bot.GetRemainingCount(CardId.DarkMagician) >= 2 || Bot.HasInGraveyard(CardId.DarkMagician)) &&
                 Bot.HasInSpellZone(CardId.MagicianNavigation) &&
                 (Bot.HasInMonstersZone(CardId.DarkMagician) || Bot.HasInMonstersZone(CardId.ApprenticeLllusionMagician)) &&
                 Duel.Player == 1 && !Bot.HasInHand(CardId.DarkMagician))
@@ -1152,7 +1152,7 @@ namespace WindBot.Game.AI.Decks
             //AI.SelectPlace(Zones.z2, 1);
             if (Bot.HasInHand(CardId.DarkMagician) && !Bot.HasInSpellZone(CardId.MagicianNavigation))
             {
-                if (Bot.GetRemainingCount(CardId.DarkMagician, 3) > 0)
+                if (Bot.HasInDeck(CardId.DarkMagician))
                 {
                     AI.SelectCard(CardId.DarkMagician);
                     AI.SelectPosition(CardPosition.FaceUpAttack);
@@ -1283,7 +1283,7 @@ namespace WindBot.Game.AI.Decks
                 //AI.SelectPlace(Zones.z2, 2);
                 AI.SelectCard(spell);
                 if (Bot.HasInHandOrInSpellZone(CardId.EternalSoul) && Bot.HasInHandOrInSpellZone(CardId.DarkMagicalCircle))
-                    if (Bot.GetRemainingCount(CardId.DarkMagician, 3) >= 2 && !Bot.HasInHandOrInSpellZoneOrInGraveyard(CardId.LllusionMagic))
+                    if (Bot.GetRemainingCount(CardId.DarkMagician) >= 2 && !Bot.HasInHandOrInSpellZoneOrInGraveyard(CardId.LllusionMagic))
                     {
                         AI.SelectNextCard(CardId.LllusionMagic);
                         return true;
@@ -1305,7 +1305,7 @@ namespace WindBot.Game.AI.Decks
                 if (Bot.HasInHandOrInSpellZone(CardId.MagicianNavigation) &&
                     !Bot.HasInHand(CardId.DarkMagician) &&
                     !Bot.HasInHandOrInSpellZone(CardId.EternalSoul) &&
-                    Bot.GetRemainingCount(CardId.LllusionMagic, 1) > 0)
+                    Bot.HasInDeck(CardId.LllusionMagic))
                 {
                     AI.SelectNextCard(CardId.LllusionMagic);
                     return true;
@@ -1342,7 +1342,7 @@ namespace WindBot.Game.AI.Decks
             if (Card.Location == CardLocation.MonsterZone)
             {
                 if (Bot.HasInHandOrInSpellZone(CardId.EternalSoul) && Bot.HasInHandOrInSpellZone(CardId.DarkMagicalCircle))
-                    if (Bot.GetRemainingCount(CardId.DarkMagician, 3) >= 2 && Bot.GetRemainingCount(CardId.LllusionMagic, 1) > 0)
+                    if (Bot.GetRemainingCount(CardId.DarkMagician) >= 2 && Bot.HasInDeck(CardId.LllusionMagic))
                     {
                         AI.SelectCard(CardId.LllusionMagic);
                         return true;
@@ -1350,7 +1350,7 @@ namespace WindBot.Game.AI.Decks
 
                 if (Bot.HasInHand(CardId.ApprenticeLllusionMagician) &&
                   !Bot.HasInHandOrInSpellZone(CardId.MagicianNavigation) &&
-                  Bot.GetRemainingCount(CardId.MagicianNavigation, 3) > 0)
+                  Bot.HasInDeck(CardId.MagicianNavigation))
                 {
                     AI.SelectCard(CardId.MagicianNavigation);
                     return true;
@@ -1358,7 +1358,7 @@ namespace WindBot.Game.AI.Decks
 
                 if (Bot.HasInHandOrInSpellZone(CardId.EternalSoul) &&
                     !Bot.HasInHandOrInMonstersZoneOrInGraveyard(CardId.DarkMagician) &&
-                    Bot.GetRemainingCount(CardId.LllusionMagic, 1) > 0)
+                    Bot.HasInDeck(CardId.LllusionMagic))
                 {
                     AI.SelectCard(CardId.LllusionMagic);
                     return true;
@@ -1367,7 +1367,7 @@ namespace WindBot.Game.AI.Decks
                 if (Bot.HasInHandOrInSpellZone(CardId.MagicianNavigation) &&
                     !Bot.HasInHand(CardId.DarkMagician) &&
                     !Bot.HasInHandOrInSpellZone(CardId.EternalSoul) &&
-                    Bot.GetRemainingCount(CardId.LllusionMagic, 1) > 0)
+                    Bot.HasInDeck(CardId.LllusionMagic))
                 {
                     AI.SelectCard(CardId.LllusionMagic);
                     return true;
@@ -1375,14 +1375,14 @@ namespace WindBot.Game.AI.Decks
                 if (!Bot.HasInHandOrInSpellZone(CardId.EternalSoul) &&
                     Bot.HasInHandOrInSpellZone(CardId.DarkMagicalCircle) &&
                     Bot.HasInHandOrInSpellZone(CardId.MagicianNavigation) &&
-                    Bot.GetRemainingCount(CardId.EternalSoul, 3) > 0)
+                    Bot.HasInDeck(CardId.EternalSoul))
                 {
                     AI.SelectCard(CardId.EternalSoul);
                     return true;
                 }
                 if ((Bot.HasInHandOrInSpellZone(CardId.EternalSoul) || Bot.HasInHandOrInSpellZone(CardId.MagicianNavigation)) &&
                     !Bot.HasInHandOrInSpellZone(CardId.DarkMagicalCircle) &&
-                    Bot.GetRemainingCount(CardId.DarkMagicalCircle, 3) > 0)
+                    Bot.HasInDeck(CardId.DarkMagicalCircle))
                 {
                     AI.SelectCard(CardId.DarkMagicalCircle);
                     return true;
@@ -1392,7 +1392,7 @@ namespace WindBot.Game.AI.Decks
                 {
                     if (Bot.HasInHand(CardId.DarkMagician) &&
                         !Bot.HasInGraveyard(CardId.MagicianNavigation) &&
-                        Bot.GetRemainingCount(CardId.MagicianNavigation, 3) > 0
+                        Bot.HasInDeck(CardId.MagicianNavigation)
                         )
                         AI.SelectCard(CardId.MagicianNavigation);
                     else if (!Bot.HasInHandOrInSpellZone(CardId.DarkMagicalCircle))

--- a/Game/AI/Decks/DogmatikaExecutor.cs
+++ b/Game/AI/Decks/DogmatikaExecutor.cs
@@ -134,13 +134,6 @@ namespace WindBot.Game.AI.Decks
         const int hintTimingMainEnd = 0x4;
         const int hintDamageStep = 0x2000;
 
-        Dictionary<int, List<int>> DeckCountTable = new Dictionary<int, List<int>>{
-            {3, new List<int> { CardId.DogmatikaEcclesia, _CardId.AshBlossom, _CardId.MaxxC, CardId.KnightmareCorruptorIblee, CardId.NadirServant,
-                                CardId.WANTED_SeekerOfSinfulSpoils, CardId.DogmatikaMatrix, _CardId.InfiniteImpermanence, CardId.DogmatikaPunishment }},
-            {2, new List<int> { CardId.DogmatikaAlbaZoa, CardId.DogmatikaFleurdelis, _CardId.CalledByTheGrave }},
-            {1, new List<int> { CardId.ThesIrisSwordsoul, CardId.DogmatikaMaximus, CardId.DiabellstarTheBlackWitch, CardId.DogmatikaLamity, CardId.DogmatikaMacabre,
-                                CardId.SinfulSpoilsOfDoom_Rciela, _CardId.CrossoutDesignator }},
-        };
         List<int> notToNegateIdList = new List<int>{
             58699500, 20343502
         };
@@ -447,7 +440,7 @@ namespace WindBot.Game.AI.Decks
         {
             List<int> result = new List<int>();
 
-            bool canSearchAlbaZoa = !Bot.HasInHand(CardId.DogmatikaAlbaZoa) && CheckRemainInDeck(CardId.DogmatikaAlbaZoa) > 0;
+            bool canSearchAlbaZoa = !Bot.HasInHand(CardId.DogmatikaAlbaZoa) && Bot.HasInDeck(CardId.DogmatikaAlbaZoa);
             int totalLevelInGY = Bot.Graveyard.Where(card => card != null && card.HasType(CardType.Fusion | CardType.Synchro)).Sum(c => (int?)c.Level ?? 0);
 
             bool needSearchAlbaZoa = Bot.HasInHandOrInSpellZone(CardId.DogmatikaLamity) && Bot.HasInExtra(CardId.DespianLuluwalilith) && canSearchAlbaZoa;
@@ -461,12 +454,12 @@ namespace WindBot.Game.AI.Decks
             }
 
             if (Bot.HasInHand(CardId.DogmatikaAlbaZoa) && Bot.HasInExtra(CardId.DespianLuluwalilith) && !Bot.HasInHandOrInSpellZone(CardId.DogmatikaLamity)
-                && CheckRemainInDeck(CardId.DogmatikaLamity) > 0)
+                && Bot.HasInDeck(CardId.DogmatikaLamity))
             {
                 result.Add(CardId.DogmatikaLamity);
             }
 
-            if (Bot.HasInHand(CardId.DogmatikaAlbaZoa) && !Bot.HasInHandOrInSpellZone(CardId.DogmatikaMacabre) && CheckRemainInDeck(CardId.DogmatikaMacabre) > 0
+            if (Bot.HasInHand(CardId.DogmatikaAlbaZoa) && !Bot.HasInHandOrInSpellZone(CardId.DogmatikaMacabre) && Bot.HasInDeck(CardId.DogmatikaMacabre)
                 && totalLevelInGY >= 12)
             {
                 result.Add(CardId.DogmatikaMacabre);
@@ -510,8 +503,8 @@ namespace WindBot.Game.AI.Decks
             if (baseAtk <= 2500 && Bot.HasInExtra(CardId.TitanikladTheAshDragon) && CheckCalledbytheGrave(CardId.TitanikladTheAshDragon) == 0
                 && !discardExtraThisTurn.Contains(CardId.TitanikladTheAshDragon) && !enemyActivateLockBird)
             {
-                bool successFlag = !activatedCardIdList.Contains(CardId.DogmatikaEcclesia) && CheckRemainInDeck(CardId.DogmatikaEcclesia) > 0;
-                successFlag |= Bot.GetMonsters().Any(card => card.IsFaceup() && card.HasSetcode(SetcodeDogmatika)) && !Bot.HasInHand(CardId.DogmatikaFleurdelis) && CheckRemainInDeck(CardId.DogmatikaFleurdelis) > 0;
+                bool successFlag = !activatedCardIdList.Contains(CardId.DogmatikaEcclesia) && Bot.HasInDeck(CardId.DogmatikaEcclesia);
+                successFlag |= Bot.GetMonsters().Any(card => card.IsFaceup() && card.HasSetcode(SetcodeDogmatika)) && !Bot.HasInHand(CardId.DogmatikaFleurdelis) && Bot.HasInDeck(CardId.DogmatikaFleurdelis);
                 if (successFlag)
                 {
                     selectResult = Bot.ExtraDeck.FirstOrDefault(card => card.IsCode(CardId.TitanikladTheAshDragon));
@@ -526,7 +519,7 @@ namespace WindBot.Game.AI.Decks
             if (baseAtk <= 2500 && Bot.HasInExtra(CardId.GranguignolTheDuskDragon))
             {
                 bool successFlag = Bot.HasInExtra(CardId.DespianLuluwalilith);
-                successFlag |= CheckRemainInDeck(CardId.DogmatikaEcclesia, CardId.DogmatikaFleurdelis, CardId.DogmatikaMaximus) > 0;
+                successFlag |= Bot.HasInDeck(CardId.DogmatikaEcclesia, CardId.DogmatikaFleurdelis, CardId.DogmatikaMaximus);
                 if (successFlag)
                 {
                     selectResult = Bot.ExtraDeck.FirstOrDefault(card => card.IsCode(CardId.GranguignolTheDuskDragon));
@@ -596,31 +589,7 @@ namespace WindBot.Game.AI.Decks
             return 0;
         }
 
-        /// <summary>
-        /// Check remain cards in deck
-        /// </summary>
-        /// <param name="id">Card's ID</param>
-        public int CheckRemainInDeck(int id)
-        {
-            for (int count = 1; count < 4; ++count)
-            {
-                if (DeckCountTable[count].Contains(id)) {
-                    return Bot.GetRemainingCount(id, count);
-                }
-            }
-            return 0;
-        }
 
-        public int CheckRemainInDeck(params int[] ids)
-        {
-            int sumResult = 0;
-            foreach (int id in ids)
-            {
-                sumResult += CheckRemainInDeck(id);
-            }
-
-            return sumResult;
-        }
 
         /// <summary>
         /// Whether spell or trap will be negate. If so, return true.
@@ -923,9 +892,9 @@ namespace WindBot.Game.AI.Decks
                         if (elder != null && destroyList.Count() > 0) discardList.Add(elder);
                         if (ashDragon != null && !activatedCardIdList.Contains(CardId.TitanikladTheAshDragon) && !discardEnemyExtraIdList.Contains(CardId.TitanikladTheAshDragon))
                         {
-                            bool checkFlag = !activatedCardIdList.Contains(CardId.DogmatikaEcclesia) && CheckRemainInDeck(CardId.DogmatikaEcclesia) > 0
+                            bool checkFlag = !activatedCardIdList.Contains(CardId.DogmatikaEcclesia) && Bot.HasInDeck(CardId.DogmatikaEcclesia)
                                 && CheckCalledbytheGrave(CardId.DogmatikaEcclesia) == 0;
-                            checkFlag |= CheckRemainInDeck(CardId.DogmatikaFleurdelis) > 0 && !Bot.HasInHand(CardId.DogmatikaFleurdelis) && !enemyActivateLockBird;
+                            checkFlag |= Bot.HasInDeck(CardId.DogmatikaFleurdelis) && !Bot.HasInHand(CardId.DogmatikaFleurdelis) && !enemyActivateLockBird;
                             if (checkFlag) discardList.Add(ashDragon);
                         }
                         if (garura != null && !activatedCardIdList.Contains(CardId.GaruraWingsOfResonantLife) && !enemyActivateLockBird) discardList.Add(garura);
@@ -1522,7 +1491,7 @@ namespace WindBot.Game.AI.Decks
                     AI.SelectCard(CardId.DogmatikaFleurdelis);
                     return true;
                 }
-                if (CheckRemainInDeck(CardId.DogmatikaMacabre) > 0)
+                if (Bot.HasInDeck(CardId.DogmatikaMacabre))
                 {
                     ClientCard albaZoaInHand = Bot.Hand.FirstOrDefault(card => card.IsCode(CardId.DogmatikaAlbaZoa));
                     if (albaZoaInHand != null)
@@ -1553,7 +1522,7 @@ namespace WindBot.Game.AI.Decks
                     }
                 }
             }
-            if (Bot.GetMonsterCount() == 0 || CheckRemainInDeck(CardId.SinfulSpoilsOfDoom_Rciela) > 0)
+            if (Bot.GetMonsterCount() == 0 || Bot.HasInDeck(CardId.SinfulSpoilsOfDoom_Rciela))
             {
                 List<int> spellIdList = new List<int>{ _CardId.CrossoutDesignator, _CardId.InfiniteImpermanence, _CardId.CalledByTheGrave, 
                     CardId.DogmatikaPunishment, CardId.DogmatikaMacabre, CardId.DogmatikaLamity };
@@ -1623,7 +1592,7 @@ namespace WindBot.Game.AI.Decks
             {
                 if ((Duel.Player == 0 && Duel.Phase == DuelPhase.End) || (Duel.Player == 1 && Duel.Phase < DuelPhase.End))
                 {
-                    if (!Bot.HasInHand(CardId.DogmatikaFleurdelis) && CheckRemainInDeck(CardId.DogmatikaFleurdelis) > 0)
+                    if (!Bot.HasInHand(CardId.DogmatikaFleurdelis) && Bot.HasInDeck(CardId.DogmatikaFleurdelis))
                     {
                         AI.SelectCard(CardId.DogmatikaFleurdelis);
                         activatedCardIdList.Add(Card.Id);
@@ -1644,7 +1613,7 @@ namespace WindBot.Game.AI.Decks
                     checkIdListFirstPart.Add(CardId.DogmatikaMatrix);
                     foreach (int checkId in checkIdListFirstPart)
                     {
-                        if (!Bot.HasInHandOrInSpellZone(checkId) && CheckRemainInDeck(checkId) > 0)
+                        if (!Bot.HasInHandOrInSpellZone(checkId) && Bot.HasInDeck(checkId))
                         {
                             AI.SelectCard(checkId);
                             activatedCardIdList.Add(Card.Id);
@@ -1656,7 +1625,7 @@ namespace WindBot.Game.AI.Decks
 
                 // search matrix
                 bool canSearchMatrix = DogmatikaMatrixCanActivate() && !activatedCardIdList.Contains(CardId.DogmatikaMatrix)
-                    && CheckRemainInDeck(CardId.DogmatikaMatrix) > 0 && !Bot.HasInHand(CardId.DogmatikaMatrix);
+                    && Bot.HasInDeck(CardId.DogmatikaMatrix) && !Bot.HasInHand(CardId.DogmatikaMatrix);
                 if (canSearchMatrix && Enemy.GetMonsterCount() > 0)
                 {
                     AI.SelectCard(CardId.DogmatikaMatrix);
@@ -1667,7 +1636,7 @@ namespace WindBot.Game.AI.Decks
 
                 // search for ritual
                 List<int> needSearchRitualIdList = GetNeedSearchRitualCardIdList();
-                bool canSearchMaximus = CheckRemainInDeck(CardId.DogmatikaMaximus) > 0 && !activatedCardIdList.Contains(CardId.DogmatikaMaximus)
+                bool canSearchMaximus = Bot.HasInDeck(CardId.DogmatikaMaximus) && !activatedCardIdList.Contains(CardId.DogmatikaMaximus)
                     && Bot.Graveyard.Where(card => card.HasType(CardType.Fusion | CardType.Synchro | CardType.Xyz | CardType.Link)).Count() > 0;
                 if (needSearchRitualIdList.Count() > 0)
                 {
@@ -1708,7 +1677,7 @@ namespace WindBot.Game.AI.Decks
                 checkIdListSecondPart.Add(CardId.DogmatikaMatrix);
                 foreach (int checkId in checkIdListSecondPart)
                 {
-                    if (!Bot.HasInHandOrInSpellZone(checkId) && CheckRemainInDeck(checkId) > 0)
+                    if (!Bot.HasInHandOrInSpellZone(checkId) && Bot.HasInDeck(checkId))
                     {
                         AI.SelectCard(checkId);
                         activatedCardIdList.Add(Card.Id);
@@ -1790,7 +1759,7 @@ namespace WindBot.Game.AI.Decks
             {
                 if (CheckHasExtraOnField() || !summoned)
                 {
-                    if (Bot.HasInGraveyard(CardId.DogmatikaEcclesia) || CheckRemainInDeck(CardId.DogmatikaEcclesia) > 0)
+                    if (Bot.HasInGraveyard(CardId.DogmatikaEcclesia) || Bot.HasInDeck(CardId.DogmatikaEcclesia))
                     {
                         searchId = CardId.DogmatikaEcclesia;
                         discardExtra = GetExtraToDiscard(1500, null);
@@ -1802,7 +1771,7 @@ namespace WindBot.Game.AI.Decks
             if (searchId == 0 || discardExtra == null)
             {
                 if (!activatedCardIdList.Contains(CardId.DogmatikaMaximus) && CheckCalledbytheGrave(CardId.DogmatikaMaximus) == 0
-                    && Bot.HasInGraveyard(CardId.DogmatikaMaximus) || CheckRemainInDeck(CardId.DogmatikaMaximus) > 0)
+                    && Bot.HasInGraveyard(CardId.DogmatikaMaximus) || Bot.HasInDeck(CardId.DogmatikaMaximus))
                 {
                     searchId = CardId.DogmatikaMaximus;
                     discardExtra = GetExtraToDiscard(1500, null);
@@ -1813,7 +1782,7 @@ namespace WindBot.Game.AI.Decks
             if (searchId == 0 || discardExtra == null)
             {
                 if (!Bot.HasInHand(CardId.DogmatikaFleurdelis) && Bot.GetMonsters().Any(card => card.IsFaceup() && card.HasSetcode(SetcodeDogmatika))
-                    && Bot.HasInGraveyard(CardId.DogmatikaFleurdelis) || CheckRemainInDeck(CardId.DogmatikaFleurdelis) > 0)
+                    && Bot.HasInGraveyard(CardId.DogmatikaFleurdelis) || Bot.HasInDeck(CardId.DogmatikaFleurdelis))
                 {
                     searchId = CardId.DogmatikaFleurdelis;
                     discardExtra = GetExtraToDiscard(2500, null);
@@ -1823,7 +1792,7 @@ namespace WindBot.Game.AI.Decks
             // search ecclesia for next turn
             if (searchId == 0 || discardExtra == null)
             {
-                if (Bot.HasInGraveyard(CardId.DogmatikaEcclesia) || CheckRemainInDeck(CardId.DogmatikaEcclesia) > 0)
+                if (Bot.HasInGraveyard(CardId.DogmatikaEcclesia) || Bot.HasInDeck(CardId.DogmatikaEcclesia))
                 {
                     searchId = CardId.DogmatikaEcclesia;
                     discardExtra = GetExtraToDiscard(1500, null);
@@ -2123,7 +2092,7 @@ namespace WindBot.Game.AI.Decks
                 // do not negate black witch
                 if (code == CardId.DiabellstarTheBlackWitch) return false;
                 if (CheckCalledbytheGrave(code) > 0) return false;
-                if (CheckRemainInDeck(code) > 0)
+                if (Bot.HasInDeck(code))
                 {
                     if (!(Card.Location == CardLocation.SpellZone))
                     {
@@ -2152,7 +2121,7 @@ namespace WindBot.Game.AI.Decks
 
         public bool DogmatikaMatrixCanActivate()
         {
-            return CheckRemainInDeck(CardId.DogmatikaAlbaZoa, CardId.DogmatikaLamity, CardId.DogmatikaMacabre) > 0;
+            return Bot.HasInDeck(CardId.DogmatikaAlbaZoa, CardId.DogmatikaLamity, CardId.DogmatikaMacabre);
         }
 
         public bool DogmatikaMatrixActivate()
@@ -2186,7 +2155,7 @@ namespace WindBot.Game.AI.Decks
                         SelectSTPlace(null, true);
                         AI.SelectYesNo(true);
                         // search both monster and spell
-                        if (CheckRemainInDeck(CardId.DogmatikaAlbaZoa) > 0 && CheckRemainInDeck(CardId.DogmatikaLamity, CardId.DogmatikaMacabre) > 0)
+                        if (Bot.HasInDeck(CardId.DogmatikaAlbaZoa) && Bot.HasInDeck(CardId.DogmatikaLamity, CardId.DogmatikaMacabre))
                         {
                             AI.SelectCard(CardId.DogmatikaAlbaZoa);
                             AI.SelectNextCard(CardId.DogmatikaLamity, CardId.DogmatikaMacabre);
@@ -2251,7 +2220,7 @@ namespace WindBot.Game.AI.Decks
             {
                 if (hasExtraOnField || !summoned)
                 {
-                    if (CheckRemainInDeck(CardId.DogmatikaEcclesia) > 0)
+                    if (Bot.HasInDeck(CardId.DogmatikaEcclesia))
                     {
                         AI.SelectNextCard(CardId.DogmatikaEcclesia);
                         return;
@@ -2260,7 +2229,7 @@ namespace WindBot.Game.AI.Decks
             }
 
             // seach Maximus
-            if (CheckRemainInDeck(CardId.DogmatikaMaximus) > 0 && !activatedCardIdList.Contains(CardId.DogmatikaMaximus)
+            if (Bot.HasInDeck(CardId.DogmatikaMaximus) && !activatedCardIdList.Contains(CardId.DogmatikaMaximus)
                 && Bot.Graveyard.Where(card => card.HasType(CardType.Fusion | CardType.Synchro | CardType.Xyz | CardType.Link)).Count() > 0)
             {
                 AI.SelectNextCard(CardId.DogmatikaMaximus);
@@ -2268,7 +2237,7 @@ namespace WindBot.Game.AI.Decks
             }
 
             // search Fleurdelis
-            if (CheckRemainInDeck(CardId.DogmatikaFleurdelis) > 0 && !Bot.HasInHand(CardId.DogmatikaFleurdelis) && hasExtraOnField
+            if (Bot.HasInDeck(CardId.DogmatikaFleurdelis) && !Bot.HasInHand(CardId.DogmatikaFleurdelis) && hasExtraOnField
                 && Bot.GetMonsters().Any(card => card.IsFaceup() && card.HasSetcode(SetcodeDogmatika)))
             {
                 AI.SelectNextCard(CardId.DogmatikaFleurdelis);
@@ -2279,7 +2248,7 @@ namespace WindBot.Game.AI.Decks
                     CardId.DogmatikaMaximus, CardId.DogmatikaFleurdelis, CardId.DogmatikaAlbaZoa, CardId.DogmatikaLamity, CardId.DogmatikaMacabre };
             foreach (int searchId in searchIdList)
             {
-                if (CheckRemainInDeck(searchId) > 0)
+                if (Bot.HasInDeck(searchId))
                 {
                     AI.SelectNextCard(searchId);
                     return;
@@ -2454,13 +2423,13 @@ namespace WindBot.Game.AI.Decks
 
         public bool TitanikladTheAshDragonActivate()
         {
-            if (!activatedCardIdList.Contains(CardId.DogmatikaEcclesia) && CheckRemainInDeck(CardId.DogmatikaEcclesia) > 0 && CheckCalledbytheGrave(CardId.DogmatikaEcclesia) == 0)
+            if (!activatedCardIdList.Contains(CardId.DogmatikaEcclesia) && Bot.HasInDeck(CardId.DogmatikaEcclesia) && CheckCalledbytheGrave(CardId.DogmatikaEcclesia) == 0)
             {
                 AI.SelectOption(1);
                 AI.SelectCard(CardId.DogmatikaEcclesia);
                 return true;
             }
-            if (CheckRemainInDeck(CardId.DogmatikaFleurdelis) > 0)
+            if (Bot.HasInDeck(CardId.DogmatikaFleurdelis))
             {
                 if (!Bot.HasInHand(CardId.DogmatikaFleurdelis) && !enemyActivateLockBird)
                 {
@@ -2478,7 +2447,7 @@ namespace WindBot.Game.AI.Decks
                     return true;
                 }
             }
-            if (CheckRemainInDeck(CardId.DogmatikaMaximus) > 0)
+            if (Bot.HasInDeck(CardId.DogmatikaMaximus))
             {
                 AI.SelectOption(1);
                 AI.SelectCard(CardId.DogmatikaMaximus);
@@ -2515,18 +2484,18 @@ namespace WindBot.Game.AI.Decks
             // spsummon
             if (Card.Location == CardLocation.Grave)
             {
-                if (!activatedCardIdList.Contains(CardId.DogmatikaEcclesia) && CheckRemainInDeck(CardId.DogmatikaEcclesia) > 0
+                if (!activatedCardIdList.Contains(CardId.DogmatikaEcclesia) && Bot.HasInDeck(CardId.DogmatikaEcclesia)
                     && CheckCalledbytheGrave(CardId.DogmatikaEcclesia) == 0 && !enemyActivateLockBird)
                 {
                     AI.SelectCard(CardId.DogmatikaEcclesia);
                     return true;
                 }
-                if (CheckRemainInDeck(CardId.ThesIrisSwordsoul) > 0)
+                if (Bot.HasInDeck(CardId.ThesIrisSwordsoul))
                 {
                     AI.SelectCard(CardId.ThesIrisSwordsoul);
                     return true;
                 }
-                if (Duel.Turn > 1 && Enemy.GetMonsterCount() == 0 && CheckRemainInDeck(CardId.DogmatikaFleurdelis) > 0)
+                if (Duel.Turn > 1 && Enemy.GetMonsterCount() == 0 && Bot.HasInDeck(CardId.DogmatikaFleurdelis))
                 {
                     AI.SelectCard(CardId.DogmatikaFleurdelis);
                     return true;
@@ -2536,7 +2505,7 @@ namespace WindBot.Game.AI.Decks
                     List<int> checkIdList = new List<int>{ CardId.DogmatikaMaximus, CardId.DogmatikaEcclesia, CardId.DogmatikaFleurdelis };
                     foreach (int checkId in checkIdList)
                     {
-                        if (CheckRemainInDeck(checkId) > 0)
+                        if (Bot.HasInDeck(checkId))
                         {
                             AI.SelectCard(checkId);
                             return true;
@@ -2591,7 +2560,7 @@ namespace WindBot.Game.AI.Decks
                     CardId.DogmatikaEcclesia, CardId.DogmatikaFleurdelis, CardId.DogmatikaMatrix };
                 foreach (int checkId in recycleMainIdList)
                 {
-                    if (CheckRemainInDeck(checkId) <= 0 && Bot.HasInGraveyard(checkId))
+                    if (!Bot.HasInDeck(checkId) && Bot.HasInGraveyard(checkId))
                     {
                         AI.SelectCard(checkId);
                         omegaActivateCount ++;

--- a/Game/AI/Decks/DragunExecutor.cs
+++ b/Game/AI/Decks/DragunExecutor.cs
@@ -211,7 +211,7 @@ namespace WindBot.Game.AI.Decks
         {
             if (Bot.HasInHand(CardId.RedEyesFusion))
                 return false;
-            if (!Bot.HasInDeck(CardId.RedEyesWyvern) && Bot.GetRemainingCount(CardId.RedEyesBDragon) == 1 && !Bot.HasInHand(CardId.RedEyesBDragon))
+            if (!Bot.HasInDeck(CardId.RedEyesWyvern) && Bot.GetCardCountInDeck(CardId.RedEyesBDragon) == 1 && !Bot.HasInHand(CardId.RedEyesBDragon))
                 return false;
             AI.SelectCard(CardId.RedEyesWyvern);
             return true;

--- a/Game/AI/Decks/DragunExecutor.cs
+++ b/Game/AI/Decks/DragunExecutor.cs
@@ -211,7 +211,7 @@ namespace WindBot.Game.AI.Decks
         {
             if (Bot.HasInHand(CardId.RedEyesFusion))
                 return false;
-            if (Bot.GetRemainingCount(CardId.RedEyesWyvern, 1) == 0 && Bot.GetRemainingCount(CardId.RedEyesBDragon, 2) == 1 && !Bot.HasInHand(CardId.RedEyesBDragon))
+            if (!Bot.HasInDeck(CardId.RedEyesWyvern) && Bot.GetRemainingCount(CardId.RedEyesBDragon) == 1 && !Bot.HasInHand(CardId.RedEyesBDragon))
                 return false;
             AI.SelectCard(CardId.RedEyesWyvern);
             return true;
@@ -223,7 +223,7 @@ namespace WindBot.Game.AI.Decks
             { // you don't want to use DragunofRedEyes which is treated as RedEyesBDragon as fusion material
                 if (Util.GetBotAvailZonesFromExtraDeck() == 0)
                     return false;
-                if (Bot.GetRemainingCount(CardId.RedEyesBDragon, 2) == 0 && !Bot.HasInHand(CardId.RedEyesBDragon))
+                if (!Bot.HasInDeck(CardId.RedEyesBDragon) && !Bot.HasInHand(CardId.RedEyesBDragon))
                     return false;
             }
             AI.SelectMaterials(CardLocation.Deck);
@@ -234,7 +234,7 @@ namespace WindBot.Game.AI.Decks
         private bool TourGuideFromTheUnderworldSummon()
         {
             if (DefaultCheckWhetherCardIsNegated(Card)) return false;
-            if (Bot.GetRemainingCount(CardId.TourGuideFromTheUnderworld, 2) == 0 && Bot.GetRemainingCount(CardId.Sangan, 2) == 0)
+            if (!Bot.HasInDeck(CardId.TourGuideFromTheUnderworld) && !Bot.HasInDeck(CardId.Sangan))
                 return false;
             return true;
         }

--- a/Game/AI/Decks/ExosisterExecutor.cs
+++ b/Game/AI/Decks/ExosisterExecutor.cs
@@ -150,13 +150,6 @@ namespace WindBot.Game.AI.Decks
             72490637, 21011044, 59419719, 14735698, 45410988
         };
 
-        Dictionary<int, List<int>> DeckCountTable = new Dictionary<int, List<int>>{
-            {3, new List<int> { CardId.ExosisterElis, CardId.ExosisterStella, CardId.ExosisterMartha, CardId.Aratama, CardId.Sakitama,
-                                _CardId.MaxxC, _CardId.AshBlossom, CardId.ExosisterPax, CardId.ExosisterVadis }},
-            {2, new List<int> { CardId.ExosisterIrene, CardId.ExosisterSophia, CardId.PotofExtravagance, _CardId.CalledByTheGrave,
-                                CardId.ExosisterReturnia, _CardId.InfiniteImpermanence }},
-            {1, new List<int> { CardId.ExosisterArment }},
-        };
         Dictionary<int, int> ExosisterMentionTable = new Dictionary<int, int>{
             {CardId.ExosisterElis, CardId.ExosisterStella}, {CardId.ExosisterStella, CardId.ExosisterElis},
             {CardId.ExosisterIrene, CardId.ExosisterSophia}, {CardId.ExosisterSophia, CardId.ExosisterIrene},
@@ -373,20 +366,6 @@ namespace WindBot.Game.AI.Decks
             return null;
         }
 
-        /// <summary>
-        /// Check remain cards in deck
-        /// </summary>
-        /// <param name="id">Card's ID</param>
-        public int CheckRemainInDeck(int id)
-        {
-            for (int count = 1; count < 4; ++count)
-            {
-                if (DeckCountTable[count].Contains(id)) {
-                    return Bot.GetRemainingCount(id, count);
-                }
-            }
-            return 0;
-        }
 
         /// <summary>
         /// Check negated turn count of id
@@ -505,7 +484,7 @@ namespace WindBot.Game.AI.Decks
         /// </summary>
         public bool CheckMarthaActivatable()
         {
-            return !marthaEffect1Activated && CheckCalledbytheGrave(CardId.ExosisterMartha) == 0 && CheckRemainInDeck(CardId.ExosisterElis) > 0
+            return !marthaEffect1Activated && CheckCalledbytheGrave(CardId.ExosisterMartha) == 0 && Bot.HasInDeck(CardId.ExosisterElis)
                 && !Bot.GetMonsters().Any(card => card.IsFacedown() || !card.HasType(CardType.Xyz));
         }
 
@@ -1757,7 +1736,7 @@ namespace WindBot.Game.AI.Decks
             List<int> lastSearchList = new List<int>();
             foreach (int cardId in searchTarget)
             {
-                if (Bot.HasInHandOrInSpellZone(cardId) || CheckRemainInDeck(cardId) == 0)
+                if (Bot.HasInHandOrInSpellZone(cardId) || !Bot.HasInDeck(cardId))
                 {
                     lastSearchList.Add(cardId);
                     continue;
@@ -1797,7 +1776,7 @@ namespace WindBot.Game.AI.Decks
             }
 
             // search martha for activate
-            if (CheckMarthaActivatable() && CheckRemainInDeck(CardId.ExosisterMartha) > 0 && !Bot.HasInHand(CardId.ExosisterMartha))
+            if (CheckMarthaActivatable() && Bot.HasInDeck(CardId.ExosisterMartha) && !Bot.HasInHand(CardId.ExosisterMartha))
             {
                 kaspitellEffect3Activated = true;
                 SelectDetachMaterial(Card);
@@ -1815,7 +1794,7 @@ namespace WindBot.Game.AI.Decks
             }
             // search stella for next xyz
             if (!summoned && !Bot.HasInHand(CardId.ExosisterStella) && !stellaEffect1Activated && CheckCalledbytheGrave(CardId.ExosisterStella) == 0
-                && CheckRemainInDeck(CardId.ExosisterStella) > 0 && Bot.Hand.Any(card => card?.Data != null && card.IsMonster() && card.HasSetcode(SetcodeExosister)))
+                && Bot.HasInDeck(CardId.ExosisterStella) && Bot.Hand.Any(card => card?.Data != null && card.IsMonster() && card.HasSetcode(SetcodeExosister)))
             {
                 kaspitellEffect3Activated = true;
                 SelectDetachMaterial(Card);
@@ -2018,7 +1997,7 @@ namespace WindBot.Game.AI.Decks
             if (Duel.Player == 0 && Duel.LastChainPlayer != 0)
             {
                 // search returnia for banish
-                if (CheckAtAdvantage() && GetProblematicEnemyCard(true) != null && CheckRemainInDeck(CardId.ExosisterReturnia) > 0 && !Bot.HasInHandOrInSpellZone(CardId.ExosisterReturnia))
+                if (CheckAtAdvantage() && GetProblematicEnemyCard(true) != null && Bot.HasInDeck(CardId.ExosisterReturnia) && !Bot.HasInHandOrInSpellZone(CardId.ExosisterReturnia))
                 {
                     if (Bot.GetMonsterCount() > 0 && Bot.GetMonsters().All(card => card.IsFaceup() && card.HasSetcode(SetcodeExosister)))
                     {
@@ -2034,7 +2013,7 @@ namespace WindBot.Game.AI.Decks
                 }
 
                 // search martha for activate
-                if (CheckMarthaActivatable() && CheckRemainInDeck(CardId.ExosisterMartha) > 0 && !Bot.HasInHand(CardId.ExosisterMartha))
+                if (CheckMarthaActivatable() && Bot.HasInDeck(CardId.ExosisterMartha) && !Bot.HasInHand(CardId.ExosisterMartha))
                 {
                     if (!(Card.Location == CardLocation.SpellZone))
                     {
@@ -2050,7 +2029,7 @@ namespace WindBot.Game.AI.Decks
                 if (!stellaEffect1Activated && CheckCalledbytheGrave(CardId.ExosisterStella) == 0)
                 {
                     // try to search stella
-                    if (Bot.Hand.Count(card => card.IsCode(CardId.ExosisterStella)) == 0 && CheckRemainInDeck(CardId.ExosisterStella) > 0)
+                    if (Bot.Hand.Count(card => card.IsCode(CardId.ExosisterStella)) == 0 && Bot.HasInDeck(CardId.ExosisterStella))
                     {
                         bool shouldSpSummon = !CheckLessOperation() && summoned && Bot.HasInMonstersZoneOrInGraveyard(CardId.ExosisterElis);
                         if (Bot.Hand.Any(card => card?.Data != null && card.IsMonster() && card.HasSetcode(SetcodeExosister)))
@@ -2100,7 +2079,7 @@ namespace WindBot.Game.AI.Decks
                         foreach (int checkId in checkListForSpSummon)
                         {
                             int checkTarget = CheckExosisterMentionCard(checkId);
-                            if (checkTarget > 0 && Bot.HasInMonstersZoneOrInGraveyard(checkId) && CheckRemainInDeck(checkTarget) > 0)
+                            if (checkTarget > 0 && Bot.HasInMonstersZoneOrInGraveyard(checkId) && Bot.HasInDeck(checkTarget))
                             {
                                 if (!(Card.Location == CardLocation.SpellZone))
                                 {
@@ -2150,11 +2129,11 @@ namespace WindBot.Game.AI.Decks
                     if (shouldSpSummon)
                     {
                         int checkTarget = CheckExosisterMentionCard(checkId);
-                        checkSuccessFlag = checkTarget > 0 && Bot.HasInMonstersZoneOrInGraveyard(checkTarget) && CheckRemainInDeck(checkId) > 0
+                        checkSuccessFlag = checkTarget > 0 && Bot.HasInMonstersZoneOrInGraveyard(checkTarget) && Bot.HasInDeck(checkId)
                                 && !exosisterTransformEffectList.Contains(checkId) && !Bot.HasInMonstersZone(checkId);
                     } else 
                     {
-                        checkSuccessFlag = !Bot.HasInHandOrHasInMonstersZone(checkId) && !Bot.HasInSpellZone(checkId) && CheckRemainInDeck(checkId) > 0;
+                        checkSuccessFlag = !Bot.HasInHandOrHasInMonstersZone(checkId) && !Bot.HasInSpellZone(checkId) && Bot.HasInDeck(checkId);
                     }
 
                     if (checkSuccessFlag)
@@ -2190,7 +2169,7 @@ namespace WindBot.Game.AI.Decks
                 };
                 foreach (int checkId in checkSpellTrapListForSearch)
                 {
-                    if (!Bot.HasInHandOrHasInMonstersZone(checkId) && !Bot.HasInSpellZone(checkId) && CheckRemainInDeck(checkId) > 0)
+                    if (!Bot.HasInHandOrHasInMonstersZone(checkId) && !Bot.HasInSpellZone(checkId) && Bot.HasInDeck(checkId))
                     {
                         if (!(Card.Location == CardLocation.SpellZone))
                         {
@@ -2390,7 +2369,7 @@ namespace WindBot.Game.AI.Decks
                 foreach (int checkId in checkListForSpSummon)
                 {
                     int checkTarget = CheckExosisterMentionCard(checkId);
-                    if (checkTarget > 0 && CheckRemainInDeck(checkId) > 0 && CheckRemainInDeck(checkTarget) > 0)
+                    if (checkTarget > 0 && Bot.HasInDeck(checkId) && Bot.HasInDeck(checkTarget))
                     {
                         if (checkTransform)
                         {
@@ -2549,7 +2528,7 @@ namespace WindBot.Game.AI.Decks
                 return false;
             }
 
-            if (CheckRemainInDeck(CardId.ExosisterElis) > 0)
+            if (Bot.HasInDeck(CardId.ExosisterElis))
             {
                 summoned = true;
                 return true;
@@ -2570,7 +2549,7 @@ namespace WindBot.Game.AI.Decks
             {
                 return false;
             }
-            if (!Card.HasSetcode(SetcodeExosister) || (Card.IsCode(CardId.ExosisterMartha) && CheckRemainInDeck(CardId.ExosisterElis) > 0))
+            if (!Card.HasSetcode(SetcodeExosister) || (Card.IsCode(CardId.ExosisterMartha) && Bot.HasInDeck(CardId.ExosisterElis)))
             {
                 return false;
             }
@@ -2598,7 +2577,7 @@ namespace WindBot.Game.AI.Decks
             {
                 return false;
             }
-            if (CheckRemainInDeck(CardId.Sakitama) > 0)
+            if (Bot.HasInDeck(CardId.Sakitama))
             {
                 summoned = true;
                 return true;
@@ -2788,7 +2767,7 @@ namespace WindBot.Game.AI.Decks
             bool searchStella = true;
             bool forMagnifica = false;
             if (marthaEffect1Activated || CheckCalledbytheGrave(CardId.ExosisterMartha) > 0
-                || CheckRemainInDeck(CardId.ExosisterMartha) == 0 || CheckRemainInDeck(CardId.ExosisterElis) == 0)
+                || !Bot.HasInDeck(CardId.ExosisterMartha) || !Bot.HasInDeck(CardId.ExosisterElis))
             {
                 searchMartha = false;
             }
@@ -2796,7 +2775,7 @@ namespace WindBot.Game.AI.Decks
             {
                 searchMartha = false;
             }
-            if (stellaEffect1Activated || CheckCalledbytheGrave(CardId.ExosisterStella) > 0 || CheckRemainInDeck(CardId.ExosisterStella) == 0
+            if (stellaEffect1Activated || CheckCalledbytheGrave(CardId.ExosisterStella) > 0 || !Bot.HasInDeck(CardId.ExosisterStella)
                 || !Bot.Hand.Any(card => card?.Data != null && card.IsMonster() && card.HasSetcode(SetcodeExosister)))
             {
                 searchStella = false;

--- a/Game/AI/Decks/FrogExecutor.cs
+++ b/Game/AI/Decks/FrogExecutor.cs
@@ -106,7 +106,7 @@ namespace WindBot.Game.AI.Decks
                 return false;
             m_swapFrogSummoned = -1;
 
-            if (Bot.GetRemainingCount(CardId.Ronintoadin, 2) == 0)
+            if (!Bot.HasInDeck(CardId.Ronintoadin))
                 return false;
 
             AI.SelectCard(CardId.Ronintoadin);

--- a/Game/AI/Decks/HeroBeat1103Executor.cs
+++ b/Game/AI/Decks/HeroBeat1103Executor.cs
@@ -158,26 +158,26 @@ namespace WindBot.Game.AI.Decks
         private List<int> GetHeroSearchPriority()
         {
             List<int> priority = new List<int>();
-            int stratosCount = Bot.GetRemainingCount(CardId.ElementalHEROStratos, 1);
-            int neosAliusCount = Bot.GetRemainingCount(CardId.ElementalHERONeosAlius, 3);
-            int bubblemanCount = Bot.GetRemainingCount(CardId.ElementalHEROBubbleman, 1);
+            bool hasStratos = Bot.HasInDeck(CardId.ElementalHEROStratos);
+            bool hasNeosAlius = Bot.HasInDeck(CardId.ElementalHERONeosAlius);
+            bool hasBubbleman = Bot.HasInDeck(CardId.ElementalHEROBubbleman);
 
-            if (stratosCount > 0 &&
+            if (hasStratos &&
                 !Bot.HasInHand(CardId.ElementalHEROStratos) &&
                 !Bot.HasInMonstersZone(CardId.ElementalHEROStratos))
                 priority.Add(CardId.ElementalHEROStratos);
-            if (neosAliusCount > 0 &&
+            if (hasNeosAlius &&
                 !Bot.HasInHand(CardId.ElementalHERONeosAlius) &&
                 !Bot.HasInMonstersZone(CardId.ElementalHERONeosAlius))
                 priority.Add(CardId.ElementalHERONeosAlius);
-            if (bubblemanCount > 0 && !Bot.HasInHand(CardId.ElementalHEROBubbleman))
+            if (hasBubbleman && !Bot.HasInHand(CardId.ElementalHEROBubbleman))
                 priority.Add(CardId.ElementalHEROBubbleman);
 
-            if (neosAliusCount > 0 && !priority.Contains(CardId.ElementalHERONeosAlius))
+            if (hasNeosAlius && !priority.Contains(CardId.ElementalHERONeosAlius))
                 priority.Add(CardId.ElementalHERONeosAlius);
-            if (bubblemanCount > 0 && !priority.Contains(CardId.ElementalHEROBubbleman))
+            if (hasBubbleman && !priority.Contains(CardId.ElementalHEROBubbleman))
                 priority.Add(CardId.ElementalHEROBubbleman);
-            if (stratosCount > 0 && !priority.Contains(CardId.ElementalHEROStratos))
+            if (hasStratos && !priority.Contains(CardId.ElementalHEROStratos))
                 priority.Add(CardId.ElementalHEROStratos);
             return priority;
         }

--- a/Game/AI/Decks/KashtiraExecutor.cs
+++ b/Game/AI/Decks/KashtiraExecutor.cs
@@ -404,11 +404,11 @@ namespace WindBot.Game.AI.Decks
             {
                 activate_pre_PrimePlanetParaisos = false;
                 IList<int> cardsId = new List<int>();
-                if (!Bot.HasInHand(CardId.KashtiraUnicorn) && !activate_KashtiraUnicorn_1 && CheckRemainInDeck(CardId.KashtiraUnicorn) > 0) cardsId.Add(CardId.KashtiraUnicorn);
-                if (!Bot.HasInHand(CardId.KashtiraFenrir) && !activate_KashtiraFenrir_1 && CheckRemainInDeck(CardId.KashtiraFenrir) > 0) cardsId.Add(CardId.KashtiraFenrir);
-                if (!Bot.HasInHand(CardId.KashtiraScareclaw) && !activate_KashtiraScareclaw_1 && CheckRemainInDeck(CardId.KashtiraScareclaw) > 0) cardsId.Add(CardId.KashtiraScareclaw);
-                if (!Bot.HasInHand(CardId.KashtiraTearlaments) && !activate_KashtiraTearlaments_1 && CheckRemainInDeck(CardId.KashtiraTearlaments) > 0) cardsId.Add(CardId.KashtiraTearlaments);
-                if (!Bot.HasInHand(CardId.KashtiraRiseheart) && (!activate_KashtiraRiseheart_2 || !activate_KashtiraRiseheart_1) && CheckRemainInDeck(CardId.KashtiraRiseheart) > 0) cardsId.Add(CardId.KashtiraRiseheart);
+                if (!Bot.HasInHand(CardId.KashtiraUnicorn) && !activate_KashtiraUnicorn_1 && Bot.HasInDeck(CardId.KashtiraUnicorn)) cardsId.Add(CardId.KashtiraUnicorn);
+                if (!Bot.HasInHand(CardId.KashtiraFenrir) && !activate_KashtiraFenrir_1 && Bot.HasInDeck(CardId.KashtiraFenrir)) cardsId.Add(CardId.KashtiraFenrir);
+                if (!Bot.HasInHand(CardId.KashtiraScareclaw) && !activate_KashtiraScareclaw_1 && Bot.HasInDeck(CardId.KashtiraScareclaw)) cardsId.Add(CardId.KashtiraScareclaw);
+                if (!Bot.HasInHand(CardId.KashtiraTearlaments) && !activate_KashtiraTearlaments_1 && Bot.HasInDeck(CardId.KashtiraTearlaments)) cardsId.Add(CardId.KashtiraTearlaments);
+                if (!Bot.HasInHand(CardId.KashtiraRiseheart) && (!activate_KashtiraRiseheart_2 || !activate_KashtiraRiseheart_1) && Bot.HasInDeck(CardId.KashtiraRiseheart)) cardsId.Add(CardId.KashtiraRiseheart);
                 IList<ClientCard> copyCards = new List<ClientCard>(cards);
                 IList<ClientCard> res = CardsIdToClientCards(cardsId, copyCards);
                 if (res?.Count <= 0) return null;
@@ -416,54 +416,6 @@ namespace WindBot.Game.AI.Decks
 
             }
             return base.OnSelectCard(cards, min, max, hint, cancelable);
-        }
-        private int CheckRemainInDeck(int id)
-        {
-            switch (id)
-            {
-                case CardId.Nibiru:
-                    return Bot.GetRemainingCount(CardId.Nibiru, 1);
-                case CardId.KashtiraUnicorn:
-                    return Bot.GetRemainingCount(CardId.KashtiraUnicorn, 3);
-                case CardId.KashtiraFenrir:
-                    return Bot.GetRemainingCount(CardId.KashtiraFenrir, 3);
-                case CardId.KashtiraTearlaments:
-                    return Bot.GetRemainingCount(CardId.KashtiraTearlaments, 1);
-                case CardId.KashtiraScareclaw:
-                    return Bot.GetRemainingCount(CardId.KashtiraScareclaw, 2);
-                case CardId.DimensionShifter:
-                    return Bot.GetRemainingCount(CardId.DimensionShifter, 2);
-                case CardId.NemesesCorridor:
-                    return Bot.GetRemainingCount(CardId.NemesesCorridor, 1);
-                case CardId.KashtiraRiseheart:
-                    return Bot.GetRemainingCount(CardId.KashtiraRiseheart, 3);
-                case CardId.G:
-                    return Bot.GetRemainingCount(CardId.G, 2);
-                case CardId.AshBlossom:
-                    return Bot.GetRemainingCount(CardId.AshBlossom, 3);
-                case CardId.MechaPhantom:
-                    return Bot.GetRemainingCount(CardId.MechaPhantom, 1);
-                case CardId.Terraforming:
-                    return Bot.GetRemainingCount(CardId.Terraforming, 1);
-                case CardId.PotofProsperity:
-                    return Bot.GetRemainingCount(CardId.PotofProsperity, 2);
-                case CardId.KashtiraPapiyas:
-                    return Bot.GetRemainingCount(CardId.KashtiraPapiyas, 3);
-                case CardId.CalledbytheGrave:
-                    return Bot.GetRemainingCount(CardId.CalledbytheGrave, 2);
-                case CardId.CrossoutDesignator:
-                    return Bot.GetRemainingCount(CardId.CrossoutDesignator, 1);
-                case CardId.KashtiraBirth:
-                    return Bot.GetRemainingCount(CardId.KashtiraBirth, 3);
-                case CardId.PrimePlanetParaisos:
-                    return Bot.GetRemainingCount(CardId.PrimePlanetParaisos, 3);
-                case CardId.KashtiraBigBang:
-                    return Bot.GetRemainingCount(CardId.KashtiraBigBang, 1);
-                case CardId.InfiniteImpermanence:
-                    return Bot.GetRemainingCount(CardId.InfiniteImpermanence, 2);
-                default:
-                    return 0;
-            }
         }
         #region CopyImpermanence
         public bool Impermanence_activate()
@@ -635,7 +587,7 @@ namespace WindBot.Game.AI.Decks
         }
         private bool CrossoutDesignatorCheck(ClientCard LastChainCard, int id)
         {
-            if (LastChainCard.IsCode(id) && CheckRemainInDeck(id) > 0)
+            if (LastChainCard.IsCode(id) && Bot.HasInDeck(id))
             {
                 AI.SelectAnnounceID(id);
                 return true;
@@ -785,7 +737,7 @@ namespace WindBot.Game.AI.Decks
             if (ActivateDescription == -1) return true;
             else
             {
-                if (CheckRemainInDeck(CardId.MechaPhantom) <= 0
+                if (!Bot.HasInDeck(CardId.MechaPhantom)
                     && GetEnemyOnFields().Count <= 0 && Bot.Graveyard.Count(card => card != null && card.HasType(CardType.Trap))<=0) return false;
                 List<ClientCard> tRelease = new List<ClientCard>();
                 List<ClientCard> nRelease = new List<ClientCard>();
@@ -801,7 +753,7 @@ namespace WindBot.Game.AI.Decks
                 opt_1 = false;
                 opt_2 = false;
                 if (count >= 3 && Bot.Graveyard.Count(card => card != null && card.HasType(CardType.Trap)) >0 ) opt_2 = true;
-                if (count >= 2 && CheckRemainInDeck(CardId.MechaPhantom) > 0) opt_1 = true;
+                if (count >= 2 && Bot.HasInDeck(CardId.MechaPhantom)) opt_1 = true;
                 if (count >= 1 && GetEnemyOnFields().Count > 0) opt_0 = true;
                 if (!opt_0 && !opt_1 && !opt_2) return false;
                 return true;
@@ -924,7 +876,7 @@ namespace WindBot.Game.AI.Decks
         }
         private bool GalaxyTomahawkSummon()
         {
-            if (CheckRemainInDeck(CardId.MechaPhantom) <= 0) return false;
+            if (!Bot.HasInDeck(CardId.MechaPhantom)) return false;
             if (Bot.GetMonsterCount() >= 4) return false;
             if (onlyXyzSummon || activate_DimensionShifter || Bot.HasInMonstersZone(CardId.KashtiraAriseHeart,true,false,true)) return false;
             if (!Bot.HasInExtra(CardId.MekkKnightCrusadiaAvramax) && !(Bot.HasInExtra(CardId.CupidPitch) || Bot.HasInExtra(CardId.BorreloadSavageDragon))) return false;
@@ -1113,15 +1065,15 @@ namespace WindBot.Game.AI.Decks
         }
         private bool KashtiraShangriIraEffect()
         {
-            if (!Bot.HasInMonstersZone(CardId.KashtiraUnicorn, true, false, true) && Enemy.ExtraDeck.Count > 0 && CheckRemainInDeck(CardId.KashtiraUnicorn) > 0)
+            if (!Bot.HasInMonstersZone(CardId.KashtiraUnicorn, true, false, true) && Enemy.ExtraDeck.Count > 0 && Bot.HasInDeck(CardId.KashtiraUnicorn))
             {
                 AI.SelectCard(CardId.KashtiraUnicorn);
             }
-            else if (!Bot.HasInMonstersZone(CardId.KashtiraFenrir, true, false, true) && CheckRemainInDeck(CardId.KashtiraFenrir) > 0)
+            else if (!Bot.HasInMonstersZone(CardId.KashtiraFenrir, true, false, true) && Bot.HasInDeck(CardId.KashtiraFenrir))
             {
                 AI.SelectCard(CardId.KashtiraFenrir);
             }
-            else if (!Bot.HasInMonstersZone(CardId.KashtiraScareclaw, true, false, true) && CheckRemainInDeck(CardId.KashtiraScareclaw) > 0)
+            else if (!Bot.HasInMonstersZone(CardId.KashtiraScareclaw, true, false, true) && Bot.HasInDeck(CardId.KashtiraScareclaw))
             {
                 AI.SelectCard(CardId.KashtiraScareclaw);
             }
@@ -1204,13 +1156,13 @@ namespace WindBot.Game.AI.Decks
             {
                 IList<int> cardsId = new List<int>();
                 if ((!Bot.HasInHandOrInSpellZone(CardId.KashtiraBirth) || isSummoned)
-                    && !Bot.HasInHand(CardId.KashtiraRiseheart) && (!activate_KashtiraRiseheart_2 && (!activate_KashtiraRiseheart_1 || !isSummoned)) && CheckRemainInDeck(CardId.KashtiraRiseheart) > 0)
+                    && !Bot.HasInHand(CardId.KashtiraRiseheart) && (!activate_KashtiraRiseheart_2 && (!activate_KashtiraRiseheart_1 || !isSummoned)) && Bot.HasInDeck(CardId.KashtiraRiseheart))
                     cardsId.Add(CardId.KashtiraRiseheart);
-                if (Bot.HasInHandOrInSpellZone(CardId.KashtiraBirth) && !isSummoned && !Bot.HasInHand(CardId.KashtiraUnicorn) && !activate_KashtiraUnicorn_1 && CheckRemainInDeck(CardId.KashtiraUnicorn) > 0)
+                if (Bot.HasInHandOrInSpellZone(CardId.KashtiraBirth) && !isSummoned && !Bot.HasInHand(CardId.KashtiraUnicorn) && !activate_KashtiraUnicorn_1 && Bot.HasInDeck(CardId.KashtiraUnicorn))
                     cardsId.Add(CardId.KashtiraUnicorn);
-                if (!Bot.HasInHand(CardId.KashtiraTearlaments) && !activate_KashtiraTearlaments_1 && CheckRemainInDeck(CardId.KashtiraTearlaments) > 0)
+                if (!Bot.HasInHand(CardId.KashtiraTearlaments) && !activate_KashtiraTearlaments_1 && Bot.HasInDeck(CardId.KashtiraTearlaments))
                     cardsId.Add(CardId.KashtiraTearlaments);
-                if (!Bot.HasInHand(CardId.KashtiraScareclaw) && !activate_KashtiraScareclaw_1 && CheckRemainInDeck(CardId.KashtiraScareclaw) > 0)
+                if (!Bot.HasInHand(CardId.KashtiraScareclaw) && !activate_KashtiraScareclaw_1 && Bot.HasInDeck(CardId.KashtiraScareclaw))
                     cardsId.Add(CardId.KashtiraScareclaw);
                 cardsId.Add(CardId.KashtiraUnicorn);
                 cardsId.Add(CardId.KashtiraRiseheart);
@@ -1248,7 +1200,7 @@ namespace WindBot.Game.AI.Decks
             List<int> cardsId = new List<int>();
             if (!Bot.HasInHandOrInSpellZone(CardId.PrimePlanetParaisos) && !activate_PrimePlanetParaisos)
                 cardsId.Add(CardId.PrimePlanetParaisos);
-            if (!Bot.HasInHandOrInSpellZone(CardId.PrimePlanetParaisos) && !activate_PrimePlanetParaisos && CheckRemainInDeck(CardId.PrimePlanetParaisos) > 0)
+            if (!Bot.HasInHandOrInSpellZone(CardId.PrimePlanetParaisos) && !activate_PrimePlanetParaisos && Bot.HasInDeck(CardId.PrimePlanetParaisos))
                 cardsId.Add(CardId.Terraforming);
             if (!Bot.HasInHand(CardId.KashtiraUnicorn) && !activate_KashtiraUnicorn_1)
                 cardsId.Add(CardId.KashtiraUnicorn);
@@ -1282,7 +1234,7 @@ namespace WindBot.Game.AI.Decks
         {
             if (Card.Location != CardLocation.Hand)
             {
-                if (CheckRemainInDeck(CardId.KashtiraBigBang) > 0 && Bot.GetMonsters().GetMatchingCards(card => card != null && card.HasType(CardType.Xyz)
+                if (Bot.HasInDeck(CardId.KashtiraBigBang) && Bot.GetMonsters().GetMatchingCards(card => card != null && card.HasType(CardType.Xyz)
                         && card.HasSetcode(0x189) && card.IsFaceup() && card.Overlays.Count > 0).Count > 0)
                 {
                     AI.SelectCard(CardId.KashtiraBigBang);
@@ -1290,14 +1242,14 @@ namespace WindBot.Game.AI.Decks
                 else if (Bot.HasInHandOrInSpellZone(CardId.KashtiraBirth) && !active_KashtiraBirth)
                 {
                     if (!Bot.HasInGraveyardOrInBanished(CardId.KashtiraUnicorn) && !activate_KashtiraUnicorn_1
-                        && CheckRemainInDeck(CardId.KashtiraUnicorn) > 0 && !active_KashtiraPapiyas_1
-                         && !Bot.HasInHand(CardId.KashtiraPapiyas) && CheckRemainInDeck(CardId.KashtiraPapiyas) > 0)
+                        && Bot.HasInDeck(CardId.KashtiraUnicorn) && !active_KashtiraPapiyas_1
+                         && !Bot.HasInHand(CardId.KashtiraPapiyas) && Bot.HasInDeck(CardId.KashtiraPapiyas))
                         AI.SelectCard(CardId.KashtiraUnicorn);
                     else if (!Bot.HasInGraveyardOrInBanished(CardId.KashtiraFenrir) && !activate_KashtiraFenrir_1
-                        && CheckRemainInDeck(CardId.KashtiraFenrir) > 0)
+                        && Bot.HasInDeck(CardId.KashtiraFenrir))
                         AI.SelectCard(CardId.KashtiraFenrir);
                     else if (!Bot.HasInGraveyardOrInBanished(CardId.KashtiraUnicorn) && !activate_KashtiraUnicorn_1
-                        && CheckRemainInDeck(CardId.KashtiraUnicorn) > 0)
+                        && Bot.HasInDeck(CardId.KashtiraUnicorn))
                         AI.SelectCard(CardId.KashtiraFenrir);
                     else if (Bot.Graveyard.Count(card => card != null && card.HasType(CardType.Monster) && card.HasSetcode(0x189) && !card.HasType(CardType.Xyz))
                     + Bot.Banished.Count(card_2 => card_2 != null && card_2.HasType(CardType.Monster) && card_2.HasSetcode(0x189) && !card_2.HasType(CardType.Xyz)) <= 0)
@@ -1310,7 +1262,7 @@ namespace WindBot.Game.AI.Decks
                 {
                     AI.SelectCard(CardId.KashtiraFenrir, CardId.KashtiraUnicorn, CardId.KashtiraScareclaw, CardId.KashtiraTearlaments, CardId.KashtiraRiseheart);
                 }
-                else if (!active_KashtiraPapiyas_2 && CheckRemainInDeck(CardId.KashtiraPapiyas) > 0 && Bot.Banished.GetMatchingCardsCount(card => card != null && card.IsFaceup() && card.HasSetcode(0x189) && card.Id != CardId.KashtiraPapiyas) > 0)
+                else if (!active_KashtiraPapiyas_2 && Bot.HasInDeck(CardId.KashtiraPapiyas) && Bot.Banished.GetMatchingCardsCount(card => card != null && card.IsFaceup() && card.HasSetcode(0x189) && card.Id != CardId.KashtiraPapiyas) > 0)
                 {
                     AI.SelectCard(CardId.KashtiraPapiyas, CardId.KashtiraFenrir, CardId.KashtiraUnicorn, CardId.KashtiraScareclaw, CardId.KashtiraTearlaments, CardId.KashtiraRiseheart);
                 }
@@ -1355,7 +1307,7 @@ namespace WindBot.Game.AI.Decks
         {
             if (Card.Location == CardLocation.Hand || (Card.Location == CardLocation.SpellZone && Card.IsFacedown())) return false;
             List<int> cardsid = new List<int>();
-            if (!activate_KashtiraUnicorn_1 && !active_KashtiraPapiyas_1 && (Bot.HasInHand(CardId.KashtiraPapiyas) || CheckRemainInDeck(CardId.KashtiraPapiyas) > 0)) cardsid.Add(CardId.KashtiraPapiyas);
+            if (!activate_KashtiraUnicorn_1 && !active_KashtiraPapiyas_1 && (Bot.HasInHand(CardId.KashtiraPapiyas) || Bot.HasInDeck(CardId.KashtiraPapiyas))) cardsid.Add(CardId.KashtiraPapiyas);
             if (!activate_KashtiraFenrir_1) cardsid.Add(CardId.KashtiraFenrir);
             if (!activate_KashtiraUnicorn_1) cardsid.Add(CardId.KashtiraUnicorn);
             if (!activate_KashtiraRiseheart_2) cardsid.Add(CardId.KashtiraRiseheart);

--- a/Game/AI/Decks/LabrynthExecutor.cs
+++ b/Game/AI/Decks/LabrynthExecutor.cs
@@ -617,7 +617,7 @@ namespace WindBot.Game.AI.Decks
                     banishList.AddRange(faceDownMonsters);
                     List<ClientCard> notImportantMonster = botMonsters.Where(card => !banishList.Contains(card)
                         && ((card.HasType(CardType.Fusion | CardType.Synchro | CardType.Xyz | CardType.Link) && Bot.HasInExtra(card.Id))
-                        || Bot.HasInDeck(card.Id))).ToList();
+                        || Bot.HasInDeck(card.GetNonAltartCode()))).ToList();
                     notImportantMonster.Sort(CardContainer.CompareCardAttack);
                     banishList.AddRange(notImportantMonster);
 
@@ -629,7 +629,7 @@ namespace WindBot.Game.AI.Decks
 
                     List<ClientCard> importantMonster = botMonsters.Where(card => !banishList.Contains(card) && !card.IsCode(CardId.LovelyLabrynthOfTheSilverCastle)
                         && ((card.HasType(CardType.Fusion | CardType.Synchro | CardType.Xyz | CardType.Link) && !Bot.HasInExtra(card.Id))
-                        || !Bot.HasInDeck(card.Id))).ToList();
+                        || !Bot.HasInDeck(card.GetNonAltartCode()))).ToList();
                     importantMonster.Sort(CardContainer.CompareCardAttack);
                     banishList.AddRange(importantMonster);
 

--- a/Game/AI/Decks/LabrynthExecutor.cs
+++ b/Game/AI/Decks/LabrynthExecutor.cs
@@ -159,14 +159,6 @@ namespace WindBot.Game.AI.Decks
         const int hintTimingMainEnd = 0x4;
         const int hintBattleStart = 0x8;
 
-        Dictionary<int, List<int>> DeckCountTable = new Dictionary<int, List<int>>{
-            {3, new List<int> { CardId.AriannaTheLabrynthServant, CardId.LabrynthChandraglier, _CardId.AshBlossom, _CardId.MaxxC,
-                                CardId.LabrynthStovieTorbie, CardId.LabrynthCooclock, _CardId.InfiniteImpermanence, CardId.BigWelcomeLabrynth }},
-            {2, new List<int> { CardId.LadyLabrynthOfTheSilverCastle, CardId.AriasTheLabrynthButler, CardId.PotOfExtravagance, CardId.WelcomeLabrynth,
-                                CardId.TransactionRollback }},
-            {1, new List<int> { CardId.LovelyLabrynthOfTheSilverCastle, CardId.UnchainedSoulOfSharvara, CardId.ArianeTheLabrynthServant,
-                                CardId.DestructiveDarumaKarmaCannon, CardId.EscapeOfTheUnchained, _CardId.DimensionalBarrier }}
-        };
         List<int> notToNegateIdList = new List<int>{
             58699500, 20343502
         };
@@ -454,30 +446,6 @@ namespace WindBot.Game.AI.Decks
             return true;
         }
 
-        /// <summary>
-        /// Check remain cards in deck
-        /// </summary>
-        /// <param name="id">Card's ID</param>
-        public int CheckRemainInDeck(int id)
-        {
-            for (int count = 1; count < 4; ++count)
-            {
-                if (DeckCountTable[count].Contains(id)) {
-                    return Bot.GetRemainingCount(id, count);
-                }
-            }
-            return 0;
-        }
-        public int CheckRemainInDeck(params int[] ids)
-        {
-            int sumResult = 0;
-            foreach (int id in ids)
-            {
-                sumResult += CheckRemainInDeck(id);
-            }
-
-            return sumResult;
-        }
 
         /// <summary>
         /// Whether spell or trap will be negate. If so, return true.
@@ -613,7 +581,7 @@ namespace WindBot.Game.AI.Decks
 
         public bool CheckBigWelcomeCanSpSummon(int cardId)
         {
-            return Bot.HasInHandOrInGraveyard(cardId) || CheckRemainInDeck(cardId) > 0;
+            return Bot.HasInHandOrInGraveyard(cardId) || Bot.HasInDeck(cardId);
         }
 
         public int CompareUsableAttack(ClientCard cardA, ClientCard cardB)
@@ -649,7 +617,7 @@ namespace WindBot.Game.AI.Decks
                     banishList.AddRange(faceDownMonsters);
                     List<ClientCard> notImportantMonster = botMonsters.Where(card => !banishList.Contains(card)
                         && ((card.HasType(CardType.Fusion | CardType.Synchro | CardType.Xyz | CardType.Link) && Bot.HasInExtra(card.Id))
-                        || CheckRemainInDeck(card.Id) > 0)).ToList();
+                        || Bot.HasInDeck(card.Id))).ToList();
                     notImportantMonster.Sort(CardContainer.CompareCardAttack);
                     banishList.AddRange(notImportantMonster);
 
@@ -661,7 +629,7 @@ namespace WindBot.Game.AI.Decks
 
                     List<ClientCard> importantMonster = botMonsters.Where(card => !banishList.Contains(card) && !card.IsCode(CardId.LovelyLabrynthOfTheSilverCastle)
                         && ((card.HasType(CardType.Fusion | CardType.Synchro | CardType.Xyz | CardType.Link) && !Bot.HasInExtra(card.Id))
-                        || CheckRemainInDeck(card.Id) == 0)).ToList();
+                        || !Bot.HasInDeck(card.Id))).ToList();
                     importantMonster.Sort(CardContainer.CompareCardAttack);
                     banishList.AddRange(importantMonster);
 
@@ -699,7 +667,7 @@ namespace WindBot.Game.AI.Decks
                             haveUnchainSoul |= Bot.HasInHand(CardId.UnchainedSoulOfSharvara);
                             haveUnchainSoul |= Duel.Player == 0 && Duel.Phase <= DuelPhase.Main2
                                 && Bot.HasInExtra(CardId.UnchainedSoulLordOfYama) && !activatedCardIdList.Contains(CardId.UnchainedSoulLordOfYama)
-                                && (CheckRemainInDeck(CardId.UnchainedSoulOfSharvara) > 0 || Bot.HasInGraveyard(CardId.UnchainedSoulOfSharvara))
+                                && (Bot.HasInDeck(CardId.UnchainedSoulOfSharvara) || Bot.HasInGraveyard(CardId.UnchainedSoulOfSharvara))
                                 && Bot.GetMonsters().Where(card => card.IsFaceup() && card.HasRace(CardRace.Fiend) && card.Level <= 4).Count() >= 2;
                         }
                         bool haveAriane = false;
@@ -918,12 +886,12 @@ namespace WindBot.Game.AI.Decks
                     // search cooclock/bulter to activate trap
                     ClientCard arias = null;
                     ClientCard cooclock = null;
-                    if (!activatedCardIdList.Contains(CardId.AriasTheLabrynthButler) && CheckRemainInDeck(CardId.AriasTheLabrynthButler) > 0
+                    if (!activatedCardIdList.Contains(CardId.AriasTheLabrynthButler) && Bot.HasInDeck(CardId.AriasTheLabrynthButler)
                         && !Bot.HasInHand(CardId.AriasTheLabrynthButler))
                     {
                         arias = GetWelcomeOrBigWelcomeTarget(cards, CardId.AriasTheLabrynthButler);
                     }
-                    if (!activatedCardIdList.Contains(CardId.LabrynthCooclock) && CheckRemainInDeck(CardId.LabrynthCooclock) > 0
+                    if (!activatedCardIdList.Contains(CardId.LabrynthCooclock) && Bot.HasInDeck(CardId.LabrynthCooclock)
                         && !Bot.HasInHand(CardId.LabrynthCooclock))
                     {
                         cooclock = GetWelcomeOrBigWelcomeTarget(cards, CardId.LabrynthCooclock);
@@ -1090,7 +1058,7 @@ namespace WindBot.Game.AI.Decks
                     foreach (int checkId in uniqueCheckIdList)
                     {
                         ClientCard targetCard = GetWelcomeOrBigWelcomeTarget(cards, checkId);
-                        if (CheckRemainInDeck(checkId) > 0)
+                        if (Bot.HasInDeck(checkId))
                         {
                             if (checkId == CardId.BigWelcomeLabrynth || checkId == CardId.WelcomeLabrynth)
                             {
@@ -1170,7 +1138,7 @@ namespace WindBot.Game.AI.Decks
                     }
 
                     ClientCard cooclock = cards.FirstOrDefault(c => c.IsCode(CardId.LabrynthCooclock));
-                    bool canSearchWelcome = CheckRemainInDeck(CardId.WelcomeLabrynth, CardId.BigWelcomeLabrynth) > 0
+                    bool canSearchWelcome = Bot.HasInDeck(CardId.WelcomeLabrynth, CardId.BigWelcomeLabrynth)
                                         && (Bot.HasInHandOrHasInMonstersZone(new List<int> { CardId.LabrynthChandraglier, CardId.LabrynthStovieTorbie })
                                             || summonInChainList.Any(c => c.IsCode(CardId.AriannaTheLabrynthServant))
                                             || (Duel.Player == 0 && !summoned && !activatedCardIdList.Contains(CardId.AriannaTheLabrynthServant) && Bot.HasInHand(CardId.AriannaTheLabrynthServant)));
@@ -1876,7 +1844,7 @@ namespace WindBot.Game.AI.Decks
 
                 if (GetCanBeUsedForLinkMaterial(true, card => !card.HasRace(CardRace.Fiend)).Count() == 2
                     && !activatedCardIdList.Contains(CardId.UnchainedSoulLordOfYama)
-                    && (Bot.HasInGraveyard(CardId.UnchainedSoulOfSharvara) || CheckRemainInDeck(CardId.UnchainedSoulOfSharvara) > 0))
+                    && (Bot.HasInGraveyard(CardId.UnchainedSoulOfSharvara) || Bot.HasInDeck(CardId.UnchainedSoulOfSharvara)))
                 {
                     activatedCardIdList.Add(Card.Id);
                     return true;
@@ -2042,7 +2010,7 @@ namespace WindBot.Game.AI.Decks
                     {
                         searchFlag |= (CurrentTiming & hintTimingMainEnd) != 0;
                         searchFlag |= GetProblematicEnemyCardList(false).Count() > 0
-                            && (Bot.HasInMonstersZoneOrInGraveyard(CardId.LovelyLabrynthOfTheSilverCastle) || CheckRemainInDeck(CardId.LovelyLabrynthOfTheSilverCastle) > 0)
+                            && (Bot.HasInMonstersZoneOrInGraveyard(CardId.LovelyLabrynthOfTheSilverCastle) || Bot.HasInDeck(CardId.LovelyLabrynthOfTheSilverCastle))
                             && !activatedCardIdList.Contains(CardId.LovelyLabrynthOfTheSilverCastle + 1);
                     }
                     if (Duel.Player == 0) searchFlag |= summoned && !CheckShouldNoMoreSpSummon();
@@ -2101,7 +2069,7 @@ namespace WindBot.Game.AI.Decks
                 if (CheckShouldNoMoreSpSummon() && !(haveRollback && Bot.Graveyard.Any(card => card.IsCode(CardId.WelcomeLabrynth, CardId.BigWelcomeLabrynth)))) return false;
                 int specialSummonId = 0;
                 // arianna
-                if (!activatedCardIdList.Contains(CardId.AriannaTheLabrynthServant) && CheckRemainInDeck(CardId.AriannaTheLabrynthServant) > 0)
+                if (!activatedCardIdList.Contains(CardId.AriannaTheLabrynthServant) && Bot.HasInDeck(CardId.AriannaTheLabrynthServant))
                 {
                     specialSummonId = CardId.AriannaTheLabrynthServant;
                 }
@@ -2111,7 +2079,7 @@ namespace WindBot.Game.AI.Decks
                     List<int> checkIdList = new List<int>{CardId.LabrynthStovieTorbie, CardId.LabrynthChandraglier, CardId.LabrynthCooclock};
                     foreach (int checkId in checkIdList)
                     {
-                        if (!Bot.HasInHandOrInMonstersZoneOrInGraveyard(checkId) && CheckRemainInDeck(checkId) > 0)
+                        if (!Bot.HasInHandOrInMonstersZoneOrInGraveyard(checkId) && Bot.HasInDeck(checkId))
                         {
                             specialSummonId = checkId;
                             break;
@@ -2130,7 +2098,7 @@ namespace WindBot.Game.AI.Decks
                     });
                     foreach (int checkId in checkIdList)
                     {
-                        if (CheckRemainInDeck(checkId) > 0)
+                        if (Bot.HasInDeck(checkId))
                         {
                             specialSummonId = checkId;
                             break;
@@ -2257,7 +2225,7 @@ namespace WindBot.Game.AI.Decks
                 }
                 bool activateFlag = becomeTarget;
                 // set big welcome for lovely
-                bool canActivateSetBigWelcomeThisTurn = CheckRemainInDeck(CardId.BigWelcomeLabrynth) > 0 && cooclockAffected && !activatedCardIdList.Contains(CardId.BigWelcomeLabrynth)
+                bool canActivateSetBigWelcomeThisTurn = Bot.HasInDeck(CardId.BigWelcomeLabrynth) && cooclockAffected && !activatedCardIdList.Contains(CardId.BigWelcomeLabrynth)
                     && (Bot.HasInMonstersZone(CardId.LovelyLabrynthOfTheSilverCastle, true, false, true) || CheckBigWelcomeCanSpSummon(CardId.LovelyLabrynthOfTheSilverCastle))
                     && (!Bot.GetSpells().Any(card => card.IsFacedown() && card.IsCode(CardId.BigWelcomeLabrynth) && !setTrapThisTurn.Contains(card)))
                     && (
@@ -2391,7 +2359,7 @@ namespace WindBot.Game.AI.Decks
                     // whether have labrynth to trigger cooclock
                     bool haveBigWelcome = Duel.Player == 0 && Bot.HasInHand(CardId.BigWelcomeLabrynth)
                         && (Bot.GetMonsters().Any(card => card.IsFaceup() && card.HasSetcode(SetcodeLabrynth)) || (!summoned && Bot.Hand.Any(card => card != Card && card.HasType(CardType.Monster) && card.Level <= 4 && card.HasSetcode(SetcodeLabrynth))));
-                    if (CheckRemainInDeck(CardId.BigWelcomeLabrynth) > 0)
+                    if (Bot.HasInDeck(CardId.BigWelcomeLabrynth))
                     {
                         foreach (int checkId in new List<int> { CardId.LabrynthChandraglier, CardId.LabrynthStovieTorbie })
                         {
@@ -2589,7 +2557,7 @@ namespace WindBot.Game.AI.Decks
 
                 bool becomeTarget = Card.Location == CardLocation.SpellZone && DefaultOnBecomeTarget();
                 if ((Duel.Player == 0 && Duel.Phase <= DuelPhase.Main2 || Duel.Player == 1 && activateTimingFlag)
-                    && CheckRemainInDeck(CardId.ArianeTheLabrynthServant) > 0 && Bot.HasInHandOrInSpellZone(CardId.TransactionRollback)
+                    && Bot.HasInDeck(CardId.ArianeTheLabrynthServant) && Bot.HasInHandOrInSpellZone(CardId.TransactionRollback)
                     && !chainSummoningIdList.Contains(CardId.ArianeTheLabrynthServant))
                 {
                     if (!noSelect)
@@ -2605,7 +2573,7 @@ namespace WindBot.Game.AI.Decks
                 ariannaCheck |= Duel.Player == 0;
                 if (ariannaCheck)
                 {
-                    if (CheckRemainInDeck(CardId.AriannaTheLabrynthServant) > 0 && !activatedCardIdList.Contains(CardId.AriannaTheLabrynthServant)
+                    if (Bot.HasInDeck(CardId.AriannaTheLabrynthServant) && !activatedCardIdList.Contains(CardId.AriannaTheLabrynthServant)
                         && !CheckWhetherNegated(true, true, CardType.Monster) && !chainSummoningIdList.Contains(CardId.AriannaTheLabrynthServant))
                     {
                         if (!noSelect)
@@ -2618,7 +2586,7 @@ namespace WindBot.Game.AI.Decks
                 }
                 if (Bot.HasInSpellZoneOrInGraveyard(CardId.BigWelcomeLabrynth) && !activatedCardIdList.Contains(CardId.BigWelcomeLabrynth))
                 {
-                    if (Bot.HasInHand(CardId.LovelyLabrynthOfTheSilverCastle) && CheckRemainInDeck(CardId.AriasTheLabrynthButler) > 0
+                    if (Bot.HasInHand(CardId.LovelyLabrynthOfTheSilverCastle) && Bot.HasInDeck(CardId.AriasTheLabrynthButler)
                          && !chainSummoningIdList.Contains(CardId.AriasTheLabrynthButler) && !Bot.HasInMonstersZone(CardId.AriasTheLabrynthButler, true, false, true))
                     {
                         if (!noSelect)
@@ -2638,18 +2606,18 @@ namespace WindBot.Game.AI.Decks
                     if (!noSelect)
                     {
                         if (Bot.HasInSpellZoneOrInGraveyard(CardId.BigWelcomeLabrynth) && !activatedCardIdList.Contains(CardId.BigWelcomeLabrynth)
-                            && CheckRemainInDeck(CardId.LovelyLabrynthOfTheSilverCastle) > 0 && !chainSummoningIdList.Contains(CardId.LovelyLabrynthOfTheSilverCastle))
+                            && Bot.HasInDeck(CardId.LovelyLabrynthOfTheSilverCastle) && !chainSummoningIdList.Contains(CardId.LovelyLabrynthOfTheSilverCastle))
                         {
                             chainSummoningIdList.Add(CardId.LovelyLabrynthOfTheSilverCastle);
                         }
-                        else if (!activatedCardIdList.Contains(CardId.AriannaTheLabrynthServant) && CheckRemainInDeck(CardId.AriannaTheLabrynthServant) > 0
+                        else if (!activatedCardIdList.Contains(CardId.AriannaTheLabrynthServant) && Bot.HasInDeck(CardId.AriannaTheLabrynthServant)
                             && !CheckWhetherNegated(true, true, CardType.Monster) && !chainSummoningIdList.Contains(CardId.AriannaTheLabrynthServant))
                         {
                             chainSummoningIdList.Add(CardId.AriannaTheLabrynthServant);
                         }
                         else if (Bot.HasInGraveyard(CardId.BigWelcomeLabrynth) && !activatedCardIdList.Contains(CardId.BigWelcomeLabrynth)
                             && !Bot.GetMonsters().Any(card => card.IsFaceup() && card.HasRace(CardRace.Fiend) && card.Level >= 8)
-                            && CheckRemainInDeck(CardId.LadyLabrynthOfTheSilverCastle) > 0 && !chainSummoningIdList.Contains(CardId.LadyLabrynthOfTheSilverCastle))
+                            && Bot.HasInDeck(CardId.LadyLabrynthOfTheSilverCastle) && !chainSummoningIdList.Contains(CardId.LadyLabrynthOfTheSilverCastle))
                         {
                             chainSummoningIdList.Add(CardId.LadyLabrynthOfTheSilverCastle);
                         }
@@ -2658,7 +2626,7 @@ namespace WindBot.Game.AI.Decks
                             List<int> checkIdList = new List<int>{CardId.LabrynthStovieTorbie, CardId.LabrynthChandraglier, CardId.LabrynthCooclock};
                             foreach (int checkId in checkIdList)
                             {
-                                if (!Bot.HasInHandOrInMonstersZoneOrInGraveyard(checkId) && CheckRemainInDeck(checkId) > 0
+                                if (!Bot.HasInHandOrInMonstersZoneOrInGraveyard(checkId) && Bot.HasInDeck(checkId)
                                      && !chainSummoningIdList.Contains(checkId))
                                 {
                                     selectId = checkId;
@@ -2673,7 +2641,7 @@ namespace WindBot.Game.AI.Decks
                             {
                                 foreach (int checkId in fullCheckIdList)
                                 {
-                                    if (CheckRemainInDeck(checkId) > 0 && !chainSummoningIdList.Contains(checkId))
+                                    if (Bot.HasInDeck(checkId) && !chainSummoningIdList.Contains(checkId))
                                     {
                                         selectId = checkId;
                                         break;
@@ -3290,7 +3258,7 @@ namespace WindBot.Game.AI.Decks
                 // trigger furniture/welcome
                 List<ClientCard> checkFurnitureList = new List<ClientCard>(Bot.Hand);
                 checkFurnitureList.AddRange(Bot.GetMonsters());
-                if ((CheckRemainInDeck(CardId.WelcomeLabrynth, CardId.BigWelcomeLabrynth) == 0
+                if ((!Bot.HasInDeck(CardId.WelcomeLabrynth, CardId.BigWelcomeLabrynth)
                     || !checkFurnitureList.Any(card => card.IsCode(CardId.LabrynthChandraglier, CardId.LabrynthStovieTorbie)))
                     && Duel.LastChainPlayer < 0 && Duel.Player == 0 && !Bot.HasInMonstersZone(CardId.LovelyLabrynthOfTheSilverCastle, true, false, true)
                     && !(cooclockAffected && Bot.HasInHandOrInSpellZone(CardId.BigWelcomeLabrynth)))

--- a/Game/AI/Decks/Level8Executor.cs
+++ b/Game/AI/Decks/Level8Executor.cs
@@ -341,7 +341,7 @@ namespace WindBot.Game.AI.Decks
                 AI.SelectCard(CardId.ScrapRecycler);
                 return true;
             }
-            if (L4NonTunerSummonFirst() && Bot.GetRemainingCount(CardId.PerformageTrickClown, 1) > 0)
+            if (L4NonTunerSummonFirst() && Bot.HasInDeck(CardId.PerformageTrickClown))
             {
                 AI.SelectCard(CardId.PerformageTrickClown);
                 return true;
@@ -357,7 +357,7 @@ namespace WindBot.Game.AI.Decks
 
         private bool ScrapRecyclerSummonFirst()
         {
-            return Bot.GetRemainingCount(CardId.ScrapGolem, 2) > 0 && Bot.GetRemainingCount(CardId.MechaPhantomBeastOLion, 2) > 0 && Bot.GetRemainingCount(CardId.JetSynchron, 2) > 0;
+            return Bot.HasInDeck(CardId.ScrapGolem) && Bot.HasInDeck(CardId.MechaPhantomBeastOLion) && Bot.HasInDeck(CardId.JetSynchron);
         }
 
         private bool ScrapRecyclerEffect()
@@ -618,7 +618,7 @@ namespace WindBot.Game.AI.Decks
         {
             if (Card.Location == CardLocation.Grave)
             {
-                if (Bot.GetRemainingCount(CardId.WorldCarrotweightChampion, 1) > 0)
+                if (Bot.HasInDeck(CardId.WorldCarrotweightChampion))
                 {
                     AI.SelectCard(CardId.WorldCarrotweightChampion);
                     return true;
@@ -811,7 +811,7 @@ namespace WindBot.Game.AI.Decks
             {
                 int targetLevel = 8;
 
-                if (Bot.MonsterZone.IsExistingMatchingCard(card => card.Level == targetLevel - 5 && card.IsFaceup() && !card.IsTuner()) && Bot.GetRemainingCount(CardId.MechaPhantomBeastOLion, 2) > 0)
+                if (Bot.MonsterZone.IsExistingMatchingCard(card => card.Level == targetLevel - 5 && card.IsFaceup() && !card.IsTuner()) && Bot.HasInDeck(CardId.MechaPhantomBeastOLion))
                 {
                     AI.SelectCard(CardId.MechaPhantomBeastOLion);
                 }

--- a/Game/AI/Decks/LightswornShaddoldinosourExecutor.cs
+++ b/Game/AI/Decks/LightswornShaddoldinosourExecutor.cs
@@ -566,7 +566,7 @@ namespace WindBot.Game.AI.Decks
 
         private bool SouleatingOviraptoreff()
         {
-            if (!OvertexCoatlseff_used && Bot.GetRemainingCount(CardId.OvertexCoatls, 3) > 0)
+            if (!OvertexCoatlseff_used && Bot.HasInDeck(CardId.OvertexCoatls))
             {
                 AI.SelectCard(CardId.OvertexCoatls);
                 AI.SelectOption(0);
@@ -982,7 +982,7 @@ namespace WindBot.Game.AI.Decks
 
         private bool FoolishBurialEffect()
         {
-            if (Bot.GetRemainingCount(CardId.DoubleEvolutionPill, 3) > 0)
+            if (Bot.HasInDeck(CardId.DoubleEvolutionPill))
             {
                 if (!OvertexCoatlseff_used)
                 {

--- a/Game/AI/Decks/MalissExecutor.cs
+++ b/Game/AI/Decks/MalissExecutor.cs
@@ -84,16 +84,6 @@ namespace WindBot.Game.AI.Decks
         const int SetcodeDarkWorld = 0x6;
         const int SetcodeSkyStriker = 0x115;
 
-        Dictionary<int, List<int>> DeckCountTable = new Dictionary<int, List<int>>{
-            {3, new List<int> { CardId.MalissP_ChessyCat, CardId.MalissP_MarchHare,CardId.MalissP_WhiteRabbit,CardId.MalissInUnderground,
-                                CardId.BackupIgnister, CardId.MalissP_Dormouse,
-                                 _CardId.AshBlossom,_CardId.InfiniteImpermanence,CardId.DominusImpulse } },
-            {2, new List<int> { _CardId.MaxxC, _CardId.CalledByTheGrave}},
-            {1, new List<int> { CardId.GoldSarcophagus, CardId.TERRAFORMING,
-                                CardId.MalissC_GWC06, CardId.Lancea, CardId.MalissC_MTP07,
-                                _CardId.CrossoutDesignator, CardId.MalissInTheMirror, CardId.WizardIgnister,
-                                CardId.NibiruThePrimalBeing }}
-        };
 
         List<int> notToNegateIdList = new List<int> { 58699500, 20343502, 19403423 };
         List<int> notToDestroySpellTrap = new List<int> { 50005218, 6767771 };
@@ -321,17 +311,6 @@ namespace WindBot.Game.AI.Decks
 
         public override bool OnSelectHand() { return true; }
 
-        public int CheckRemainInDeck(int id)
-        {
-            for (int count = 1; count < 4; ++count)
-            {
-                if (DeckCountTable[count].Contains(id))
-                {
-                    return Bot.GetRemainingCount(id, count);
-                }
-            }
-            return 0;
-        }
         public bool MonsterRepos()
         {
             int selfAttack = Card.Attack + 1;
@@ -800,7 +779,7 @@ namespace WindBot.Game.AI.Decks
                 if (alias != 0 && alias - code < 10) code = alias;
                 if (code == 0) return false;
                 if (DefaultCheckWhetherCardIdIsNegated(code)) return false;
-                if (CheckRemainInDeck(code) > 0)
+                if (Bot.HasInDeck(code))
                 {
                     if (!(Card.Location == CardLocation.SpellZone))
                     {
@@ -1522,7 +1501,7 @@ namespace WindBot.Game.AI.Decks
             {
                 pref = CardId.MalissC_MTP07;
             }
-            if (CheckRemainInDeck(pref) > 0)
+            if (Bot.HasInDeck(pref))
             {
                 return pref;
             }
@@ -1627,15 +1606,15 @@ namespace WindBot.Game.AI.Decks
             int pick = 0;
             if (goldstart || undergroundstart)
             {
-                pick = (CheckRemainInDeck(CardId.MalissP_WhiteRabbit) > 0)
+                pick = Bot.HasInDeck(CardId.MalissP_WhiteRabbit)
                     ? CardId.MalissP_WhiteRabbit
                     : CardId.MalissP_ChessyCat;
             }
             else
             {
-                pick = (CheckRemainInDeck(CardId.MalissP_MarchHare) > 0)
+                pick = Bot.HasInDeck(CardId.MalissP_MarchHare)
                     ? CardId.MalissP_MarchHare
-                    : (CheckRemainInDeck(CardId.MalissP_WhiteRabbit) > 0)
+                    : Bot.HasInDeck(CardId.MalissP_WhiteRabbit)
                     ? CardId.MalissP_WhiteRabbit
                     : CardId.MalissP_ChessyCat;
             }
@@ -1765,9 +1744,9 @@ namespace WindBot.Game.AI.Decks
             if (enemyActivateLancea) { return false; }
             if (Bot.HasInHand(CardId.MalissP_Dormouse) || Bot.HasInHand(CardId.MalissP_WhiteRabbit)) { return false; }
             int pick = 0;
-            if (!Bot.HasInMonstersZone(CardId.MalissP_Dormouse) && CheckRemainInDeck(CardId.MalissP_Dormouse) > 0 && !ssDormouse)
+            if (!Bot.HasInMonstersZone(CardId.MalissP_Dormouse) && Bot.HasInDeck(CardId.MalissP_Dormouse) && !ssDormouse)
             { pick = CardId.MalissP_Dormouse; }
-            else if (!Bot.HasInMonstersZone(CardId.MalissP_WhiteRabbit) && CheckRemainInDeck(CardId.MalissP_WhiteRabbit) > 0 && !ssWhiteRabbit)
+            else if (!Bot.HasInMonstersZone(CardId.MalissP_WhiteRabbit) && Bot.HasInDeck(CardId.MalissP_WhiteRabbit) && !ssWhiteRabbit)
             { pick = CardId.MalissP_WhiteRabbit; }
             else if (madeIt3 && !ssChessyCat)
             { pick = CardId.MalissP_ChessyCat; }
@@ -1785,7 +1764,7 @@ namespace WindBot.Game.AI.Decks
         }
         private bool ExistsForUnderground(int id)
         {
-            return CheckRemainInDeck(id) > 0
+            return Bot.HasInDeck(id)
                 || Bot.HasInHand(id)
                 || Bot.HasInGraveyard(id);
         }
@@ -1891,15 +1870,15 @@ namespace WindBot.Game.AI.Decks
             bool haveWizard = Bot.HasInHand(CardId.WizardIgnister);
 
             int searchId = 0;
-            if (haveWizard && CheckRemainInDeck(CardId.MalissP_MarchHare) > 0 && Bot.Hand.Count > 0)
+            if (haveWizard && Bot.HasInDeck(CardId.MalissP_MarchHare) && Bot.Hand.Count > 0)
                 searchId = CardId.MalissP_MarchHare;
-            else if (CheckRemainInDeck(CardId.MalissP_Dormouse) > 0 && nsplan && Bot.HasInMonstersZone(CardId.SALAMANGREAT_ALMIRAJ))
+            else if (Bot.HasInDeck(CardId.MalissP_Dormouse) && nsplan && Bot.HasInMonstersZone(CardId.SALAMANGREAT_ALMIRAJ))
                 searchId = CardId.MalissP_Dormouse;
-            else if (CheckRemainInDeck(CardId.MalissP_WhiteRabbit) > 0 && nsBackupplan)
+            else if (Bot.HasInDeck(CardId.MalissP_WhiteRabbit) && nsBackupplan)
                 searchId = CardId.MalissP_WhiteRabbit;
-            else if (!haveWizard && CheckRemainInDeck(CardId.WizardIgnister) > 0 && Bot.Hand.Count > 0)
+            else if (!haveWizard && Bot.HasInDeck(CardId.WizardIgnister) && Bot.Hand.Count > 0)
                 searchId = CardId.WizardIgnister;
-            else if (CheckRemainInDeck(CardId.MalissP_WhiteRabbit) > 0)
+            else if (Bot.HasInDeck(CardId.MalissP_WhiteRabbit))
                 searchId = CardId.MalissP_WhiteRabbit;
             else
                 return false;
@@ -2146,7 +2125,7 @@ namespace WindBot.Game.AI.Decks
         {
             if (ActiveUnderground) return false;
             if (HaveUndergroundOnHandOrField()) return false;
-            return CheckRemainInDeck(CardId.MalissInUnderground) > 0;
+            return Bot.HasInDeck(CardId.MalissInUnderground);
         }
         private bool Step2_RedRansom_Search()
         {
@@ -2157,7 +2136,7 @@ namespace WindBot.Game.AI.Decks
             {
                 chooseId = CardId.MalissInUnderground;
             }
-            else if (CheckRemainInDeck(CardId.MalissInTheMirror) > 0)
+            else if (Bot.HasInDeck(CardId.MalissInTheMirror))
             {
                 chooseId = CardId.MalissInTheMirror;
             }
@@ -2265,9 +2244,9 @@ namespace WindBot.Game.AI.Decks
 
             if (GetMMZCount() >= 5) return false;
 
-            int want = !Bot.HasInHand(CardId.WizardIgnister) && CheckRemainInDeck(CardId.WizardIgnister) > 0
+            int want = !Bot.HasInHand(CardId.WizardIgnister) && Bot.HasInDeck(CardId.WizardIgnister)
                        ? CardId.WizardIgnister
-                       : (CheckRemainInDeck(CardId.MalissP_MarchHare) > 0 ? CardId.MalissP_MarchHare : 0);
+                       : (Bot.HasInDeck(CardId.MalissP_MarchHare) ? CardId.MalissP_MarchHare : 0);
             if (want == 0) return false;
 
             AI.SelectCard(want);
@@ -2328,11 +2307,11 @@ namespace WindBot.Game.AI.Decks
 
             int pick = 0;
 
-            if (CheckRemainInDeck(CardId.MalissInTheMirror) > 0 && nsplan)
+            if (Bot.HasInDeck(CardId.MalissInTheMirror) && nsplan)
             {
                 pick = CardId.MalissInTheMirror;
             }
-            else if (CheckRemainInDeck(CardId.MalissInTheMirror) > 0 && NSDorMouse)
+            else if (Bot.HasInDeck(CardId.MalissInTheMirror) && NSDorMouse)
             {
                 pick = CardId.MalissInTheMirror;
             }
@@ -2472,7 +2451,7 @@ namespace WindBot.Game.AI.Decks
 
             foreach (var id in pawnOrder)
             {
-                if (CheckRemainInDeck(id) > 0 && PawnSelfSS_AvailableId(id))
+                if (Bot.HasInDeck(id) && PawnSelfSS_AvailableId(id))
                 {
                     pickId = id;
                     break;
@@ -2493,7 +2472,7 @@ namespace WindBot.Game.AI.Decks
         private bool Wicckid_SearchTuner()
         {
             if (DefaultCheckWhetherCardIdIsNegated(Card.Id)) return false;
-            if (CheckRemainInDeck(CardId.BackupIgnister) <= 0) return false;
+            if (!Bot.HasInDeck(CardId.BackupIgnister)) return false;
             var cost = PickGYCyberseForWicckidCost_Safe();
             if (cost == null)
             {
@@ -2583,9 +2562,9 @@ namespace WindBot.Game.AI.Decks
 
             int pick = 0;
 
-            if (CheckRemainInDeck(CardId.MalissP_WhiteRabbit) > 0 && PawnSelfSS_AvailableId(CardId.MalissP_WhiteRabbit))
+            if (Bot.HasInDeck(CardId.MalissP_WhiteRabbit) && PawnSelfSS_AvailableId(CardId.MalissP_WhiteRabbit))
                 pick = CardId.MalissP_WhiteRabbit;
-            else if (CheckRemainInDeck(CardId.MalissP_ChessyCat) > 0 && PawnSelfSS_AvailableId(CardId.MalissP_ChessyCat))
+            else if (Bot.HasInDeck(CardId.MalissP_ChessyCat) && PawnSelfSS_AvailableId(CardId.MalissP_ChessyCat))
                 pick = CardId.MalissP_ChessyCat;
 
             if (pick == 0) return false;
@@ -3142,10 +3121,10 @@ namespace WindBot.Game.AI.Decks
         }
         private int PickMalissTrapForWB()
         {
-            if (CheckRemainInDeck(CardId.MalissC_GWC06) > 0 || Bot.HasInGraveyard(CardId.MalissC_GWC06))
+            if (Bot.HasInDeck(CardId.MalissC_GWC06) || Bot.HasInGraveyard(CardId.MalissC_GWC06))
                 return CardId.MalissC_GWC06;
 
-            if (CheckRemainInDeck(CardId.MalissC_MTP07) > 0 || Bot.HasInGraveyard(CardId.MalissC_MTP07))
+            if (Bot.HasInDeck(CardId.MalissC_MTP07) || Bot.HasInGraveyard(CardId.MalissC_MTP07))
                 return CardId.MalissC_MTP07;
 
             return 0;
@@ -4081,13 +4060,13 @@ namespace WindBot.Game.AI.Decks
             foreach (var id in monPref)
             {
                 var m = Bot.Graveyard.GetFirstMatchingCard(c => c != null && c.IsCode(id));
-                if (m != null && CheckRemainInDeck(id) > 0) return m;
+                if (m != null && Bot.HasInDeck(id)) return m;
             }
             return null;
         }
         private int PickMTP07SearchId()
         {
-            if (CheckRemainInDeck(CardId.MalissP_MarchHare) > 0)
+            if (Bot.HasInDeck(CardId.MalissP_MarchHare))
                 return CardId.MalissP_MarchHare;
 
             int[] pawnPref = {
@@ -4096,7 +4075,7 @@ namespace WindBot.Game.AI.Decks
                                 CardId.MalissP_ChessyCat
                             };
             foreach (var id in pawnPref)
-                if (CheckRemainInDeck(id) > 0) return id;
+                if (Bot.HasInDeck(id)) return id;
 
             return 0;
         }
@@ -4205,7 +4184,7 @@ namespace WindBot.Game.AI.Decks
 
             if (card.IsCode(CardId.TERRAFORMING) &&
                 (undergroundActive ||
-                 CheckRemainInDeck(CardId.MalissInUnderground) == 0))
+                 !Bot.HasInDeck(CardId.MalissInUnderground)))
             {
                 score -= 500;
             }

--- a/Game/AI/Decks/Monarch506Executor.cs
+++ b/Game/AI/Decks/Monarch506Executor.cs
@@ -323,12 +323,12 @@ namespace WindBot.Game.AI.Decks
                     priority.Add(CardId.DDWarriorLady);
                 }
                 if (!Bot.HasInGraveyard(CardId.TreebornFrog) &&
-                    Bot.GetRemainingCount(CardId.TreebornFrog, 1) > 0)
+                    Bot.HasInDeck(CardId.TreebornFrog))
                     priority.Add(CardId.TreebornFrog);
                 if (!UseNerfedCardEffects &&
                     Bot.HasInHand(CardId.DestinyDraw) &&
                     !Bot.HasInGraveyard(CardId.DestinyHEROMalicious) &&
-                    Bot.GetRemainingCount(CardId.DestinyHEROMalicious, 2) > 0)
+                    Bot.HasInDeck(CardId.DestinyHEROMalicious))
                     priority.Add(CardId.DestinyHEROMalicious);
                 if (DiskCommanderEffectAvailable &&
                     Bot.HasInGraveyard(CardId.DestinyHERODiskCommander))
@@ -555,13 +555,12 @@ namespace WindBot.Game.AI.Decks
                 return false;
 
             List<int> discardPriority = new List<int>();
-            int maliciousRemaining =
-                Bot.GetRemainingCount(CardId.DestinyHEROMalicious, 2);
-            if (maliciousRemaining > 0)
+            bool hasMaliciousRemaining = Bot.HasInDeck(CardId.DestinyHEROMalicious);
+            if (hasMaliciousRemaining)
                 discardPriority.Add(CardId.DestinyHEROMalicious);
             if (DiskCommanderEffectAvailable && HasRevivalAvailable())
                 discardPriority.Add(CardId.DestinyHERODiskCommander);
-            if (maliciousRemaining == 0)
+            if (!hasMaliciousRemaining)
                 discardPriority.Add(CardId.DestinyHEROMalicious);
             if (!DiskCommanderEffectAvailable)
                 discardPriority.Add(CardId.DestinyHERODiskCommander);
@@ -578,7 +577,7 @@ namespace WindBot.Game.AI.Decks
                 return false;
 
             List<int> priority = new List<int>();
-            if (Bot.GetRemainingCount(CardId.ElementalHEROStratos, 1) > 0)
+            if (Bot.HasInDeck(CardId.ElementalHEROStratos))
                 priority.Add(CardId.ElementalHEROStratos);
             if (Util.GetProblematicEnemyMonster(0, true) != null ||
                 Util.IsOneEnemyBetter())
@@ -605,13 +604,13 @@ namespace WindBot.Game.AI.Decks
 
             List<int> priority = new List<int>();
             if (!Bot.HasInGraveyard(CardId.TreebornFrog) &&
-                Bot.GetRemainingCount(CardId.TreebornFrog, 1) > 0)
+                Bot.HasInDeck(CardId.TreebornFrog))
                 priority.Add(CardId.TreebornFrog);
-            if (Bot.GetRemainingCount(CardId.DestinyHEROMalicious, 2) >= 2)
+            if (Bot.GetRemainingCount(CardId.DestinyHEROMalicious) >= 2)
                 priority.Add(CardId.DestinyHEROMalicious);
             if (DiskCommanderEffectAvailable &&
                 HasRevivalAvailable() &&
-                Bot.GetRemainingCount(CardId.DestinyHERODiskCommander, 1) > 0)
+                Bot.HasInDeck(CardId.DestinyHERODiskCommander))
                 priority.Add(CardId.DestinyHERODiskCommander);
             if (priority.Count == 0)
                 return false;
@@ -934,7 +933,7 @@ namespace WindBot.Game.AI.Decks
                 {
                     if (card.IsCode(CardId.TreebornFrog)) return 0;
                     if (card.IsCode(CardId.DestinyHEROMalicious) &&
-                        Bot.GetRemainingCount(CardId.DestinyHEROMalicious, 2) > 0)
+                        Bot.HasInDeck(CardId.DestinyHEROMalicious))
                         return 1;
                     if (card.IsCode(CardId.DestinyHERODiskCommander) &&
                         (!DiskCommanderEffectAvailable || HasRevivalAvailable()))
@@ -1253,26 +1252,26 @@ namespace WindBot.Game.AI.Decks
                 Bot.HasInHandOrInSpellZone(CardId.PhoenixWingWindBlast);
             if (hasDestinyDraw &&
                 !maliciousInGrave &&
-                Bot.GetRemainingCount(CardId.DestinyHEROMalicious, 2) > 0)
+                Bot.HasInDeck(CardId.DestinyHEROMalicious))
                 searchPriority.Add(CardId.DestinyHEROMalicious);
             if (DiskCommanderEffectAvailable &&
                 Bot.HasInGraveyard(CardId.DestinyHERODiskCommander) &&
-                Bot.GetRemainingCount(CardId.DestinyHEROFearMonger, 1) > 0)
+                Bot.HasInDeck(CardId.DestinyHEROFearMonger))
                 searchPriority.Add(CardId.DestinyHEROFearMonger);
             if (hasDestinyDraw &&
-                Bot.GetRemainingCount(CardId.DestinyHERODiskCommander, 1) > 0)
+                Bot.HasInDeck(CardId.DestinyHERODiskCommander))
                 searchPriority.Add(CardId.DestinyHERODiskCommander);
             if (!hasDestinyDraw &&
                 !hasPhoenixWingWindBlast &&
                 DiskCommanderEffectAvailable &&
-                Bot.GetRemainingCount(CardId.DestinyHERODiskCommander, 1) > 0)
+                Bot.HasInDeck(CardId.DestinyHERODiskCommander))
             {
                 searchPriority.Add(CardId.DestinyHERODiskCommander);
             }
             if (!maliciousInGrave &&
-                Bot.GetRemainingCount(CardId.DestinyHEROMalicious, 2) > 0)
+                Bot.HasInDeck(CardId.DestinyHEROMalicious))
                 searchPriority.Add(CardId.DestinyHEROMalicious);
-            if (Bot.GetRemainingCount(CardId.DestinyHEROFearMonger, 1) > 0)
+            if (Bot.HasInDeck(CardId.DestinyHEROFearMonger))
                 searchPriority.Add(CardId.DestinyHEROFearMonger);
 
             int otherHeroCount = Bot.GetMonsters().Count(card =>
@@ -1459,7 +1458,7 @@ namespace WindBot.Game.AI.Decks
         private bool MonsterRepos()
         {
             if (Card.IsCode(CardId.GravekeepersSpy) && Card.IsFacedown())
-                return Bot.GetRemainingCount(CardId.GravekeepersSpy, 2) > 0;
+                return Bot.HasInDeck(CardId.GravekeepersSpy);
 
             if (Card.IsCode(
                 CardId.TreebornFrog,

--- a/Game/AI/Decks/Monarch506Executor.cs
+++ b/Game/AI/Decks/Monarch506Executor.cs
@@ -606,7 +606,7 @@ namespace WindBot.Game.AI.Decks
             if (!Bot.HasInGraveyard(CardId.TreebornFrog) &&
                 Bot.HasInDeck(CardId.TreebornFrog))
                 priority.Add(CardId.TreebornFrog);
-            if (Bot.GetRemainingCount(CardId.DestinyHEROMalicious) >= 2)
+            if (Bot.GetCardCountInDeck(CardId.DestinyHEROMalicious) >= 2)
                 priority.Add(CardId.DestinyHEROMalicious);
             if (DiskCommanderEffectAvailable &&
                 HasRevivalAvailable() &&

--- a/Game/AI/Decks/OrcustExecutor.cs
+++ b/Game/AI/Decks/OrcustExecutor.cs
@@ -499,7 +499,7 @@ namespace WindBot.Game.AI.Decks
         {
             if (!Bot.HasInExtra(CardId.BorreloadSavageDragon))
                 return false;
-            if (!Bot.HasInHand(CardId.JetSynchron) && Bot.GetRemainingCount(CardId.JetSynchron, 1) == 0)
+            if (!Bot.HasInHand(CardId.JetSynchron) && !Bot.HasInDeck(CardId.JetSynchron))
                 return false;
 
             int[] matids = new[] {
@@ -582,7 +582,7 @@ namespace WindBot.Game.AI.Decks
         {
             if (ActivateDescription == -1 || (ActivateDescription == Util.GetStringId(CardId.ShootingRiserDragon, 0)))
             {
-                if (Bot.MonsterZone.IsExistingMatchingCard(card => card.Level == 3 && card.IsFaceup() && !card.IsTuner()) && Bot.GetRemainingCount(CardId.MaxxC, 3) > 0)
+                if (Bot.MonsterZone.IsExistingMatchingCard(card => card.Level == 3 && card.IsFaceup() && !card.IsTuner()) && Bot.HasInDeck(CardId.MaxxC))
                 {
                     AI.SelectCard(CardId.MaxxC);
                 }
@@ -682,7 +682,7 @@ namespace WindBot.Game.AI.Decks
         {
             if (Bot.GetHandCount() == 0)
                 return false;
-            if (Bot.GetRemainingCount(CardId.OrcustKnightmare, 2) == 0)
+            if (!Bot.HasInDeck(CardId.OrcustKnightmare))
                 return false;
             AI.SelectPlace(Zones.ExtraMonsterZones);
             return true;
@@ -716,13 +716,13 @@ namespace WindBot.Game.AI.Decks
                 AI.SelectNextCard(CardId.OrcustHarpHorror);
                 return true;
             }
-            else if (!Bot.HasInGraveyard(CardId.WorldLegacyWorldWand) && Bot.GetRemainingCount(CardId.WorldLegacyWorldWand, 1) > 0)
+            else if (!Bot.HasInGraveyard(CardId.WorldLegacyWorldWand) && Bot.HasInDeck(CardId.WorldLegacyWorldWand))
             {
                 AI.SelectCard(CardId.GalateaTheOrcustAutomaton);
                 AI.SelectNextCard(CardId.WorldLegacyWorldWand);
                 return true;
             }
-            else if (!Bot.HasInGraveyard(CardId.OrcustCymbalSkeleton) && Bot.GetRemainingCount(CardId.OrcustCymbalSkeleton, 1) > 0 && Bot.HasInGraveyard(CardId.SheorcustDingirsu) && !SheorcustDingirsuSummoned)
+            else if (!Bot.HasInGraveyard(CardId.OrcustCymbalSkeleton) && Bot.HasInDeck(CardId.OrcustCymbalSkeleton) && Bot.HasInGraveyard(CardId.SheorcustDingirsu) && !SheorcustDingirsuSummoned)
             {
                 AI.SelectCard(CardId.GalateaTheOrcustAutomaton);
                 AI.SelectNextCard(CardId.OrcustCymbalSkeleton);
@@ -748,9 +748,9 @@ namespace WindBot.Game.AI.Decks
 
         private bool RustyBardicheSummon()
         {
-            //if (Bot.GetRemainingCount(CardId.ThePhantomKnightsofAncientCloak, 1) == 0 && Bot.GetRemainingCount(CardId.ThePhantomKnightsofSilentBoots, 1) == 0)
+            //if (!Bot.HasInDeck(CardId.ThePhantomKnightsofAncientCloak) && !Bot.HasInDeck(CardId.ThePhantomKnightsofSilentBoots))
             //    return false;
-            //if (Bot.GetRemainingCount(CardId.ThePhantomKnightsofShadeBrigandine, 1) == 0 && Bot.GetRemainingCount(CardId.PhantomKnightsFogBlade, 2) == 0)
+            //if (!Bot.HasInDeck(CardId.ThePhantomKnightsofShadeBrigandine) && !Bot.HasInDeck(CardId.PhantomKnightsFogBlade))
             //    return false;
             IList<ClientCard> mats = Bot.MonsterZone.GetMatchingCards(card => card.IsCode(CardId.GalateaTheOrcustAutomaton));
             ClientCard mat2 = Bot.MonsterZone.GetMatchingCards(card => card.IsCode(CardId.OrcustCymbalSkeleton)).FirstOrDefault();
@@ -1150,7 +1150,7 @@ namespace WindBot.Game.AI.Decks
                     AI.SelectCard(target);
                     return true;
                 }
-                if(!Bot.HasInHand(CardId.OrcustHarpHorror) && Bot.GetRemainingCount(CardId.OrcustHarpHorror, 2) > 1)
+                if(!Bot.HasInHand(CardId.OrcustHarpHorror) && Bot.GetRemainingCount(CardId.OrcustHarpHorror) > 1)
                 {
                     AI.SelectCard(CardId.OrcustHarpHorror);
                     return true;

--- a/Game/AI/Decks/OrcustExecutor.cs
+++ b/Game/AI/Decks/OrcustExecutor.cs
@@ -1150,7 +1150,7 @@ namespace WindBot.Game.AI.Decks
                     AI.SelectCard(target);
                     return true;
                 }
-                if(!Bot.HasInHand(CardId.OrcustHarpHorror) && Bot.GetRemainingCount(CardId.OrcustHarpHorror) > 1)
+                if(!Bot.HasInHand(CardId.OrcustHarpHorror) && Bot.GetCardCountInDeck(CardId.OrcustHarpHorror) > 1)
                 {
                     AI.SelectCard(CardId.OrcustHarpHorror);
                     return true;

--- a/Game/AI/Decks/PumpkingExecutor.cs
+++ b/Game/AI/Decks/PumpkingExecutor.cs
@@ -462,7 +462,7 @@ namespace WindBot.Game.AI.Decks
                 || Bot.HasInHand(CardId.DeltaOfInvitation)
                 || Bot.HasInHand(CardId.Terraforming);
             bool eldlichAccess = Bot.HasInGraveyard(CardId.EldlichTheGoldenLord)
-                || CheckRemainInDeck(CardId.EldlichTheGoldenLord) > 0;
+                || Bot.HasInDeck(CardId.EldlichTheGoldenLord);
             return fieldAccess && eldlichAccess;
         }
 
@@ -671,7 +671,7 @@ namespace WindBot.Game.AI.Decks
                 || pumpkingSummonEffectAttempted
                 || pumpkingSummonEffectResolved
                 || GetOpenMainMonsterZoneCount() < 2
-                || CheckRemainInDeck(deckFollowUpId) <= 0)
+                || !Bot.HasInDeck(deckFollowUpId))
             {
                 return null;
             }
@@ -1505,23 +1505,22 @@ namespace WindBot.Game.AI.Decks
 
         private bool HasSettableCallForPumpking()
         {
-
-
-            return CheckRemainInDeck(CardId.CallOfTheHaunted) > 0
+            return Bot.HasInDeck(CardId.CallOfTheHaunted)
                 || Bot.Graveyard.Any(c => c != null
                     && c.IsCode(CardId.CallOfTheHaunted));
         }
 
         private bool HasPumpkingDeckSummonTargetInDeck()
         {
-
-            return CheckRemainInDeck(CardId.Hublot) > 0
-                || CheckRemainInDeck(CardId.GreatMammothOfTheNetherworld) > 0
-                || CheckRemainInDeck(CardId.ChangshiTheSpiridao) > 0
-                || CheckRemainInDeck(CardId.StareOfTheSnakeHair) > 0
-                || CheckRemainInDeck(CardId.OfficiatingReverie) > 0
-                || CheckRemainInDeck(CardId.ArmyOfTheHaunted) > 0
-                || CheckRemainInDeck(CardId.VampireGrace) > 0;
+            return Bot.HasInDeck(
+                CardId.Hublot,
+                CardId.GreatMammothOfTheNetherworld,
+                CardId.ChangshiTheSpiridao,
+                CardId.StareOfTheSnakeHair,
+                CardId.OfficiatingReverie,
+                CardId.ArmyOfTheHaunted,
+                CardId.VampireGrace
+            );
         }
 
         private bool CanUsePumpkingHandEffectNow()
@@ -1987,33 +1986,7 @@ namespace WindBot.Game.AI.Decks
             return Util.CheckSelectCount(result, cards, min, max);
         }
 
-        private int GetInitialDeckCount(int id)
-        {
-            if (id == CardId.PumpkingTheKingOfGraveGhosts
-                || id == CardId.StareOfTheSnakeHair
-                || IsHublotId(id)
-                || id == CardId.EctoplasmicFortification
-                || id == CardId.DeltaOfInvitation
-                || id == CardId.InfiniteImpermanence
-                || id == CardId.GhostBelle
-                || id == CardId.CallOfTheHaunted)
-            {
-                return 3;
-            }
 
-            if (id == CardId.AshBlossom
-                || id == CardId.DominusImpulse)
-            {
-                return 2;
-            }
-
-            return 1;
-        }
-
-        private int CheckRemainInDeck(int id)
-        {
-            return Bot.GetRemainingCount(id, GetInitialDeckCount(id));
-        }
 
         private bool HasPumpkingInHand()
         {
@@ -2049,11 +2022,11 @@ namespace WindBot.Game.AI.Decks
 
             if (!HasHublotInHand())
             {
-                if (CheckRemainInDeck(CardId.Hublot) > 0)
+                if (Bot.HasInDeck(CardId.Hublot))
                     return CardId.Hublot;
 
                 if (!HasPumpkingInHand()
-                    && CheckRemainInDeck(CardId.PumpkingTheKingOfGraveGhosts) > 0)
+                    && Bot.HasInDeck(CardId.PumpkingTheKingOfGraveGhosts))
                 {
                     return CardId.PumpkingTheKingOfGraveGhosts;
                 }
@@ -2062,7 +2035,7 @@ namespace WindBot.Game.AI.Decks
             }
 
             if (!HasPumpkingInHand()
-                && CheckRemainInDeck(CardId.PumpkingTheKingOfGraveGhosts) > 0)
+                && Bot.HasInDeck(CardId.PumpkingTheKingOfGraveGhosts))
             {
                 return CardId.PumpkingTheKingOfGraveGhosts;
             }
@@ -2541,15 +2514,15 @@ namespace WindBot.Game.AI.Decks
 
 
             bool ectoplasmicHasStarterTarget =
-                (!HasHublotInHand() && CheckRemainInDeck(CardId.Hublot) > 0)
+                (!HasHublotInHand() && Bot.HasInDeck(CardId.Hublot))
                 || (HasHublotInHand() && !HasPumpkingInHand()
-                    && CheckRemainInDeck(CardId.PumpkingTheKingOfGraveGhosts) > 0);
+                    && Bot.HasInDeck(CardId.PumpkingTheKingOfGraveGhosts));
 
             return Bot.GetMonsterCount() == 0
                 && !ectoplasmicSearchUsed
                 && !Bot.HasInHand(CardId.EctoplasmicFortification)
                 && Bot.HasInHand(CardId.StareOfTheSnakeHair)
-                && CheckRemainInDeck(CardId.EctoplasmicFortification) > 0
+                && Bot.HasInDeck(CardId.EctoplasmicFortification)
                 && ectoplasmicHasStarterTarget
                 && DefaultCheckWhetherBotCanSearch();
         }
@@ -2560,7 +2533,7 @@ namespace WindBot.Game.AI.Decks
                 && !HasPumpkingInHand()
                 && Bot.GetMonsterCount() == 0
                 && Bot.HasInHand(CardId.EctoplasmicFortification)
-                && CheckRemainInDeck(CardId.PumpkingTheKingOfGraveGhosts) > 0
+                && Bot.HasInDeck(CardId.PumpkingTheKingOfGraveGhosts)
                 && DefaultCheckWhetherBotCanSearch();
         }
 
@@ -2613,7 +2586,7 @@ namespace WindBot.Game.AI.Decks
                 && HasSettableCallForPumpking()
                 && HasOpenSpellZone()
                 && GetOpenMainMonsterZoneCount() >= 3
-                && CheckRemainInDeck(CardId.EldlichTheGoldenLord) > 0
+                && Bot.HasInDeck(CardId.EldlichTheGoldenLord)
                 && cards != null
                 && cards.Any(c => c != null && c.IsCode(CardId.VampireGrace));
         }
@@ -2662,22 +2635,22 @@ namespace WindBot.Game.AI.Decks
 
             bool hublotAccessible = HasHublotInHand()
                 || Bot.HasInMonstersZone(CardId.Hublot, faceUp: true)
-                || CheckRemainInDeck(CardId.Hublot) > 0
+                || Bot.HasInDeck(CardId.Hublot)
                 || (cards != null && cards.Any(c => c != null && IsHublot(c)));
-            bool reverieAvailable = CheckRemainInDeck(CardId.OfficiatingReverie) > 0
+            bool reverieAvailable = Bot.HasInDeck(CardId.OfficiatingReverie)
                 || (cards != null && cards.Any(c => c != null
                     && c.Location == CardLocation.Deck
                     && c.IsCode(CardId.OfficiatingReverie)));
             bool pumpkingAvailable = HasPumpkingAccessible()
-                || CheckRemainInDeck(CardId.PumpkingTheKingOfGraveGhosts) > 0;
+                || Bot.HasInDeck(CardId.PumpkingTheKingOfGraveGhosts);
             bool callAvailable = HasAnyCall() || HasSettableCallForPumpking();
 
             return hublotAccessible
                 && reverieAvailable
                 && pumpkingAvailable
                 && callAvailable
-                && CheckRemainInDeck(CardId.ArmyOfTheHaunted) > 0
-                && CheckRemainInDeck(CardId.EldlichTheGoldenLord) > 0
+                && Bot.HasInDeck(CardId.ArmyOfTheHaunted)
+                && Bot.HasInDeck(CardId.EldlichTheGoldenLord)
                 && Bot.HasInExtra(CardId.PumpkingTheGreatGhostKing)
                 && Bot.HasInExtra(CardId.OfficiatorOfDoomSamuel)
                 && Bot.HasInExtra(CardId.TheUndyingLegion)
@@ -2695,7 +2668,7 @@ namespace WindBot.Game.AI.Decks
 
             if (HasChangshiOnField()
                 && !changshiMillAttempted
-                && CheckRemainInDeck(CardId.EldlichTheGoldenLord) > 0)
+                && Bot.HasInDeck(CardId.EldlichTheGoldenLord))
             {
                 return true;
             }
@@ -2859,7 +2832,7 @@ namespace WindBot.Game.AI.Decks
                 ? new List<ClientCard>()
                 : cards.Where(c => c != null && c.Location == CardLocation.Deck).ToList();
             Func<int, bool> available = id => cards == null
-                ? CheckRemainInDeck(id) > 0
+                ? Bot.HasInDeck(id)
                 : deckCards.Any(c => c.IsCode(id));
 
             if (changshiHandRescueRouteActive
@@ -3208,7 +3181,7 @@ namespace WindBot.Game.AI.Decks
                 && !HasGreatPumpkingOnField()
                 && !greatPumpkingSearchAttempted
                 && !greatPumpkingSearchResolved
-                && CheckRemainInDeck(CardId.PumpkingTheKingOfGraveGhosts) > 0
+                && Bot.HasInDeck(CardId.PumpkingTheKingOfGraveGhosts)
                 && DefaultCheckWhetherBotCanSearch();
             if (liveGreatPumpkingSearch && GetRank6Materials(true).Count >= 2)
                 return true;
@@ -3278,7 +3251,7 @@ namespace WindBot.Game.AI.Decks
 
             bool snakehairBridge = Bot.HasInHand(CardId.StareOfTheSnakeHair)
                 && (Bot.HasInHand(CardId.EctoplasmicFortification)
-                    || CheckRemainInDeck(CardId.EctoplasmicFortification) > 0);
+                    || Bot.HasInDeck(CardId.EctoplasmicFortification));
             if (Bot.HasInHand(CardId.PumpkingTheKingOfGraveGhosts)
                 || HasHublotInHand()
                 || Bot.HasInHand(CardId.EctoplasmicFortification)
@@ -3322,7 +3295,7 @@ namespace WindBot.Game.AI.Decks
             }
 
             bool eldlichCanReachGrave = Bot.HasInGraveyard(CardId.EldlichTheGoldenLord)
-                || CheckRemainInDeck(CardId.EldlichTheGoldenLord) > 0;
+                || Bot.HasInDeck(CardId.EldlichTheGoldenLord);
             if (!eldlichCanReachGrave)
                 return false;
 
@@ -3357,7 +3330,7 @@ namespace WindBot.Game.AI.Decks
                 return false;
             bool armyAvailable = Bot.HasInHand(CardId.ArmyOfTheHaunted)
                 || Bot.HasInGraveyard(CardId.ArmyOfTheHaunted)
-                || CheckRemainInDeck(CardId.ArmyOfTheHaunted) > 0;
+                || Bot.HasInDeck(CardId.ArmyOfTheHaunted);
             if (!ashAvailable || !armyAvailable)
                 return false;
             if (!Bot.HasInExtra(CardId.PumpkingTheGreatGhostKing)
@@ -3413,13 +3386,14 @@ namespace WindBot.Game.AI.Decks
                 return null;
 
 
-            bool hasPumpkingDeckFollowUp =
-                CheckRemainInDeck(CardId.ChangshiTheSpiridao) > 0
-                || CheckRemainInDeck(CardId.ArmyOfTheHaunted) > 0
-                || CheckRemainInDeck(CardId.OfficiatingReverie) > 0
-                || CheckRemainInDeck(CardId.Hublot) > 0
-                || CheckRemainInDeck(CardId.GreatMammothOfTheNetherworld) > 0
-                || CheckRemainInDeck(CardId.StareOfTheSnakeHair) > 0;
+            bool hasPumpkingDeckFollowUp = Bot.HasInDeck(
+                CardId.ChangshiTheSpiridao,
+                CardId.ArmyOfTheHaunted,
+                CardId.OfficiatingReverie,
+                CardId.Hublot,
+                CardId.GreatMammothOfTheNetherworld,
+                CardId.StareOfTheSnakeHair
+            );
             if (!pumpkingSummonEffectAttempted
                 && !pumpkingSummonEffectResolved
                 && GetOpenMainMonsterZoneCount() >= 2
@@ -4189,7 +4163,7 @@ namespace WindBot.Game.AI.Decks
             if (pumpking != null && !pumpkingSummonEffectAttempted)
             {
                 if (snakehairTarget != null
-                    && CheckRemainInDeck(CardId.StareOfTheSnakeHair) > 0)
+                    && Bot.HasInDeck(CardId.StareOfTheSnakeHair))
                 {
                     pendingSnakehairDisableTarget = snakehairTarget;
                     pendingMammothDestroyTarget = null;
@@ -4199,7 +4173,7 @@ namespace WindBot.Game.AI.Decks
                 }
 
                 if (mammothTarget != null
-                    && CheckRemainInDeck(CardId.GreatMammothOfTheNetherworld) > 0)
+                    && Bot.HasInDeck(CardId.GreatMammothOfTheNetherworld))
                 {
                     pendingMammothDestroyTarget = mammothTarget;
                     pendingSnakehairDisableTarget = null;
@@ -5422,15 +5396,15 @@ namespace WindBot.Game.AI.Decks
 
             if (ectoplasmicSearchUsed
                 || Bot.HasInHand(CardId.EctoplasmicFortification)
-                || CheckRemainInDeck(CardId.EctoplasmicFortification) <= 0)
+                || !Bot.HasInDeck(CardId.EctoplasmicFortification))
             {
                 return false;
             }
 
             bool ectoplasmicHasStarterTarget =
-                (!HasHublotInHand() && CheckRemainInDeck(CardId.Hublot) > 0)
+                (!HasHublotInHand() && Bot.HasInDeck(CardId.Hublot))
                 || (HasHublotInHand() && !HasPumpkingInHand()
-                    && CheckRemainInDeck(CardId.PumpkingTheKingOfGraveGhosts) > 0);
+                    && Bot.HasInDeck(CardId.PumpkingTheKingOfGraveGhosts));
             if (!ectoplasmicHasStarterTarget)
                 return false;
 
@@ -5510,12 +5484,12 @@ namespace WindBot.Game.AI.Decks
 
             if (Duel.Player == 1)
             {
-                bool hasSnakehairLine = CheckRemainInDeck(CardId.StareOfTheSnakeHair) > 0
+                bool hasSnakehairLine = Bot.HasInDeck(CardId.StareOfTheSnakeHair)
                     && ((pendingSnakehairDisableTarget != null
                             && IsLiveEnemyMonster(pendingSnakehairDisableTarget)
                             && pendingSnakehairDisableTarget.IsAttack())
                         || Enemy.GetMonsters().Any(ShouldPreemptWithSnakehair));
-                bool hasMammothLine = CheckRemainInDeck(CardId.GreatMammothOfTheNetherworld) > 0
+                bool hasMammothLine = Bot.HasInDeck(CardId.GreatMammothOfTheNetherworld)
                     && ((pendingMammothDestroyTarget != null
                             && CanMammothDestroyTarget(pendingMammothDestroyTarget))
                         || GetMammothPreemptTarget() != null);
@@ -5563,7 +5537,7 @@ namespace WindBot.Game.AI.Decks
             IEnumerable<ClientCard> candidates = null)
         {
             return candidates == null
-                ? CheckRemainInDeck(cardId) > 0
+                ? Bot.HasInDeck(cardId)
                 : candidates.Any(c => c != null && c.IsCode(cardId));
         }
 
@@ -8461,8 +8435,8 @@ namespace WindBot.Game.AI.Decks
         {
             if (desc == Util.GetStringId(CardId.DeltaOfInvitation, 3))
             {
-                return CheckRemainInDeck(CardId.EldlichTheGoldenLord) > 0
-                    || CheckRemainInDeck(CardId.DoomkingBalerdroch) > 0;
+                return Bot.HasInDeck(CardId.EldlichTheGoldenLord)
+                    || Bot.HasInDeck(CardId.DoomkingBalerdroch);
             }
 
             if (desc == Util.GetStringId(CardId.Hublot, 3))

--- a/Game/AI/Decks/PureWindsExecutor.cs
+++ b/Game/AI/Decks/PureWindsExecutor.cs
@@ -567,7 +567,7 @@ namespace WindBot.Game.AI.Decks
         private bool SpeedroidTaketomborgeff()
         {
             if (DefaultCheckWhetherCardIsNegated(Card)) return false;
-            if ((Bot.GetRemainingCount(CardId.SpeedroidRedEyedDice, 1) >= 1) &&
+            if (Bot.HasInDeck(CardId.SpeedroidRedEyedDice) &&
                 Bot.HasInMonstersZone(CardId.SpeedroidTerrortop))
             {
                 AI.SelectCard(CardId.SpeedroidRedEyedDice);
@@ -605,7 +605,7 @@ namespace WindBot.Game.AI.Decks
             if (Enemy.HasInMonstersZone(CardId.ElShaddollWinda)) return false;
             if (WindwitchGlassBelleff_used && !Bot.HasInHand(CardId.WindwitchSnowBell)) return false;
             //AI.SelectPlace(Zones.z2, 1);
-            if (Bot.GetRemainingCount(CardId.WindwitchGlassBell, 3) >= 1)
+            if (Bot.HasInDeck(CardId.WindwitchGlassBell))
             {
                 AI.SelectCard(CardId.WindwitchGlassBell);
             }

--- a/Game/AI/Decks/RainbowExecutor.cs
+++ b/Game/AI/Decks/RainbowExecutor.cs
@@ -403,7 +403,7 @@ namespace WindBot.Game.AI.Decks
 
         private bool TraptrixRafflesiaSummon()
         {
-            if (Util.IsTurn1OrMain2() && (Bot.GetRemainingCount(CardId.BottomlessTrapHole, 1) + Bot.GetRemainingCount(CardId.TraptrixTrapHoleNightmare, 1)) > 0)
+            if (Util.IsTurn1OrMain2() && Bot.HasInDeck(CardId.BottomlessTrapHole, CardId.TraptrixTrapHoleNightmare))
             {
                 AI.SelectPosition(CardPosition.FaceUpDefence);
                 return true;

--- a/Game/AI/Decks/Rank8Executor.cs
+++ b/Game/AI/Decks/Rank8Executor.cs
@@ -402,7 +402,7 @@ namespace WindBot.Game.AI.Decks
             List<int> worthwhileHorusMonsters = HorusMonsterIds
                 .Where(id => !_horusSpecialSummonedThisTurn.Contains(id)
                     && !Bot.HasInGraveyard(id)
-                    && Bot.GetRemainingCount(id, id == CardId.ImsetyGloryOfHorus ? 3 : 2) > 0)
+                    && Bot.HasInDeck(id))
                 .ToList();
             if (worthwhileHorusMonsters.Count == 0)
                 return false;

--- a/Game/AI/Decks/RyzealExecutor.cs
+++ b/Game/AI/Decks/RyzealExecutor.cs
@@ -918,7 +918,7 @@ namespace WindBot.Game.AI.Decks
                     List<ClientCard> faceDownMonsters = botMonsters.Where(card => card.IsFacedown()).ToList();
                     banishList.AddRange(faceDownMonsters);
                     List<ClientCard> dumpMainMonsterList = botMonsters.Where(card => !banishList.Contains(card)
-                        && Bot.HasInDeck(card.Id)).ToList();
+                        && Bot.HasInDeck(card.GetNonAltartCode())).ToList();
                     dumpMainMonsterList.Sort(CardContainer.CompareCardAttack);
                     banishList.AddRange(dumpMainMonsterList);
 
@@ -933,7 +933,7 @@ namespace WindBot.Game.AI.Decks
                     banishList.AddRange(Util.ShuffleList(faceDownSpells));
 
                     List<ClientCard> uniqueMainMonster = botMonsters.Where(card => !banishList.Contains(card)
-                        && !card.HasType(CardType.Fusion | CardType.Synchro | CardType.Xyz | CardType.Link) && !Bot.HasInDeck(card.Id)).ToList();
+                        && !card.HasType(CardType.Fusion | CardType.Synchro | CardType.Xyz | CardType.Link) && !Bot.HasInDeck(card.GetNonAltartCode())).ToList();
                     uniqueMainMonster.Sort(CardContainer.CompareCardAttack);
                     banishList.AddRange(uniqueMainMonster);
 

--- a/Game/AI/Decks/RyzealExecutor.cs
+++ b/Game/AI/Decks/RyzealExecutor.cs
@@ -2786,7 +2786,7 @@ namespace WindBot.Game.AI.Decks
             foreach (int id in checkIdList)
             {
                 ClientCard target = Bot.Graveyard.FirstOrDefault(c => c.IsCode(id));
-                if (target != null && (Bot.GetRemainingCount(id) + Bot.ExtraDeck.Count(c => c.IsCode(id)) + Bot.Hand.Count(c => c.IsCode(id))) == 0)
+                if (target != null && (Bot.GetCardCountInDeck(id) + Bot.ExtraDeck.Count(c => c.IsCode(id)) + Bot.Hand.Count(c => c.IsCode(id))) == 0)
                 {
                     if (target.HasType(CardType.Xyz) && GetLevel4CountOnField() == 1) continue;
                     targetList.Add(target);
@@ -2814,7 +2814,7 @@ namespace WindBot.Game.AI.Decks
             List<int> checkIdList = new List<int> { CardId.RyzealPlugIn, CardId.RyzealDuodrive, CardId.RyzealDeadnader, CardId.NodeRyzeal, CardId.ExRyzeal, CardId.IceRyzeal, CardId.ThodeRyzeal };
             foreach (int id in checkIdList)
             {
-                int remainCount = Bot.GetRemainingCount(id) + Bot.ExtraDeck.Count(c => c.IsCode(id));
+                int remainCount = Bot.GetCardCountInDeck(id) + Bot.ExtraDeck.Count(c => c.IsCode(id));
                 if (!countDict.ContainsKey(remainCount))
                 {
                     countDict.Add(remainCount, new List<int>());
@@ -3074,7 +3074,7 @@ namespace WindBot.Game.AI.Decks
         {
             bool checkFlag = Duel.MainPhase.SpecialSummonableCards.Any(c => c.IsCode(CardId.RyzealDuodrive));
             checkFlag &= !Bot.HasInMonstersZone(CardId.RyzealDuodrive, true, true, true);
-            checkFlag &= Bot.GetRemainingCount(new[] { CardId.IceRyzeal, CardId.ThodeRyzeal, CardId.NodeRyzeal, CardId.ExRyzeal, CardId.RyzealPlugIn, CardId.RyzealCross }) >= 2;
+            checkFlag &= Bot.GetCardCountInDeck(new[] { CardId.IceRyzeal, CardId.ThodeRyzeal, CardId.NodeRyzeal, CardId.ExRyzeal, CardId.RyzealPlugIn, CardId.RyzealCross }) >= 2;
             checkFlag &= !DefaultCheckWhetherCardIdIsNegated(CardId.RyzealDuodrive);
             checkFlag &= !activatedCardIdList.Contains(CardId.RyzealDuodrive + 1);
             checkFlag &= !CheckWhetherNegated(true, true, CardType.Monster);

--- a/Game/AI/Decks/RyzealExecutor.cs
+++ b/Game/AI/Decks/RyzealExecutor.cs
@@ -162,13 +162,6 @@ namespace WindBot.Game.AI.Decks
         {
             1906812, 38811586, 41373230, 44146295, 51409648, 51409648, 87746184
         };
-        Dictionary<int, List<int>> DeckCountTable = new Dictionary<int, List<int>>{
-            {3, new List<int> { CardId.IceRyzeal, CardId.ThodeRyzeal, CardId.ExRyzeal, _CardId.AshBlossom, _CardId.EffectVeiler, CardId.SeventhTachyon,
-                                _CardId.InfiniteImpermanence}},
-            {2, new List<int> { _CardId.MulcharmyFuwalos, _CardId.GhostOgreAndSnowRabbit, _CardId.MaxxC, _CardId.PotOfDesires, _CardId.CalledByTheGrave }},
-            {1, new List<int> { CardId.NodeRyzeal, _CardId.MulcharmyPurulia, _CardId.MulcharmyNyalus, _CardId.LockBird, CardId.TripleTacticsTalent,
-                                CardId.Bonfire, CardId.RyzealPlugIn, _CardId.CrossoutDesignator, CardId.RyzealCross}}
-        };
         List<int> NotToDestroySpellTrap = new List<int> { 50005218, 6767771 };
         List<int> targetNegateIdList = new List<int> {
             _CardId.EffectVeiler, _CardId.InfiniteImpermanence, _CardId.GhostMournerMoonlitChill, _CardId.BreakthroughSkill, CardId.MereologicAggregator, 74003290, 67037924,
@@ -222,30 +215,7 @@ namespace WindBot.Game.AI.Decks
             return true;
         }
 
-        /// <summary>
-        /// Check remain cards in deck
-        /// </summary>
-        /// <param name="id">Card's ID</param>
-        public int CheckRemainInDeck(int id)
-        {
-            for (int count = 1; count < 4; ++count)
-            {
-                if (DeckCountTable[count].Contains(id)) {
-                    return Bot.GetRemainingCount(id, count);
-                }
-            }
-            return 0;
-        }
 
-        public int CheckRemainInDeck(params int[] ids)
-        {
-            int sum = 0;
-            foreach (int id in ids)
-            {
-                sum += CheckRemainInDeck(id);
-            }
-            return sum;
-        }
 
         public bool CheckWhetherHaveFinalMonster()
         {
@@ -945,7 +915,7 @@ namespace WindBot.Game.AI.Decks
                     List<ClientCard> faceDownMonsters = botMonsters.Where(card => card.IsFacedown()).ToList();
                     banishList.AddRange(faceDownMonsters);
                     List<ClientCard> dumpMainMonsterList = botMonsters.Where(card => !banishList.Contains(card)
-                        && CheckRemainInDeck(card.Id) > 0).ToList();
+                        && Bot.HasInDeck(card.Id)).ToList();
                     dumpMainMonsterList.Sort(CardContainer.CompareCardAttack);
                     banishList.AddRange(dumpMainMonsterList);
 
@@ -960,7 +930,7 @@ namespace WindBot.Game.AI.Decks
                     banishList.AddRange(Util.ShuffleList(faceDownSpells));
 
                     List<ClientCard> uniqueMainMonster = botMonsters.Where(card => !banishList.Contains(card)
-                        && !card.HasType(CardType.Fusion | CardType.Synchro | CardType.Xyz | CardType.Link) && CheckRemainInDeck(card.Id) == 0).ToList();
+                        && !card.HasType(CardType.Fusion | CardType.Synchro | CardType.Xyz | CardType.Link) && !Bot.HasInDeck(card.Id)).ToList();
                     uniqueMainMonster.Sort(CardContainer.CompareCardAttack);
                     banishList.AddRange(uniqueMainMonster);
 
@@ -1948,7 +1918,7 @@ namespace WindBot.Game.AI.Decks
                 if (flag) return false;
             }
             bool spsummonFlag = lv4Count == 1;
-            spsummonFlag |= !CheckWhetherNegated(true, true, CardType.Monster) && CheckRemainInDeck(CardId.IceRyzeal, CardId.ExRyzeal) > 0
+            spsummonFlag |= !CheckWhetherNegated(true, true, CardType.Monster) && Bot.HasInDeck(CardId.IceRyzeal, CardId.ExRyzeal)
                 && !activatedCardIdList.Contains(CardId.ThodeRyzeal) && !lockBirdSolved;
             if (GetLevel4CountOnField() == 0)
             {
@@ -2137,7 +2107,7 @@ namespace WindBot.Game.AI.Decks
                 }
                 if (discardId == CardId.Number104Masquerade)
                 {
-                    if (CheckRemainInDeck(CardId.SeventhTachyon) > 0 || Bot.HasInHandOrInSpellZone(CardId.Number104Masquerade))
+                    if (Bot.HasInDeck(CardId.SeventhTachyon) || Bot.HasInHandOrInSpellZone(CardId.Number104Masquerade))
                     {
                         continue;
                     }
@@ -2370,7 +2340,7 @@ namespace WindBot.Game.AI.Decks
         public bool PotOfDesireActivateForContinue()
         {
             if (CheckWhetherNegated(true)) return false;
-            if (Bot.Deck.Count >= 15 && !CheckCanContinueSummon() && CheckRemainInDeck(CardId.IceRyzeal, CardId.ThodeRyzeal, CardId.ExRyzeal) > 0)
+            if (Bot.Deck.Count >= 15 && !CheckCanContinueSummon() && Bot.HasInDeck(CardId.IceRyzeal, CardId.ThodeRyzeal, CardId.ExRyzeal))
             {
                 SelectSTPlace(Card, true);
                 return true;
@@ -2558,7 +2528,7 @@ namespace WindBot.Game.AI.Decks
 
             // chain to negate monster effect
             if (Bot.HasInSpellZone(CardId.RyzealCross, true, true) && !activatedCardIdList.Contains(CardId.RyzealCross + 2)
-                && CheckRemainInDeck(CardId.ExRyzeal, CardId.IceRyzeal, CardId.NodeRyzeal, CardId.ThodeRyzeal) > 0)
+                && Bot.HasInDeck(CardId.ExRyzeal, CardId.IceRyzeal, CardId.NodeRyzeal, CardId.ThodeRyzeal))
             {
                 ClientCard lastChainCard = Util.GetLastChainCard();
                 if (lastChainCard != null && lastChainCard.IsMonster() && lastChainCard.Controller == 1 && CheckCardShouldNegate(lastChainCard))
@@ -2769,7 +2739,7 @@ namespace WindBot.Game.AI.Decks
             if (CheckWhetherNegated(true)) return false;
             if (Card.Location == CardLocation.SpellZone && Card.IsFaceup()) return false;
             bool flag = RyzealCrossActivateRecycleFirst();
-            bool canSetMaterial = Bot.HasInHandOrInSpellZone(CardId.RyzealPlugIn) && CheckRemainInDeck(CardId.IceRyzeal, CardId.ExRyzeal, CardId.NodeRyzeal, CardId.ThodeRyzeal) > 0
+            bool canSetMaterial = Bot.HasInHandOrInSpellZone(CardId.RyzealPlugIn) && Bot.HasInDeck(CardId.IceRyzeal, CardId.ExRyzeal, CardId.NodeRyzeal, CardId.ThodeRyzeal)
                 && (Bot.Graveyard.Any(c => c != null && c.HasSetcode(SetcodeRyzeal) && (c.IsCanRevive() || !c.HasType(CardType.Xyz))) ||
                     Bot.Banished.Any(c => c != null && c.IsFaceup() && c.HasSetcode(SetcodeRyzeal) && (c.IsCanRevive() || !c.HasType(CardType.Xyz))));
             flag |= Bot.MonsterZone.Count(c => c != null && c.IsFaceup() && c.HasType(CardType.Xyz) && c.HasSetcode(SetcodeRyzeal) && (c.Overlays.Count() > 0 || canSetMaterial)) > 0;
@@ -2794,7 +2764,7 @@ namespace WindBot.Game.AI.Decks
             foreach (int id in checkIdList)
             {
                 ClientCard target = Bot.Graveyard.FirstOrDefault(c => c.IsCode(id));
-                if (target != null && (CheckRemainInDeck(id) + Bot.ExtraDeck.Count(c => c.IsCode(id)) + Bot.Hand.Count(c => c.IsCode(id))) == 0)
+                if (target != null && (Bot.GetRemainingCount(id) + Bot.ExtraDeck.Count(c => c.IsCode(id)) + Bot.Hand.Count(c => c.IsCode(id))) == 0)
                 {
                     if (target.HasType(CardType.Xyz) && GetLevel4CountOnField() == 1) continue;
                     targetList.Add(target);
@@ -2822,7 +2792,7 @@ namespace WindBot.Game.AI.Decks
             List<int> checkIdList = new List<int> { CardId.RyzealPlugIn, CardId.RyzealDuodrive, CardId.RyzealDeadnader, CardId.NodeRyzeal, CardId.ExRyzeal, CardId.IceRyzeal, CardId.ThodeRyzeal };
             foreach (int id in checkIdList)
             {
-                int remainCount = CheckRemainInDeck(id) + Bot.ExtraDeck.Count(c => c.IsCode(id));
+                int remainCount = Bot.GetRemainingCount(id) + Bot.ExtraDeck.Count(c => c.IsCode(id));
                 if (!countDict.ContainsKey(remainCount))
                 {
                     countDict.Add(remainCount, new List<int>());
@@ -2861,7 +2831,7 @@ namespace WindBot.Game.AI.Decks
                 if (alias != 0 && alias - code < 10) code = alias;
                 if (code == 0) return false;
                 if (DefaultCheckWhetherCardIdIsNegated(code)) return false;
-                if (CheckRemainInDeck(code) > 0)
+                if (Bot.HasInDeck(code))
                 {
                     if (!(Card.Location == CardLocation.SpellZone))
                     {
@@ -3082,7 +3052,7 @@ namespace WindBot.Game.AI.Decks
         {
             bool checkFlag = Duel.MainPhase.SpecialSummonableCards.Any(c => c.IsCode(CardId.RyzealDuodrive));
             checkFlag &= !Bot.HasInMonstersZone(CardId.RyzealDuodrive, true, true, true);
-            checkFlag &= CheckRemainInDeck(CardId.IceRyzeal, CardId.ThodeRyzeal, CardId.NodeRyzeal, CardId.ExRyzeal, CardId.RyzealPlugIn, CardId.RyzealCross) >= 2;
+            checkFlag &= Bot.GetRemainingCount(new[] { CardId.IceRyzeal, CardId.ThodeRyzeal, CardId.NodeRyzeal, CardId.ExRyzeal, CardId.RyzealPlugIn, CardId.RyzealCross }) >= 2;
             checkFlag &= !DefaultCheckWhetherCardIdIsNegated(CardId.RyzealDuodrive);
             checkFlag &= !activatedCardIdList.Contains(CardId.RyzealDuodrive + 1);
             checkFlag &= !CheckWhetherNegated(true, true, CardType.Monster);

--- a/Game/AI/Decks/ST1732Executor.cs
+++ b/Game/AI/Decks/ST1732Executor.cs
@@ -384,8 +384,7 @@ namespace WindBot.Game.AI.Decks
 
         private bool DraconnetSummon()
         {
-            return Bot.GetRemainingCount(CardId.Digitron, 1) > 0
-                || Bot.GetRemainingCount(CardId.Bitron, 1) > 0;
+            return Bot.HasInDeck(CardId.Digitron, CardId.Bitron);
         }
 
         private bool DraconnetEffect()

--- a/Game/AI/Decks/SacredBeastExecutor.cs
+++ b/Game/AI/Decks/SacredBeastExecutor.cs
@@ -66,41 +66,6 @@ namespace WindBot.Game.AI.Decks
             public const int AmeNoMurakumoNoMitsurugi = 19899073;
             public const int DogmatikaMaximus = 95679145;
         }
-        private readonly Dictionary<int, List<int>> DeckCountTable = new Dictionary<int, List<int>>
-        {
-            { 3, new List<int>
-                {
-                    CardId.UnleashingTheSacredBeasts,
-                    CardId.HamonSacredBeastOfSinfulCatastrophe,
-                    CardId.RavielSacredBeastOfEndlessEternity,
-                    CardId.MulcharmyFuwalos,
-                    CardId.MartyrOfTheSacredBeasts,
-                    CardId.SkyfireOfTheSacredBeast,
-                    CardId.LightningCrash,
-                    CardId.FallenParadiseOfTheSacredBeasts,
-                    CardId.HeavyPolymerization,
-                    CardId.DivineAbyssOfTheSacredBeast,
-                    CardId.CardOfTheSoul
-                }
-            },
-
-            { 2, new List<int>
-                {
-                    CardId.AshBlossom
-                }
-            },
-
-            { 1, new List<int>
-                {
-                    CardId.UriaSacredBeastOfCataclysmicFire,
-                    CardId.ThunderKingTheLightningstrikeKaiju,
-                    CardId.TheOrchestratorOfTheSacredBeasts,
-                    CardId.MaxxC,
-                    CardId.CalledByTheGrave,
-                    CardId.DestructionChantOfTheSacredBeast
-                }
-            },
-        };
 
         const int SetcodeTimeLord = 0x4a;
         const int SetcodePhantom = 0xdb;
@@ -460,7 +425,7 @@ namespace WindBot.Game.AI.Decks
                 if (Duel.Player == 1)
                 {
                     if (!Bot.HasInSpellZone(CardId.DivineAbyssOfTheSacredBeast)
-                        && CheckRemainInDeck(CardId.DivineAbyssOfTheSacredBeast) > 0)
+                        && Bot.HasInDeck(CardId.DivineAbyssOfTheSacredBeast))
                     {
                         target = CardId.DivineAbyssOfTheSacredBeast;
                     }
@@ -468,7 +433,7 @@ namespace WindBot.Game.AI.Decks
 
                 if (target == 0 && Duel.Player == 0)
                 {
-                    if (CheckRemainInDeck(CardId.SkyfireOfTheSacredBeast) > 0)
+                    if (Bot.HasInDeck(CardId.SkyfireOfTheSacredBeast))
                         target = CardId.SkyfireOfTheSacredBeast;
                 }
 
@@ -850,17 +815,6 @@ namespace WindBot.Game.AI.Decks
             Logger.DebugWriteLine("Use default.");
             return base.OnSelectCard(cards, min, max, hint, cancelable);
         }
-        public int CheckRemainInDeck(int id)
-        {
-            for (int count = 1; count < 4; ++count)
-            {
-                if (DeckCountTable[count].Contains(id))
-                {
-                    return Bot.GetRemainingCount(id, count);
-                }
-            }
-            return 0;
-        }
         public bool CheckAtAdvantage()
         {
             if (GetProblematicEnemyMonster() == null && Bot.GetMonsters().Any(card => card.IsFaceup()))
@@ -901,7 +855,7 @@ namespace WindBot.Game.AI.Decks
                 if (alias != 0 && alias - code < 10) code = alias;
                 if (code == 0) return false;
                 if (DefaultCheckWhetherCardIdIsNegated(code)) return false;
-                if (CheckRemainInDeck(code) > 0)
+                if (Bot.HasInDeck(code))
                 {
                     if (!(Card.Location == CardLocation.SpellZone))
                     {
@@ -1671,7 +1625,7 @@ namespace WindBot.Game.AI.Decks
                     return false;
                 if (CountFaceupSpellTrap(CardId.DivineAbyssOfTheSacredBeast) < 3
                     && Bot.GetSpellCount() <= 3
-                    && CheckRemainInDeck(CardId.DivineAbyssOfTheSacredBeast) > 0)
+                    && Bot.HasInDeck(CardId.DivineAbyssOfTheSacredBeast))
                 {
                     AI.SelectCard(new List<int>{ CardId.DivineAbyssOfTheSacredBeast,
                                                  CardId.DivineAbyssOfTheSacredBeast });
@@ -1801,13 +1755,13 @@ namespace WindBot.Game.AI.Decks
             bool hasHamon = Bot.HasInHand(CardId.HamonSacredBeastOfSinfulCatastrophe);
             bool hasRaviel = Bot.HasInHand(CardId.RavielSacredBeastOfEndlessEternity);
 
-            if (!hasHamon && !useHamonSearchEffectAlready && CheckRemainInDeck(CardId.HamonSacredBeastOfSinfulCatastrophe) > 0)
+            if (!hasHamon && !useHamonSearchEffectAlready && Bot.HasInDeck(CardId.HamonSacredBeastOfSinfulCatastrophe))
             {
                 AI.SelectCard(CardId.HamonSacredBeastOfSinfulCatastrophe);
                 return true;
             }
 
-            if ((hasHamon || useHamonSearchEffectAlready) && !hasRaviel && CheckRemainInDeck(CardId.RavielSacredBeastOfEndlessEternity) > 0)
+            if ((hasHamon || useHamonSearchEffectAlready) && !hasRaviel && Bot.HasInDeck(CardId.RavielSacredBeastOfEndlessEternity))
             {
                 AI.SelectCard(CardId.RavielSacredBeastOfEndlessEternity);
                 return true;
@@ -1823,7 +1777,7 @@ namespace WindBot.Game.AI.Decks
             bool hasHamon = Bot.HasInHand(CardId.HamonSacredBeastOfSinfulCatastrophe);
             bool hasKaiju = Bot.HasInHand(CardId.ThunderKingTheLightningstrikeKaiju);
 
-            if (!hasHamon && !useHamonSearchEffectAlready && CheckRemainInDeck(CardId.HamonSacredBeastOfSinfulCatastrophe) > 0)
+            if (!hasHamon && !useHamonSearchEffectAlready && Bot.HasInDeck(CardId.HamonSacredBeastOfSinfulCatastrophe))
             {
                 AI.SelectCard(CardId.HamonSacredBeastOfSinfulCatastrophe);
                 SelectSTPlace(null, true);
@@ -1831,7 +1785,7 @@ namespace WindBot.Game.AI.Decks
                 return true;
             }
 
-            if (Enemy.GetMonsterCount() > 0 && !hasKaiju && CheckRemainInDeck(CardId.ThunderKingTheLightningstrikeKaiju) > 0)
+            if (Enemy.GetMonsterCount() > 0 && !hasKaiju && Bot.HasInDeck(CardId.ThunderKingTheLightningstrikeKaiju))
             {
                 AI.SelectCard(CardId.ThunderKingTheLightningstrikeKaiju);
                 SelectSTPlace(null, true);
@@ -1864,24 +1818,24 @@ namespace WindBot.Game.AI.Decks
         private int PickHamonSpellSearchTarget()
         {
             if (!HasCardAccessible(CardId.UnleashingTheSacredBeasts)
-                && CheckRemainInDeck(CardId.UnleashingTheSacredBeasts) > 0)
+                && Bot.HasInDeck(CardId.UnleashingTheSacredBeasts))
                 return CardId.UnleashingTheSacredBeasts;
 
             if (!HasCardAccessible(CardId.SkyfireOfTheSacredBeast)
-                && CheckRemainInDeck(CardId.SkyfireOfTheSacredBeast) > 0)
+                && Bot.HasInDeck(CardId.SkyfireOfTheSacredBeast))
                 return CardId.SkyfireOfTheSacredBeast;
 
             if (!HasCardAccessible(CardId.FallenParadiseOfTheSacredBeasts)
-                && CheckRemainInDeck(CardId.FallenParadiseOfTheSacredBeasts) > 0)
+                && Bot.HasInDeck(CardId.FallenParadiseOfTheSacredBeasts))
                 return CardId.FallenParadiseOfTheSacredBeasts;
 
-            if (CheckRemainInDeck(CardId.UnleashingTheSacredBeasts) > 0)
+            if (Bot.HasInDeck(CardId.UnleashingTheSacredBeasts))
                 return CardId.UnleashingTheSacredBeasts;
 
-            if (CheckRemainInDeck(CardId.SkyfireOfTheSacredBeast) > 0)
+            if (Bot.HasInDeck(CardId.SkyfireOfTheSacredBeast))
                 return CardId.SkyfireOfTheSacredBeast;
 
-            if (CheckRemainInDeck(CardId.FallenParadiseOfTheSacredBeasts) > 0)
+            if (Bot.HasInDeck(CardId.FallenParadiseOfTheSacredBeasts))
                 return CardId.FallenParadiseOfTheSacredBeasts;
 
             return 0;
@@ -1974,8 +1928,8 @@ namespace WindBot.Game.AI.Decks
             if (Card.Location != CardLocation.Grave) return false;
 
             if (!Bot.HasInHand(CardId.HamonSacredBeastOfSinfulCatastrophe)
-                && CheckRemainInDeck(CardId.HamonSacredBeastOfSinfulCatastrophe) > 0
-                && CheckRemainInDeck(CardId.UnleashingTheSacredBeasts) > 0)
+                && Bot.HasInDeck(CardId.HamonSacredBeastOfSinfulCatastrophe)
+                && Bot.HasInDeck(CardId.UnleashingTheSacredBeasts))
             {
                 AI.SelectCard(CardId.HamonSacredBeastOfSinfulCatastrophe);
                 return true;
@@ -2058,14 +2012,14 @@ namespace WindBot.Game.AI.Decks
             if (Duel.Player == 1)
             {
                 if (!Bot.HasInSpellZone(CardId.DivineAbyssOfTheSacredBeast)
-                    && CheckRemainInDeck(CardId.DivineAbyssOfTheSacredBeast) > 0)
+                    && Bot.HasInDeck(CardId.DivineAbyssOfTheSacredBeast))
                 {
                     target = CardId.DivineAbyssOfTheSacredBeast;
                 }
             }
             if (target == 0 && Duel.Player == 0)
             {
-                if (CheckRemainInDeck(CardId.SkyfireOfTheSacredBeast) > 0)
+                if (Bot.HasInDeck(CardId.SkyfireOfTheSacredBeast))
                     target = CardId.SkyfireOfTheSacredBeast;
             }
 
@@ -2094,14 +2048,14 @@ namespace WindBot.Game.AI.Decks
             });
             AI.SelectNextCard(revealTarget);
 
-            if (CheckRemainInDeck(CardId.FallenParadiseOfTheSacredBeasts) > 0)
+            if (Bot.HasInDeck(CardId.FallenParadiseOfTheSacredBeasts))
                 AI.SelectNextCard(CardId.FallenParadiseOfTheSacredBeasts);
 
             return true;
         }
         private int CountAccessibleSkyfireCopiesForEffect()
         {
-            int count = CheckRemainInDeck(CardId.SkyfireOfTheSacredBeast);
+            int count = Bot.GetRemainingCount(CardId.SkyfireOfTheSacredBeast);
             count += Bot.Hand.Count(c => c != null && c.IsCode(CardId.SkyfireOfTheSacredBeast));
             count += Bot.Graveyard.Count(c => c != null && c.IsCode(CardId.SkyfireOfTheSacredBeast));
             return count;
@@ -2165,7 +2119,7 @@ namespace WindBot.Game.AI.Decks
             if (useRaviel) return false;
             if (Card.Location != CardLocation.Hand) return false;
             if (!Bot.HasInHand(CardId.UriaSacredBeastOfCataclysmicFire) &&
-                CheckRemainInDeck(CardId.UriaSacredBeastOfCataclysmicFire) > 0 &&
+                Bot.HasInDeck(CardId.UriaSacredBeastOfCataclysmicFire) &&
                 useHamonSearchEffectAlready
                 )
             {
@@ -2175,7 +2129,7 @@ namespace WindBot.Game.AI.Decks
                 return true;
             }
             else if (!Bot.HasInHand(CardId.HamonSacredBeastOfSinfulCatastrophe) &&
-                CheckRemainInDeck(CardId.HamonSacredBeastOfSinfulCatastrophe) > 0 &&
+                Bot.HasInDeck(CardId.HamonSacredBeastOfSinfulCatastrophe) &&
                 !useHamonSearchEffectAlready
                 )
             {
@@ -2187,7 +2141,7 @@ namespace WindBot.Game.AI.Decks
             else if (useHamonSearchEffectAlready &&
                       !normalSummon &&
                       !Bot.HasInHand(CardId.MartyrOfTheSacredBeasts) &&
-                      (CheckRemainInDeck(CardId.MartyrOfTheSacredBeasts) > 0) &&
+                      Bot.HasInDeck(CardId.MartyrOfTheSacredBeasts) &&
                       HasOtherSacredBeastInHandForRavielCost())
             {
                 AI.SelectCard(CardId.MartyrOfTheSacredBeasts);
@@ -2234,7 +2188,7 @@ namespace WindBot.Game.AI.Decks
         private bool Uria_Hand_SearchDestructionChant()
         {
             if (Card.Location != CardLocation.Hand) return false;
-            if (CheckRemainInDeck(CardId.DestructionChantOfTheSacredBeast) <= 0) return false;
+            if (!Bot.HasInDeck(CardId.DestructionChantOfTheSacredBeast)) return false;
 
             ClientCard discard = GetBestDiscardCost(new int[]
             {
@@ -2254,7 +2208,7 @@ namespace WindBot.Game.AI.Decks
 
             if (ActivateDescription != Util.GetStringId(CardId.MartyrOfTheSacredBeasts, 1)) return false;
             if (Bot.GetMonstersInMainZone().Count(c => c != null) >= 3) return false;
-            if (CheckRemainInDeck(CardId.MartyrOfTheSacredBeasts) + Bot.Graveyard.Count(c => c != null && c.IsCode(CardId.MartyrOfTheSacredBeasts)) < 2) return false;
+            if (Bot.GetRemainingCount(CardId.MartyrOfTheSacredBeasts) + Bot.Graveyard.Count(c => c != null && c.IsCode(CardId.MartyrOfTheSacredBeasts)) < 2) return false;
 
             AI.SelectCard(new[] { CardId.MartyrOfTheSacredBeasts, CardId.MartyrOfTheSacredBeasts });
             Martyrx3 = true;

--- a/Game/AI/Decks/SacredBeastExecutor.cs
+++ b/Game/AI/Decks/SacredBeastExecutor.cs
@@ -2055,7 +2055,7 @@ namespace WindBot.Game.AI.Decks
         }
         private int CountAccessibleSkyfireCopiesForEffect()
         {
-            int count = Bot.GetRemainingCount(CardId.SkyfireOfTheSacredBeast);
+            int count = Bot.GetCardCountInDeck(CardId.SkyfireOfTheSacredBeast);
             count += Bot.Hand.Count(c => c != null && c.IsCode(CardId.SkyfireOfTheSacredBeast));
             count += Bot.Graveyard.Count(c => c != null && c.IsCode(CardId.SkyfireOfTheSacredBeast));
             return count;
@@ -2208,7 +2208,7 @@ namespace WindBot.Game.AI.Decks
 
             if (ActivateDescription != Util.GetStringId(CardId.MartyrOfTheSacredBeasts, 1)) return false;
             if (Bot.GetMonstersInMainZone().Count(c => c != null) >= 3) return false;
-            if (Bot.GetRemainingCount(CardId.MartyrOfTheSacredBeasts) + Bot.Graveyard.Count(c => c != null && c.IsCode(CardId.MartyrOfTheSacredBeasts)) < 2) return false;
+            if (Bot.GetCardCountInDeck(CardId.MartyrOfTheSacredBeasts) + Bot.Graveyard.Count(c => c != null && c.IsCode(CardId.MartyrOfTheSacredBeasts)) < 2) return false;
 
             AI.SelectCard(new[] { CardId.MartyrOfTheSacredBeasts, CardId.MartyrOfTheSacredBeasts });
             Martyrx3 = true;

--- a/Game/AI/Decks/SalamangreatExecutor.cs
+++ b/Game/AI/Decks/SalamangreatExecutor.cs
@@ -626,7 +626,7 @@ namespace WindBot.Game.AI.Decks
 
         private bool FalcoToGY(bool FromDeck)
         {
-            if (FromDeck && Bot.Deck.ContainsCardWithId(CardId.Falco))
+            if (FromDeck && Bot.HasInDeck(CardId.Falco))
             {
                 if (Bot.HasInGraveyard(salamangreat_spellTrap))
                 {

--- a/Game/AI/Decks/SkyStrikerExecutor.cs
+++ b/Game/AI/Decks/SkyStrikerExecutor.cs
@@ -701,27 +701,27 @@ namespace WindBot.Game.AI.Decks
 
         private int GetCardToSearch()
         {
-            if (!Bot.HasInHand(CardId.HornetDrones) && Bot.GetRemainingCount(CardId.HornetDrones, 3) > 0)
+            if (!Bot.HasInHand(CardId.HornetDrones) && Bot.HasInDeck(CardId.HornetDrones))
             {
                 return CardId.HornetDrones;
             }
-            else if (Util.GetProblematicEnemyMonster() != null && Bot.GetRemainingCount(CardId.WidowAnchor, 3) > 0)
+            else if (Util.GetProblematicEnemyMonster() != null && Bot.HasInDeck(CardId.WidowAnchor))
             {
                 return CardId.WidowAnchor;
             }
-            else if (EmptyMainMonsterZone() && Util.GetProblematicEnemyMonster() != null && Bot.GetRemainingCount(CardId.Afterburners, 1) > 0)
+            else if (EmptyMainMonsterZone() && Util.GetProblematicEnemyMonster() != null && Bot.HasInDeck(CardId.Afterburners))
             {
                 return CardId.Afterburners;
             }
-            else if (EmptyMainMonsterZone() && Util.GetProblematicEnemySpell() != null && Bot.GetRemainingCount(CardId.JammingWave, 1) > 0)
+            else if (EmptyMainMonsterZone() && Util.GetProblematicEnemySpell() != null && Bot.HasInDeck(CardId.JammingWave))
             {
                 return CardId.JammingWave;
             }
-            else if (!Bot.HasInHand(CardId.Raye) && !Bot.HasInMonstersZone(CardId.Raye) && Bot.GetRemainingCount(CardId.Raye, 3) > 0)
+            else if (!Bot.HasInHand(CardId.Raye) && !Bot.HasInMonstersZone(CardId.Raye) && Bot.HasInDeck(CardId.Raye))
             {
                 return CardId.Raye;
             }
-            else if (!Bot.HasInHand(CardId.WidowAnchor) && !Bot.HasInSpellZone(CardId.WidowAnchor) && Bot.GetRemainingCount(CardId.WidowAnchor, 3) > 0)
+            else if (!Bot.HasInHand(CardId.WidowAnchor) && !Bot.HasInSpellZone(CardId.WidowAnchor) && Bot.HasInDeck(CardId.WidowAnchor))
             {
                 return CardId.WidowAnchor;
             }

--- a/Game/AI/Decks/SwordsoulExecutor.cs
+++ b/Game/AI/Decks/SwordsoulExecutor.cs
@@ -149,13 +149,6 @@ namespace WindBot.Game.AI.Decks
         const int hintTimingMainEnd = 0x4;
         const int hintReplaceDestroy = 96;
 
-        Dictionary<int, List<int>> DeckCountTable = new Dictionary<int, List<int>>{
-            {3, new List<int> { CardId.SwordsoulStrategistLongyuan, CardId.SwordsoulOfTaia, CardId.SwordsoulOfMoYe, CardId.IncredibleEcclesiaTheVirtuous,
-                                _CardId.AshBlossom, _CardId.MaxxC, _CardId.EffectVeiler, CardId.SwordsoulEmergence, _CardId.InfiniteImpermanence }},
-            {2, new List<int> { CardId.TenyiSpirit_Ashuna, _CardId.PotOfDesires, _CardId.CalledByTheGrave, CardId.SwordsoulBlackout }},
-            {1, new List<int> { CardId.NibiruThePrimalBeing, CardId.TenyiSpirit_Vishuda, CardId.TenyiSpirit_Adhara, CardId.SwordsoulSacredSummit,
-                                CardId.CrossoutDesignator }},
-        };
 
         List<int> currentNegatingIdList = new List<int>();
         bool enemyActivateMaxxC = false;
@@ -427,20 +420,6 @@ namespace WindBot.Game.AI.Decks
             return 0;
         }
 
-        /// <summary>
-        /// Check remain cards in deck
-        /// </summary>
-        /// <param name="id">Card's ID</param>
-        public int CheckRemainInDeck(int id)
-        {
-            for (int count = 1; count < 4; ++count)
-            {
-                if (DeckCountTable[count].Contains(id)) {
-                    return Bot.GetRemainingCount(id, count);
-                }
-            }
-            return 0;
-        }
 
         /// <summary>
         /// Whether spell or trap will be negate. If so, return true.
@@ -851,14 +830,14 @@ namespace WindBot.Game.AI.Decks
                 List<int> tunerIdList = new List<int>{_CardId.AshBlossom, _CardId.EffectVeiler, CardId.TenyiSpirit_Adhara};
                 bool hasTuner = Bot.GetMonsters().Any(card => card.IsFaceup() && card.IsCode(tunerIdList));
                 hasTuner |= !summoned && Bot.HasInHand(tunerIdList);
-                if (hasTuner && CheckRemainInDeck(CardId.TenyiSpirit_Vishuda) > 0)
+                if (hasTuner && Bot.HasInDeck(CardId.TenyiSpirit_Vishuda))
                 {
                     AI.SelectCard(CardId.TenyiSpirit_Ashuna);
                     onlyWyrmSpSummon = true;
                     activatedCardIdList.Add(Card.Id);
                     return true;
                 }
-                if (Bot.HasInMonstersZone(CardId.TenyiSpirit_Ashuna, false, false, true) && CheckRemainInDeck(CardId.TenyiSpirit_Adhara) > 0)
+                if (Bot.HasInMonstersZone(CardId.TenyiSpirit_Ashuna, false, false, true) && Bot.HasInDeck(CardId.TenyiSpirit_Adhara))
                 {
                     AI.SelectCard(CardId.TenyiSpirit_Adhara);
                     onlyWyrmSpSummon = true;
@@ -997,7 +976,7 @@ namespace WindBot.Game.AI.Decks
                 List<int> sendToGYTarget = new List<int>();
 
                 // send Mo Ye to SS
-                if (!Bot.HasInGraveyard(CardId.SwordsoulOfMoYe) && CheckRemainInDeck(CardId.SwordsoulOfMoYe) > 0)
+                if (!Bot.HasInGraveyard(CardId.SwordsoulOfMoYe) && Bot.HasInDeck(CardId.SwordsoulOfMoYe))
                 {
                     bool sendMoYe = false;
                     // baxia
@@ -1024,7 +1003,7 @@ namespace WindBot.Game.AI.Decks
                 List<int> checkTenyiList = new List<int> {CardId.TenyiSpirit_Adhara, CardId.TenyiSpirit_Vishuda, CardId.TenyiSpirit_Ashuna};
                 foreach (int id in checkTenyiList)
                 {
-                    if (CheckRemainInDeck(id) > 0)
+                    if (Bot.HasInDeck(id))
                     {
                         sendToGYTarget.Add(id);
                     }
@@ -1216,9 +1195,9 @@ namespace WindBot.Game.AI.Decks
             }
             if (Duel.Player == 0 && !CheckWhetherNegated())
             {
-                bool canActivateMoye = !activatedCardIdList.Contains(CardId.SwordsoulOfMoYe) && CheckRemainInDeck(CardId.SwordsoulOfMoYe) > 0
+                bool canActivateMoye = !activatedCardIdList.Contains(CardId.SwordsoulOfMoYe) && Bot.HasInDeck(CardId.SwordsoulOfMoYe)
                     && CheckCalledbytheGrave(CardId.SwordsoulOfMoYe) == 0 && SwordsoulOfMoYeEffectCheck();
-                bool canActivateTaia = !activatedCardIdList.Contains(CardId.SwordsoulOfTaia) && CheckRemainInDeck(CardId.SwordsoulOfTaia) > 0
+                bool canActivateTaia = !activatedCardIdList.Contains(CardId.SwordsoulOfTaia) && Bot.HasInDeck(CardId.SwordsoulOfTaia)
                     && CheckCalledbytheGrave(CardId.SwordsoulOfTaia) == 0 && SwordsoulOfTaiaEffectCheck();
                 if (canActivateMoye && !summoned && !Bot.HasInHand(CardId.SwordsoulOfMoYe))
                 {
@@ -1255,12 +1234,12 @@ namespace WindBot.Game.AI.Decks
             {
                 return false;
             }
-            if (SwordsoulOfMoYeSummon() && CheckRemainInDeck(CardId.SwordsoulOfMoYe) > 0)
+            if (SwordsoulOfMoYeSummon() && Bot.HasInDeck(CardId.SwordsoulOfMoYe))
             {
                 summoned = true;
                 return true;
             }
-            if (SwordsoulOfTaiaSummon() && CheckRemainInDeck(CardId.SwordsoulOfTaia) > 0)
+            if (SwordsoulOfTaiaSummon() && Bot.HasInDeck(CardId.SwordsoulOfTaia))
             {
                 summoned = true;
                 return true;
@@ -1540,7 +1519,7 @@ namespace WindBot.Game.AI.Decks
 
             // Mo Ye
             if (!Bot.HasInHand(CardId.SwordsoulOfMoYe) && !activatedCardIdList.Contains(CardId.SwordsoulOfMoYe)
-                && CheckRemainInDeck(CardId.SwordsoulOfMoYe) > 0 && SwordsoulOfMoYeEffectCheck())
+                && Bot.HasInDeck(CardId.SwordsoulOfMoYe) && SwordsoulOfMoYeEffectCheck())
             {
                 AI.SelectCard(CardId.SwordsoulOfMoYe);
                 activatedCardIdList.Add(Card.Id);
@@ -1550,7 +1529,7 @@ namespace WindBot.Game.AI.Decks
 
             // Taia
             if (!Bot.HasInHand(CardId.SwordsoulOfTaia) && !activatedCardIdList.Contains(CardId.SwordsoulOfTaia)
-                && CheckRemainInDeck(CardId.SwordsoulOfTaia) > 0 && SwordsoulOfTaiaEffectCheck())
+                && Bot.HasInDeck(CardId.SwordsoulOfTaia) && SwordsoulOfTaiaEffectCheck())
             {
                 AI.SelectCard(CardId.SwordsoulOfTaia);
                 activatedCardIdList.Add(Card.Id);
@@ -1560,7 +1539,7 @@ namespace WindBot.Game.AI.Decks
 
             // Longyuan
             if (!Bot.HasInHand(CardId.SwordsoulStrategistLongyuan) && !activatedCardIdList.Contains(CardId.SwordsoulStrategistLongyuan)
-                && CheckRemainInDeck(CardId.SwordsoulStrategistLongyuan) > 0 && SwordsoulOfMoYeEffectCheck())
+                && Bot.HasInDeck(CardId.SwordsoulStrategistLongyuan) && SwordsoulOfMoYeEffectCheck())
             {
                 AI.SelectCard(CardId.SwordsoulStrategistLongyuan);
                 activatedCardIdList.Add(Card.Id);
@@ -1569,7 +1548,7 @@ namespace WindBot.Game.AI.Decks
             }
 
             // dump check
-            if (!Bot.HasInHand(CardId.SwordsoulOfMoYe) && CheckRemainInDeck(CardId.SwordsoulOfMoYe) > 0 && SwordsoulOfMoYeEffectCheck())
+            if (!Bot.HasInHand(CardId.SwordsoulOfMoYe) && Bot.HasInDeck(CardId.SwordsoulOfMoYe) && SwordsoulOfMoYeEffectCheck())
             {
                 AI.SelectCard(CardId.SwordsoulOfMoYe);
                 activatedCardIdList.Add(Card.Id);
@@ -1579,7 +1558,7 @@ namespace WindBot.Game.AI.Decks
             List<int> checkIdList = new List<int>{CardId.SwordsoulOfTaia, CardId.SwordsoulOfMoYe, CardId.SwordsoulStrategistLongyuan};
             foreach (int checkId in checkIdList)
             {
-                if (CheckRemainInDeck(checkId) > 0)
+                if (Bot.HasInDeck(checkId))
                 {
                     AI.SelectCard(checkId);
                     activatedCardIdList.Add(Card.Id);
@@ -1749,7 +1728,7 @@ namespace WindBot.Game.AI.Decks
                 if (alias != 0 && alias - code < 10) code = alias;
                 if (code == 0) return false;
                 if (DefaultCheckWhetherCardIdIsNegated(code)) return false;
-                if (CheckRemainInDeck(code) > 0)
+                if (Bot.HasInDeck(code))
                 {
                     if (!(Card.Location == CardLocation.SpellZone))
                     {
@@ -2214,9 +2193,9 @@ namespace WindBot.Game.AI.Decks
             }
             bool shouldSummon = GetProblematicEnemyCardList(true, true).Count() > 0;
             shouldSummon |= !activatedCardIdList.Contains(CardId.SwordsoulOfMoYe) && CheckCalledbytheGrave(CardId.SwordsoulOfMoYe) == 0
-                && CheckRemainInDeck(CardId.SwordsoulOfMoYe) > 0 && SwordsoulOfMoYeEffectCheck();
+                && Bot.HasInDeck(CardId.SwordsoulOfMoYe) && SwordsoulOfMoYeEffectCheck();
             shouldSummon |= !activatedCardIdList.Contains(CardId.SwordsoulOfTaia) && CheckCalledbytheGrave(CardId.SwordsoulOfTaia) == 0
-                && CheckRemainInDeck(CardId.SwordsoulOfTaia) > 0;
+                && Bot.HasInDeck(CardId.SwordsoulOfTaia);
             
             if (shouldSummon)
             {
@@ -2480,7 +2459,7 @@ namespace WindBot.Game.AI.Decks
                 {
                     return false;
                 }
-                if (CheckRemainInDeck(CardId.NibiruThePrimalBeing) > 0 && (Enemy.GetMonsterCount() + Enemy.GetSpellCount() > 0))
+                if (Bot.HasInDeck(CardId.NibiruThePrimalBeing) && (Enemy.GetMonsterCount() + Enemy.GetSpellCount() > 0))
                 {
                     AI.SelectCard(GetNormalEnemyTargetList(false));
                     return true;
@@ -2639,7 +2618,7 @@ namespace WindBot.Game.AI.Decks
                 // search
                 if (CheckAtAdvantage() && enemyActivateMaxxC && Util.IsTurn1OrMain2())
                 {
-                    if (CheckRemainInDeck(CardId.SwordsoulBlackout) > 0)
+                    if (Bot.HasInDeck(CardId.SwordsoulBlackout))
                     {
                         AI.SelectCard(CardId.SwordsoulBlackout);
                         activatedCardIdList.Add(Card.Id);
@@ -2652,7 +2631,7 @@ namespace WindBot.Game.AI.Decks
                     };
                     foreach (int checkId in searchIdList)
                     {
-                        if (CheckRemainInDeck(checkId) > 0 && !Bot.HasInHand(checkId))
+                        if (Bot.HasInDeck(checkId) && !Bot.HasInHand(checkId))
                         {
                             AI.SelectCard(checkId);
                             activatedCardIdList.Add(Card.Id);
@@ -2664,7 +2643,7 @@ namespace WindBot.Game.AI.Decks
                 if (CheckAtAdvantage())
                 {
                     if (!activatedCardIdList.Contains(CardId.SwordsoulStrategistLongyuan) && !Bot.HasInHand(CardId.SwordsoulStrategistLongyuan)
-                    && SwordsoulOfMoYeEffectCheck() && CheckRemainInDeck(CardId.SwordsoulStrategistLongyuan) > 0)
+                    && SwordsoulOfMoYeEffectCheck() && Bot.HasInDeck(CardId.SwordsoulStrategistLongyuan))
                     {
                         AI.SelectCard(CardId.SwordsoulStrategistLongyuan);
                         activatedCardIdList.Add(Card.Id);
@@ -2677,7 +2656,7 @@ namespace WindBot.Game.AI.Decks
                         // ready for another level 8 synchro
                         if (Bot.HasInHandOrInGraveyard(CardId.SwordsoulOfTaia) && !Bot.HasInHand(CardId.SwordsoulSacredSummit))
                         {
-                            if (CheckRemainInDeck(CardId.SwordsoulSacredSummit) > 0)
+                            if (Bot.HasInDeck(CardId.SwordsoulSacredSummit))
                             {
                                 AI.SelectCard(CardId.SwordsoulSacredSummit);
                                 activatedCardIdList.Add(Card.Id);
@@ -2686,7 +2665,7 @@ namespace WindBot.Game.AI.Decks
                         }
                         if (!Bot.HasInHandOrInGraveyard(CardId.SwordsoulOfTaia) && Bot.HasInHand(CardId.SwordsoulSacredSummit))
                         {
-                            if (CheckRemainInDeck(CardId.SwordsoulOfTaia) > 0)
+                            if (Bot.HasInDeck(CardId.SwordsoulOfTaia))
                             {
                                 AI.SelectCard(CardId.SwordsoulOfTaia);
                                 activatedCardIdList.Add(Card.Id);
@@ -2697,7 +2676,7 @@ namespace WindBot.Game.AI.Decks
                 }
             
                 if (!Bot.HasInMonstersZone(CardId.SwordsoulToken) && Bot.HasInMonstersZone(CardId.SwordsoulStrategistLongyuan)
-                    && Bot.HasInMonstersZone(CardId.SwordsoulStrategistLongyuan) && CheckRemainInDeck(CardId.SwordsoulBlackout) > 0
+                    && Bot.HasInMonstersZone(CardId.SwordsoulStrategistLongyuan) && Bot.HasInDeck(CardId.SwordsoulBlackout)
                     && !activatedCardIdList.Contains(CardId.SwordsoulBlackout))
                 {
                     Logger.DebugWriteLine("Chixiao banish blackout");
@@ -2715,7 +2694,7 @@ namespace WindBot.Game.AI.Decks
                     };
                     foreach (int checkId in searchIdList)
                     {
-                        if (CheckRemainInDeck(checkId) > 0 && !Bot.HasInHand(checkId))
+                        if (Bot.HasInDeck(checkId) && !Bot.HasInHand(checkId))
                         {
                             AI.SelectCard(checkId);
                             activatedCardIdList.Add(Card.Id);
@@ -2730,7 +2709,7 @@ namespace WindBot.Game.AI.Decks
                 };
                 foreach (int checkId in checkIdList)
                 {
-                    if (CheckRemainInDeck(checkId) > 0 && !Bot.HasInHand(checkId))
+                    if (Bot.HasInDeck(checkId) && !Bot.HasInHand(checkId))
                     {
                         AI.SelectCard(checkId);
                         activatedCardIdList.Add(Card.Id);
@@ -2788,8 +2767,8 @@ namespace WindBot.Game.AI.Decks
                     // sp summon ecclesia for moye/taia
                     if (!activatedCardIdList.Contains(CardId.IncredibleEcclesiaTheVirtuous))
                     {
-                        if ((canUseMoye && CheckRemainInDeck(CardId.SwordsoulOfMoYe) > 0)
-                        || (canUseTaia && CheckRemainInDeck(CardId.SwordsoulOfTaia) > 0))
+                        if ((canUseMoye && Bot.HasInDeck(CardId.SwordsoulOfMoYe))
+                        || (canUseTaia && Bot.HasInDeck(CardId.SwordsoulOfTaia)))
                         {
                             AI.SelectCard(destroyTarget);
                             AI.SelectNextCard(CardId.IncredibleEcclesiaTheVirtuous);
@@ -2816,13 +2795,13 @@ namespace WindBot.Game.AI.Decks
             if (Card.Location == CardLocation.Grave)
             {
                 // special summon
-                if (!activatedCardIdList.Contains(CardId.SwordsoulOfMoYe) && CheckRemainInDeck(CardId.SwordsoulOfMoYe) > 0
+                if (!activatedCardIdList.Contains(CardId.SwordsoulOfMoYe) && Bot.HasInDeck(CardId.SwordsoulOfMoYe)
                     && CheckCalledbytheGrave(CardId.SwordsoulOfMoYe) == 0 && SwordsoulOfMoYeEffectCheck())
                 {
                     AI.SelectCard(CardId.SwordsoulOfMoYe);
                     return true;
                 }
-                if (!activatedCardIdList.Contains(CardId.SwordsoulOfTaia) && CheckRemainInDeck(CardId.SwordsoulOfTaia) > 0
+                if (!activatedCardIdList.Contains(CardId.SwordsoulOfTaia) && Bot.HasInDeck(CardId.SwordsoulOfTaia)
                     && CheckCalledbytheGrave(CardId.SwordsoulOfTaia) == 0)
                 {
                     AI.SelectCard(CardId.SwordsoulOfTaia);
@@ -2833,7 +2812,7 @@ namespace WindBot.Game.AI.Decks
                     List<int> specialSummonIdListForSynchro = new List<int>{CardId.SwordsoulStrategistLongyuan, CardId.SwordsoulOfMoYe, CardId.SwordsoulOfTaia};
                     foreach (int checkId in specialSummonIdListForSynchro)
                     {
-                        if (CheckRemainInDeck(checkId) > 0)
+                        if (Bot.HasInDeck(checkId))
                         {
                             AI.SelectCard(checkId);
                             return true;
@@ -2846,7 +2825,7 @@ namespace WindBot.Game.AI.Decks
                 };
                 foreach (int checkId in specialSummonIdList)
                 {
-                    if (CheckRemainInDeck(checkId) > 0)
+                    if (Bot.HasInDeck(checkId))
                     {
                         AI.SelectCard(checkId);
                         return true;
@@ -2860,12 +2839,12 @@ namespace WindBot.Game.AI.Decks
                     return false;
                 }
                 bool selfDestroy = false;
-                if (!activatedCardIdList.Contains(CardId.SwordsoulOfMoYe) && CheckRemainInDeck(CardId.SwordsoulOfMoYe) > 0
+                if (!activatedCardIdList.Contains(CardId.SwordsoulOfMoYe) && Bot.HasInDeck(CardId.SwordsoulOfMoYe)
                     && CheckCalledbytheGrave(CardId.SwordsoulOfMoYe) == 0 && SwordsoulOfMoYeEffectCheck())
                 {
                     selfDestroy = true;
                 }
-                if (!activatedCardIdList.Contains(CardId.SwordsoulOfTaia) && CheckRemainInDeck(CardId.SwordsoulOfTaia) > 0
+                if (!activatedCardIdList.Contains(CardId.SwordsoulOfTaia) && Bot.HasInDeck(CardId.SwordsoulOfTaia)
                     && CheckCalledbytheGrave(CardId.SwordsoulOfTaia) == 0)
                 {
                     selfDestroy = true;

--- a/Game/AI/Decks/TearlamentsExecutor.cs
+++ b/Game/AI/Decks/TearlamentsExecutor.cs
@@ -1117,9 +1117,9 @@ namespace WindBot.Game.AI.Decks
                 List<ClientCard> hkeycards = new List<ClientCard>();
                 mkeycards = cards.Where(card => card != null && card.Id == CardId.TearlamentsKitkallos).ToList();
                 if (!activate_TearlamentsKitkallos_3 && mkeycards.Count > 0 && !AllActivated() && IsShouldSummonFusion(SETCODE, (int)CardRace.Aqua)
-                    && ((CheckRemainInDeck(CardId.TearlamentsHavnis) > 0 && !activate_TearlamentsHavnis_2)
-                    || (CheckRemainInDeck(CardId.TearlamentsMerrli) > 0 && !activate_TearlamentsMerrli_2)
-                    || (CheckRemainInDeck(CardId.TearlamentsScheiren) > 0 && !activate_TearlamentsScheiren_2)))
+                    && ((Bot.HasInDeck(CardId.TearlamentsHavnis) && !activate_TearlamentsHavnis_2)
+                    || (Bot.HasInDeck(CardId.TearlamentsMerrli) && !activate_TearlamentsMerrli_2)
+                    || (Bot.HasInDeck(CardId.TearlamentsScheiren) && !activate_TearlamentsScheiren_2)))
                     return Util.CheckSelectCount(mkeycards, cards, min, max);
                 if (IsShouldSummonFusion())
                 {
@@ -1183,7 +1183,7 @@ namespace WindBot.Game.AI.Decks
                 if (Bot.Deck.Count > 0) ids.Add(CardId.ShaddollBeast);
                 if (Enemy.Graveyard.Count > 0) ids.Add(CardId.NaelshaddollAriel);
                 if (!activate_Eva && Bot.Graveyard.Count(card => card != null && card.HasAttribute(CardAttribute.Light) && card.HasRace(CardRace.Fairy)) > 0
-                   && (CheckRemainInDeck(CardId.HeraldofGreenLight) > 0 || CheckRemainInDeck(CardId.HeraldofOrangeLight) > 0)) ids.Add(CardId.Eva);
+                   && (Bot.HasInDeck(CardId.HeraldofGreenLight) || Bot.HasInDeck(CardId.HeraldofOrangeLight))) ids.Add(CardId.Eva);
                 if (((Bot.HasInHand(CardId.HeraldofOrangeLight) || Bot.HasInHand(CardId.HeraldofGreenLight))
                     && Bot.Hand.Count(card => card != null && card.HasRace(CardRace.Fairy)) > 2)
                     || (!Bot.HasInHand(CardId.HeraldofOrangeLight) && !Bot.HasInHand(CardId.HeraldofGreenLight)))
@@ -1191,7 +1191,7 @@ namespace WindBot.Game.AI.Decks
                     ids.Add(CardId.MudoratheSwordOracle);
                     ids.Add(CardId.KeldotheSacredProtector);
                 }
-                if (!activate_TearlamentsScream_2 && CheckRemainInDeck(CardId.TearlamentsSulliek) > 0) ids.Add(CardId.TearlamentsScream);
+                if (!activate_TearlamentsScream_2 && Bot.HasInDeck(CardId.TearlamentsSulliek)) ids.Add(CardId.TearlamentsScream);
                 if (!activate_TearlamentsSulliek_2) ids.Add(CardId.TearlamentsSulliek);
                 if (!activate_TearlamentsReinoheart_2 && HasInList(cards, CardId.TearlamentsReinoheart)) ids.Add(CardId.TearlamentsReinoheart);
                 if (!cards.Any(card => card != null && !card.HasRace(CardRace.Fairy)))
@@ -1236,7 +1236,7 @@ namespace WindBot.Game.AI.Decks
                     cardsid.Add(CardId.ElderEntityNtss);
                 }
                 if (HasInList(cards, CardId.Eva) && !activate_Eva &&
-                    (CheckRemainInDeck(CardId.HeraldofOrangeLight) > 0 || CheckRemainInDeck(CardId.HeraldofGreenLight) > 0))
+                    (Bot.HasInDeck(CardId.HeraldofOrangeLight) || Bot.HasInDeck(CardId.HeraldofGreenLight)))
                     cardsid.Add(CardId.Eva);
                 if (HasInList(cards, CardId.MudoratheSwordOracle)) cardsid.Add(CardId.MudoratheSwordOracle);
                 if (HasInList(cards, CardId.KeldotheSacredProtector)) cardsid.Add(CardId.KeldotheSacredProtector);
@@ -1247,7 +1247,7 @@ namespace WindBot.Game.AI.Decks
                     if (cards.Any(card => card != null && card.Id == CardId.TearlamentsScheiren) && !activate_TearlamentsScheiren_2) cardsid.Add(CardId.TearlamentsScheiren);
                 }
                 if (cards.Any(card => card != null && card.Id == CardId.TearlamentsSulliek) && !activate_TearlamentsSulliek_2) cardsid.Add(CardId.TearlamentsSulliek);
-                if (cards.Any(card => card != null && card.Id == CardId.TearlamentsScream) && !activate_TearlamentsScream_2 && CheckRemainInDeck(CardId.TearlamentsSulliek) > 0) cardsid.Add(CardId.TearlamentsScream);
+                if (cards.Any(card => card != null && card.Id == CardId.TearlamentsScream) && !activate_TearlamentsScream_2 && Bot.HasInDeck(CardId.TearlamentsSulliek)) cardsid.Add(CardId.TearlamentsScream);
                 IList<ClientCard> res = CardsIdToClientCards(cardsid, cards, false);
                 if (res.Count > 0) no_fusion_card = res[0];
                 return res.Count > 0 ? Util.CheckSelectCount(res, cards, min, max) : null;
@@ -1325,9 +1325,9 @@ namespace WindBot.Game.AI.Decks
                     IList<ClientCard> temp = new List<ClientCard>();
                     if (b_cards.Count > 0 && Bot.ExtraDeck.Any(card => card != null && card.HasType(CardType.Fusion) && card.Id != CardId.ElderEntityNtss))
                     {
-                        if (CheckRemainInDeck(CardId.TearlamentsScheiren) <= 0 && HasInList(cards, CardId.TearlamentsScheiren)) bot_send_to_deck_ids.Add(CardId.TearlamentsScheiren);
-                        if (CheckRemainInDeck(CardId.TearlamentsMerrli) <= 0 && HasInList(cards, CardId.TearlamentsMerrli)) bot_send_to_deck_ids.Add(CardId.TearlamentsMerrli);
-                        if (CheckRemainInDeck(CardId.TearlamentsHavnis) <= 0 && HasInList(cards, CardId.TearlamentsHavnis)) bot_send_to_deck_ids.Add(CardId.TearlamentsHavnis);
+                        if (!Bot.HasInDeck(CardId.TearlamentsScheiren) && HasInList(cards, CardId.TearlamentsScheiren)) bot_send_to_deck_ids.Add(CardId.TearlamentsScheiren);
+                        if (!Bot.HasInDeck(CardId.TearlamentsMerrli) && HasInList(cards, CardId.TearlamentsMerrli)) bot_send_to_deck_ids.Add(CardId.TearlamentsMerrli);
+                        if (!Bot.HasInDeck(CardId.TearlamentsHavnis) && HasInList(cards, CardId.TearlamentsHavnis)) bot_send_to_deck_ids.Add(CardId.TearlamentsHavnis);
                     }
                     temp = CardsIdToClientCards(bot_send_to_deck_ids, b_cards);
                     if (temp.Count > 0)
@@ -1341,10 +1341,10 @@ namespace WindBot.Game.AI.Decks
                     }
                     bot_send_to_deck_ids.Clear();
                     if (HasInList(cards, CardId.NaelshaddollAriel)) bot_send_to_deck_ids.Add(CardId.NaelshaddollAriel);
-                    if (CheckRemainInDeck(CardId.KelbektheAncientVanguard) <= 0 && HasInList(cards, CardId.KelbektheAncientVanguard)) bot_send_to_deck_ids.Add(CardId.KelbektheAncientVanguard);
-                    if (CheckRemainInDeck(CardId.AgidotheAncientSentinel) <= 0 && HasInList(cards, CardId.AgidotheAncientSentinel)) bot_send_to_deck_ids.Add(CardId.AgidotheAncientSentinel);
-                    if (CheckRemainInDeck(CardId.HeraldofOrangeLight) <= 0 && HasInList(cards, CardId.HeraldofOrangeLight)) bot_send_to_deck_ids.Add(CardId.HeraldofOrangeLight);
-                    if (CheckRemainInDeck(CardId.HeraldofGreenLight) <= 0 && HasInList(cards, CardId.HeraldofGreenLight)) bot_send_to_deck_ids.Add(CardId.HeraldofGreenLight);
+                    if (!Bot.HasInDeck(CardId.KelbektheAncientVanguard) && HasInList(cards, CardId.KelbektheAncientVanguard)) bot_send_to_deck_ids.Add(CardId.KelbektheAncientVanguard);
+                    if (!Bot.HasInDeck(CardId.AgidotheAncientSentinel) && HasInList(cards, CardId.AgidotheAncientSentinel)) bot_send_to_deck_ids.Add(CardId.AgidotheAncientSentinel);
+                    if (!Bot.HasInDeck(CardId.HeraldofOrangeLight) && HasInList(cards, CardId.HeraldofOrangeLight)) bot_send_to_deck_ids.Add(CardId.HeraldofOrangeLight);
+                    if (!Bot.HasInDeck(CardId.HeraldofGreenLight) && HasInList(cards, CardId.HeraldofGreenLight)) bot_send_to_deck_ids.Add(CardId.HeraldofGreenLight);
                     temp = CardsIdToClientCards(bot_send_to_deck_ids, b_cards);
                     if (temp.Count > 0)
                     {
@@ -1399,8 +1399,8 @@ namespace WindBot.Game.AI.Decks
                 else
                 {
                     if (HasInList(cards, CardId.DivineroftheHerald) && !activate_DivineroftheHerald && FusionDeckCheck()
-                        && ((CheckRemainInDeck(CardId.AgidotheAncientSentinel) > 0 && !activate_AgidotheAncientSentinel_2)
-                        || (CheckRemainInDeck(CardId.KelbektheAncientVanguard) > 0 && !activate_KelbektheAncientVanguard_2)))
+                        && ((Bot.HasInDeck(CardId.AgidotheAncientSentinel) && !activate_AgidotheAncientSentinel_2)
+                        || (Bot.HasInDeck(CardId.KelbektheAncientVanguard) && !activate_KelbektheAncientVanguard_2)))
                     {
                         ids.Add(CardId.DivineroftheHerald);
                     }
@@ -1459,9 +1459,9 @@ namespace WindBot.Game.AI.Decks
                         }
                         res0 = cards.Where(card => card != null && card.Id == CardId.TearlamentsKitkallos).ToList();
                         if (res0.Count > 0 && ((!activate_TearlamentsKitkallos_1 &&
-                            ((!activate_TearlamentsScheiren_2 && CheckRemainInDeck(CardId.TearlamentsScheiren) > 0)
-                            || (!activate_TearlamentsHavnis_2 && CheckRemainInDeck(CardId.TearlamentsHavnis) > 0)
-                            || (!activate_TearlamentsMerrli_2 && CheckRemainInDeck(CardId.TearlamentsMerrli) > 0))) || !activate_TearlamentsKitkallos_2))
+                            ((!activate_TearlamentsScheiren_2 && Bot.HasInDeck(CardId.TearlamentsScheiren))
+                            || (!activate_TearlamentsHavnis_2 && Bot.HasInDeck(CardId.TearlamentsHavnis))
+                            || (!activate_TearlamentsMerrli_2 && Bot.HasInDeck(CardId.TearlamentsMerrli)))) || !activate_TearlamentsKitkallos_2))
                         {
                             TearlamentsKitkallos_summoned = true;
                             return Util.CheckSelectCount(res0, cards, min, max);
@@ -1511,9 +1511,9 @@ namespace WindBot.Game.AI.Decks
                     {
                         List<ClientCard> res = cards.Where(card => card != null && card.Id == CardId.TearlamentsKitkallos).ToList();
                         if (res.Count > 0 && !activate_TearlamentsKitkallos_1 &&
-                            ((!activate_TearlamentsScheiren_2 && CheckRemainInDeck(CardId.TearlamentsScheiren) > 0)
-                            || (!activate_TearlamentsHavnis_2 && CheckRemainInDeck(CardId.TearlamentsHavnis) > 0)
-                            || (!activate_TearlamentsMerrli_2 && CheckRemainInDeck(CardId.TearlamentsMerrli) > 0)) && Bot.GetMonstersInMainZone().Count < 4)
+                            ((!activate_TearlamentsScheiren_2 && Bot.HasInDeck(CardId.TearlamentsScheiren))
+                            || (!activate_TearlamentsHavnis_2 && Bot.HasInDeck(CardId.TearlamentsHavnis))
+                            || (!activate_TearlamentsMerrli_2 && Bot.HasInDeck(CardId.TearlamentsMerrli))) && Bot.GetMonstersInMainZone().Count < 4)
                         {
                             TearlamentsKitkallos_summoned = true;
                             return Util.CheckSelectCount(res, cards, min, max);
@@ -1564,9 +1564,9 @@ namespace WindBot.Game.AI.Decks
         }
         private bool IsCanFusionSummon()
         {
-            if ((!activate_TearlamentsMerrli_2 && CheckRemainInDeck(CardId.TearlamentsMerrli) > 0)
-                || (!activate_TearlamentsHavnis_2 && CheckRemainInDeck(CardId.TearlamentsHavnis) > 0)
-                || (!activate_TearlamentsScheiren_2 && CheckRemainInDeck(CardId.TearlamentsScheiren) > 0))
+            if ((!activate_TearlamentsMerrli_2 && Bot.HasInDeck(CardId.TearlamentsMerrli))
+                || (!activate_TearlamentsHavnis_2 && Bot.HasInDeck(CardId.TearlamentsHavnis))
+                || (!activate_TearlamentsScheiren_2 && Bot.HasInDeck(CardId.TearlamentsScheiren)))
                 return Bot.ExtraDeck.Count(card => card != null && card.HasType(CardType.Fusion) && card.Id != CardId.ElderEntityNtss) > 0;
             return false;
 
@@ -1618,68 +1618,24 @@ namespace WindBot.Game.AI.Decks
         }
         private bool FusionDeckCheck()
         {
-            return (CheckRemainInDeck(CardId.TearlamentsHavnis) > 0 && !activate_TearlamentsHavnis_2)
-                    || (CheckRemainInDeck(CardId.TearlamentsMerrli) > 0 && !activate_TearlamentsMerrli_2)
-                    || (CheckRemainInDeck(CardId.TearlamentsScheiren) > 0 && !activate_TearlamentsScheiren_2);
+            return (Bot.HasInDeck(CardId.TearlamentsHavnis) && !activate_TearlamentsHavnis_2)
+                    || (Bot.HasInDeck(CardId.TearlamentsMerrli) && !activate_TearlamentsMerrli_2)
+                    || (Bot.HasInDeck(CardId.TearlamentsScheiren) && !activate_TearlamentsScheiren_2);
         }
         private List<int> GetCardsIdSendToHand()
         {
             List<int> ids = new List<int>();
-            if (!activate_TearlamentsScheiren_1 && !Bot.HasInHand(CardId.TearlamentsScheiren) && CheckRemainInDeck(CardId.TearlamentsScheiren) > 0 && Bot.Hand.Count(card => card != null && card.HasType(CardType.Monster)) > 0) ids.Add(CardId.TearlamentsScheiren);
-            if (!activate_TearlamentsMerrli_1 && !Bot.HasInHand(CardId.TearlamentsMerrli) && CheckRemainInDeck(CardId.TearlamentsMerrli) > 0 && (!summoned ||!activate_TearlamentsKitkallos_2) ) ids.Add(CardId.TearlamentsMerrli);
-            if (!activate_TearlamentsReinoheart_1 && !Bot.HasInHand(CardId.TearlamentsReinoheart) && CheckRemainInDeck(CardId.TearlamentsReinoheart) > 0) ids.Add(CardId.TearlamentsReinoheart);
-            if (!activate_TearlamentsScheiren_1 && !Bot.HasInHand(CardId.TearlamentsScheiren) && CheckRemainInDeck(CardId.TearlamentsScheiren) > 0) ids.Add(CardId.TearlamentsScheiren);
-            if (!activate_TearlamentsHavnis_1 && !Bot.HasInHand(CardId.TearlamentsHavnis) && CheckRemainInDeck(CardId.TearlamentsHavnis) > 0)
+            if (!activate_TearlamentsScheiren_1 && !Bot.HasInHand(CardId.TearlamentsScheiren) && Bot.HasInDeck(CardId.TearlamentsScheiren) && Bot.Hand.Count(card => card != null && card.HasType(CardType.Monster)) > 0) ids.Add(CardId.TearlamentsScheiren);
+            if (!activate_TearlamentsMerrli_1 && !Bot.HasInHand(CardId.TearlamentsMerrli) && Bot.HasInDeck(CardId.TearlamentsMerrli) && (!summoned ||!activate_TearlamentsKitkallos_2) ) ids.Add(CardId.TearlamentsMerrli);
+            if (!activate_TearlamentsReinoheart_1 && !Bot.HasInHand(CardId.TearlamentsReinoheart) && Bot.HasInDeck(CardId.TearlamentsReinoheart)) ids.Add(CardId.TearlamentsReinoheart);
+            if (!activate_TearlamentsScheiren_1 && !Bot.HasInHand(CardId.TearlamentsScheiren) && Bot.HasInDeck(CardId.TearlamentsScheiren)) ids.Add(CardId.TearlamentsScheiren);
+            if (!activate_TearlamentsHavnis_1 && !Bot.HasInHand(CardId.TearlamentsHavnis) && Bot.HasInDeck(CardId.TearlamentsHavnis))
             {
                 if (Duel.Player == 0 && (Duel.Phase != DuelPhase.End || AllActivated())) ids.Add(CardId.TearlamentsHavnis);
                 else ids.Insert(0, CardId.TearlamentsHavnis);
             }
             ids.AddRange(new List<int>() { CardId.TearlamentsScheiren, CardId.TearlamentsMerrli, CardId.TearlamentsHavnis, CardId.TearlamentsReinoheart });
             return ids;
-        }
-        public int CheckRemainInDeck(int id)
-        {
-            switch (id)
-            {
-                case CardId.ShaddollBeast:
-                    return Bot.GetRemainingCount(CardId.ShaddollBeast, 1);
-                case CardId.ShaddollDragon:
-                    return Bot.GetRemainingCount(CardId.ShaddollDragon, 1);
-                case CardId.TearlamentsScheiren:
-                    return Bot.GetRemainingCount(CardId.TearlamentsScheiren, 3);
-                case CardId.TearlamentsReinoheart:
-                    return Bot.GetRemainingCount(CardId.TearlamentsReinoheart, 2);
-                case CardId.KelbektheAncientVanguard:
-                    return Bot.GetRemainingCount(CardId.KelbektheAncientVanguard, 3);
-                case CardId.MudoratheSwordOracle:
-                    return Bot.GetRemainingCount(CardId.MudoratheSwordOracle, 3);
-                case CardId.AgidotheAncientSentinel:
-                    return Bot.GetRemainingCount(CardId.AgidotheAncientSentinel, 3);
-                case CardId.KeldotheSacredProtector:
-                    return Bot.GetRemainingCount(CardId.KeldotheSacredProtector, 2);
-                case CardId.NaelshaddollAriel:
-                    return Bot.GetRemainingCount(CardId.NaelshaddollAriel, 1);
-                case CardId.TearlamentsHavnis:
-                    return Bot.GetRemainingCount(CardId.TearlamentsHavnis, 3);
-                case CardId.TearlamentsMerrli:
-                    return Bot.GetRemainingCount(CardId.TearlamentsMerrli, 3);
-                case CardId.DivineroftheHerald:
-                    return Bot.GetRemainingCount(CardId.DivineroftheHerald, 3);
-                case CardId.HeraldofOrangeLight:
-                    return Bot.GetRemainingCount(CardId.HeraldofOrangeLight, 3);
-                case CardId.HeraldofGreenLight:
-                    return Bot.GetRemainingCount(CardId.HeraldofGreenLight, 3);
-                case CardId.Eva:
-                    return Bot.GetRemainingCount(CardId.Eva, 1);
-                case CardId.TearlamentsScream:
-                    return Bot.GetRemainingCount(CardId.TearlamentsScream, 1);
-                case CardId.PrimevalPlanetPerlereino:
-                    return Bot.GetRemainingCount(CardId.PrimevalPlanetPerlereino, 2);
-                case CardId.TearlamentsSulliek:
-                    return Bot.GetRemainingCount(CardId.TearlamentsSulliek, 2);
-                default:
-                    return 0;
-            }
         }
         private bool PredaplantDragostapeliaEffect()
         {
@@ -2158,8 +2114,8 @@ namespace WindBot.Game.AI.Decks
         }
         private bool DivineroftheHeraldSummon()
         {
-            if ((CheckRemainInDeck(CardId.KelbektheAncientVanguard) > 0 && !activate_KelbektheAncientVanguard_2)
-                || (CheckRemainInDeck(CardId.AgidotheAncientSentinel) > 0 && !activate_AgidotheAncientSentinel_2))
+            if ((Bot.HasInDeck(CardId.KelbektheAncientVanguard) && !activate_KelbektheAncientVanguard_2)
+                || (Bot.HasInDeck(CardId.AgidotheAncientSentinel) && !activate_AgidotheAncientSentinel_2))
             { 
                 summoned = true;
                 return true;
@@ -2180,11 +2136,11 @@ namespace WindBot.Game.AI.Decks
             {
                 if (Duel.Player == 0)
                 {
-                    if (!IsCanSpSummon() && CheckRemainInDeck(CardId.MudoratheSwordOracle) <= 0 && CheckRemainInDeck(CardId.KeldotheSacredProtector) <= 0) return false;
+                    if (!IsCanSpSummon() && !Bot.HasInDeck(CardId.MudoratheSwordOracle) && !Bot.HasInDeck(CardId.KeldotheSacredProtector)) return false;
                     if ((AllActivated() || Bot.ExtraDeck.Count(card=>card!=null && card.HasType(CardType.Fusion) && card.Id!=CardId.ElderEntityNtss)<=0)
-                        && CheckRemainInDeck(CardId.MudoratheSwordOracle)<=0 && CheckRemainInDeck(CardId.KeldotheSacredProtector)<=0) return false;
-                    if ((activate_KelbektheAncientVanguard_2 || CheckRemainInDeck(CardId.KelbektheAncientVanguard) <= 0)
-                       && (activate_AgidotheAncientSentinel_2 || CheckRemainInDeck(CardId.AgidotheAncientSentinel) <= 0) && Bot.HasInExtra(CardId.SprightElf))
+                        && !Bot.HasInDeck(CardId.MudoratheSwordOracle) && !Bot.HasInDeck(CardId.KeldotheSacredProtector)) return false;
+                    if ((activate_KelbektheAncientVanguard_2 || !Bot.HasInDeck(CardId.KelbektheAncientVanguard))
+                       && (activate_AgidotheAncientSentinel_2 || !Bot.HasInDeck(CardId.AgidotheAncientSentinel)) && Bot.HasInExtra(CardId.SprightElf))
                     {
                         List<ClientCard> cards = Bot.GetMonsters().Where(card => card != null && card.IsFaceup() && !no_link_ids.Contains(card.Id) && card != Card).ToList();
                         if (cards.Count() >= 1) return false;
@@ -2437,9 +2393,9 @@ namespace WindBot.Game.AI.Decks
         }
         private bool AllActivated()
         {
-            return (activate_TearlamentsScheiren_2 || CheckRemainInDeck(CardId.TearlamentsScheiren) <= 0)
-                && (activate_TearlamentsHavnis_2 || CheckRemainInDeck(CardId.TearlamentsHavnis) <= 0)
-                && (activate_TearlamentsMerrli_2 || CheckRemainInDeck(CardId.TearlamentsMerrli) <= 0);
+            return (activate_TearlamentsScheiren_2 || !Bot.HasInDeck(CardId.TearlamentsScheiren))
+                && (activate_TearlamentsHavnis_2 || !Bot.HasInDeck(CardId.TearlamentsHavnis))
+                && (activate_TearlamentsMerrli_2 || !Bot.HasInDeck(CardId.TearlamentsMerrli));
         }
         private bool KelbektheAncientVanguardEffect()
         {
@@ -2550,7 +2506,7 @@ namespace WindBot.Game.AI.Decks
                 else if (!activate_TearlamentsHavnis_2 && Bot.HasInMonstersZone(CardId.TearlamentsHavnis) && IsShouldSummonFusion()) AI.SelectCard(CardId.TearlamentsHavnis);
                 else if (Bot.HasInMonstersZone(CardId.TearlamentsReinoheart) && !activate_TearlamentsReinoheart_1 && !AllActivated()) AI.SelectCard(CardId.TearlamentsReinoheart);
                 else if (Bot.HasInMonstersZone(CardId.Eva) && Bot.Graveyard.Count(card => card != null && card.HasAttribute(CardAttribute.Light) && card.HasRace(CardRace.Fairy)) > 0
-                    && (CheckRemainInDeck(CardId.HeraldofGreenLight) > 0 || CheckRemainInDeck(CardId.HeraldofOrangeLight) > 0)) AI.SelectCard(CardId.Eva);
+                    && (Bot.HasInDeck(CardId.HeraldofGreenLight) || Bot.HasInDeck(CardId.HeraldofOrangeLight))) AI.SelectCard(CardId.Eva);
                 else if ((Bot.HasInExtra(CardId.TearlamentsRulkallos) && !Bot.HasInGraveyard(CardId.TearlamentsKitkallos))
                     || (Bot.HasInExtra(CardId.PredaplantDragostapelia) && Bot.Graveyard.Count(card => card != null && card.HasType(CardType.Fusion)) <= 0)) AI.SelectCard(CardId.TearlamentsKitkallos);
                 else if (Bot.HasInMonstersZone(CardId.ShaddollDragon) && Enemy.GetSpellCount() > 0) AI.SelectCard(CardId.ShaddollDragon);
@@ -2594,9 +2550,9 @@ namespace WindBot.Game.AI.Decks
             }
             if (loc == CardLocation.Deck)
             {
-                if (!activate_TearlamentsScheiren_2 && CheckRemainInDeck(CardId.TearlamentsScheiren)>0) return true;
-                if (!activate_TearlamentsHavnis_2 && CheckRemainInDeck(CardId.TearlamentsHavnis)>0) return true;
-                if (!activate_TearlamentsMerrli_2 && CheckRemainInDeck(CardId.TearlamentsMerrli)>0) return true;
+                if (!activate_TearlamentsScheiren_2 && Bot.HasInDeck(CardId.TearlamentsScheiren)) return true;
+                if (!activate_TearlamentsHavnis_2 && Bot.HasInDeck(CardId.TearlamentsHavnis)) return true;
+                if (!activate_TearlamentsMerrli_2 && Bot.HasInDeck(CardId.TearlamentsMerrli)) return true;
             }
             return false;
         }
@@ -2621,9 +2577,9 @@ namespace WindBot.Game.AI.Decks
                         if (Duel.LastChainPlayer == 0  || Duel.CurrentChain.Count(ccard=>ccard!=null &&ccard.Controller==0
                             && (ccard.Id==CardId.TearlamentsHavnis || ccard.Id == CardId.TearlamentsMerrli || ccard.Id == CardId.TearlamentsScheiren))>0) return false;
                         if (((Bot.HasInMonstersZone(CardId.TearlamentsKitkallos,false,false,true) && !activate_TearlamentsKitkallos_3 && IsShouldSummonFusion(SETCODE, (int)CardRace.Aqua)
-                            && ((CheckRemainInDeck(CardId.TearlamentsHavnis) > 0 && !activate_TearlamentsHavnis_2)
-                            || (CheckRemainInDeck(CardId.TearlamentsMerrli) > 0 && !activate_TearlamentsMerrli_2)
-                            || (CheckRemainInDeck(CardId.TearlamentsScheiren) > 0 && !activate_TearlamentsScheiren_2)) && Bot.GetMonsterCount()<3)
+                            && ((Bot.HasInDeck(CardId.TearlamentsHavnis) && !activate_TearlamentsHavnis_2)
+                            || (Bot.HasInDeck(CardId.TearlamentsMerrli) && !activate_TearlamentsMerrli_2)
+                            || (Bot.HasInDeck(CardId.TearlamentsScheiren) && !activate_TearlamentsScheiren_2)) && Bot.GetMonsterCount()<3)
                             ||(IsCanFusionSummon() && (Bot.HasInMonstersZone(CardId.TearlamentsScheiren) || Bot.HasInMonstersZone(CardId.TearlamentsHavnis)
                             || Bot.HasInMonstersZone(CardId.TearlamentsMerrli))) || (!activate_TearlamentsReinoheart_2 && Bot.HasInMonstersZone(CardId.TearlamentsReinoheart) && (HasinZoneKeyCard(CardLocation.Hand)
                             || (Bot.Hand.Count(ccard=> ccard != null && ccard.HasSetcode(SETCODE))>0 && HasinZoneKeyCard(CardLocation.Deck)))&& IsShouldSummonFusion(SETCODE, (int)CardRace.Aqua))) && IsCanSpSummon())

--- a/Game/AI/Decks/ThunderDragonExecutor.cs
+++ b/Game/AI/Decks/ThunderDragonExecutor.cs
@@ -2212,7 +2212,7 @@ namespace WindBot.Game.AI.Decks
                         || HasInZoneNoActivate(CardId.WhiteDragonWyverburster, CardLocation.Hand) || HasInZoneNoActivate(CardId.BlackDragonCollapserpent, CardLocation.Hand)
                         || HasInZoneNoActivate(CardId.TheChaosCreator, CardLocation.Hand)) && Bot.HasInDeck(CardId.BatterymanSolar))
                         AI.SelectCard(CardId.BatterymanSolar);
-                else if(Bot.HasInMonstersZone(CardId.ThunderDragonTitan,true,false,true) && Bot.GetRemainingCount(CardId.NormalThunderDragon)>1)
+                else if(Bot.HasInMonstersZone(CardId.ThunderDragonTitan,true,false,true) && Bot.GetCardCountInDeck(CardId.NormalThunderDragon)>1)
                         AI.SelectCard(CardId.NormalThunderDragon);
                 else if(!HasInZoneNoActivate(CardId.ThunderDragonroar,CardLocation.Deck))
                         AI.SelectCard(CardId.ThunderDragonroar);
@@ -2415,11 +2415,11 @@ namespace WindBot.Game.AI.Decks
                     else if (HasInZoneNoActivate(CardId.ThunderDragonroar, CardLocation.Hand) && handActivated
                             && Bot.HasInDeck(CardId.ThunderDragonlord))
                         AI.SelectCard(CardId.ThunderDragonlord);
-                    else if (Bot.HasInDeck(CardId.ThunderDragonlord) && Bot.GetRemainingCount(CardId.NormalThunderDragon) > 1)
+                    else if (Bot.HasInDeck(CardId.ThunderDragonlord) && Bot.GetCardCountInDeck(CardId.NormalThunderDragon) > 1)
                         AI.SelectCard(CardId.ThunderDragonlord);
                     else if (handActivated && Bot.HasInHand(CardId.ThunderDragonlord) && Bot.HasInDeck(CardId.ThunderDragonroar))
                         AI.SelectCard(CardId.ThunderDragonroar);
-                    else if (Bot.GetRemainingCount(CardId.NormalThunderDragon) > 1 && !handActivated)
+                    else if (Bot.GetCardCountInDeck(CardId.NormalThunderDragon) > 1 && !handActivated)
                         AI.SelectCard(CardId.NormalThunderDragon);
                     else
                         AI.SelectCard(CardId.ThunderDragonmatrix, CardId.ThunderDragondark, CardId.ThunderDragonroar, CardId.NormalThunderDragon);

--- a/Game/AI/Decks/ThunderDragonExecutor.cs
+++ b/Game/AI/Decks/ThunderDragonExecutor.cs
@@ -190,64 +190,7 @@ namespace WindBot.Game.AI.Decks
             AddExecutor(ExecutorType.Repos, DefaultMonsterRepos);
 
         }
-        #region DeckCheck
-        public int CheckRemainInDeck(int id)
-        {
-            switch (id)
-            {
-                case CardId.ThunderDragonlord:
-                    return Bot.GetRemainingCount(CardId.ThunderDragonlord, 1);
-                case CardId.TheBystialLubellion:
-                    return Bot.GetRemainingCount(CardId.TheBystialLubellion, 2);
-                case CardId.TheChaosCreator:
-                    return Bot.GetRemainingCount(CardId.TheChaosCreator, 1);
-                case CardId.BystialDruiswurm:
-                    return Bot.GetRemainingCount(CardId.BystialDruiswurm, 2);
-                case CardId.BystialMagnamhut:
-                    return Bot.GetRemainingCount(CardId.BystialMagnamhut, 2);
-                case CardId.ThunderDragonroar:
-                    return Bot.GetRemainingCount(CardId.ThunderDragonroar, 2);
-                case CardId.ThunderDragonhawk:
-                    return Bot.GetRemainingCount(CardId.ThunderDragonhawk, 2);
-                case CardId.NormalThunderDragon:
-                    return Bot.GetRemainingCount(CardId.NormalThunderDragon, 3);
-                case CardId.ThunderDragondark:
-                    return Bot.GetRemainingCount(CardId.ThunderDragondark, 3);
-                case CardId.BlackDragonCollapserpent:
-                    return Bot.GetRemainingCount(CardId.BlackDragonCollapserpent, 2);
-                case CardId.WhiteDragonWyverburster:
-                    return Bot.GetRemainingCount(CardId.WhiteDragonWyverburster, 2);
-                case CardId.AloofLupine:
-                    return Bot.GetRemainingCount(CardId.AloofLupine, 2);
-                case CardId.BatterymanSolar:
-                    return Bot.GetRemainingCount(CardId.BatterymanSolar, 3);
-                case CardId.AshBlossom:
-                    return Bot.GetRemainingCount(CardId.AshBlossom, 2);
-                case CardId.G:
-                    return Bot.GetRemainingCount(CardId.G, 3);
-                case CardId.DragonBusterDestructionSword:
-                    return Bot.GetRemainingCount(CardId.DragonBusterDestructionSword, 1);
-                case CardId.ThunderDragonmatrix:
-                    return Bot.GetRemainingCount(CardId.ThunderDragonmatrix, 3);
-                case CardId.AllureofDarkness:
-                    return Bot.GetRemainingCount(CardId.AllureofDarkness, 3);
-                case CardId.GoldSarcophagus:
-                    return Bot.GetRemainingCount(CardId.GoldSarcophagus, 1);
-                case CardId.ThunderDragonFusion:
-                    return Bot.GetRemainingCount(CardId.ThunderDragonFusion, 2);
-                case CardId.ChaosSpace:
-                    return Bot.GetRemainingCount(CardId.ChaosSpace, 3);
-                case CardId.CalledbytheGrave:
-                    return Bot.GetRemainingCount(CardId.CalledbytheGrave, 2);
-                case CardId.BrandedRegained:
-                    return Bot.GetRemainingCount(CardId.BrandedRegained, 1);
-                case CardId.InfiniteImpermanence:
-                    return Bot.GetRemainingCount(CardId.InfiniteImpermanence, 2);
-                default:
-                    return 0;
-            }
-        }
-        #endregion
+
 
         public override bool OnSelectHand()
         {
@@ -1097,7 +1040,7 @@ namespace WindBot.Game.AI.Decks
             if (ActivateDescription == Util.GetStringId(CardId.PredaplantVerteAnaconda, 1))
             {
                 if (DefaultCheckWhetherCardIsNegated(Card)) return false;
-                if (CheckRemainInDeck(CardId.ThunderDragonFusion) <= 0) return false;
+                if (!Bot.HasInDeck(CardId.ThunderDragonFusion)) return false;
                 if (Bot.GetMonstersInMainZone().Count > 4 && Bot.GetMonstersInMainZone().Count(card => card != null && !card.IsExtraCard() && card.HasSetcode(0x11c) && card.HasType(CardType.Monster) && card.IsFaceup()) <= 0) return false;
                 List<ClientCard> g_card = Bot.Graveyard.ToList();
                 List<ClientCard> b_card = Bot.Banished.ToList();
@@ -1167,11 +1110,11 @@ namespace WindBot.Game.AI.Decks
             if (Duel.Phase == DuelPhase.End)
             {
                 int count = Bot.Graveyard.Count(card => card != null && card.HasRace(CardRace.Thunder));
-                if ((Bot.HasInGraveyard(CardId.ThunderDragonroar) || Bot.HasInGraveyard(CardId.ThunderDragondark) && count > 1) && CheckRemainInDeck(CardId.ThunderDragonFusion) >0 )
+                if ((Bot.HasInGraveyard(CardId.ThunderDragonroar) || Bot.HasInGraveyard(CardId.ThunderDragondark) && count > 1) && Bot.HasInDeck(CardId.ThunderDragonFusion) )
                     AI.SelectCard(CardId.ThunderDragonFusion);
-                else if(!Bot.HasInGraveyard(CardId.ThunderDragonroar) && CheckRemainInDeck(CardId.ThunderDragonroar) > 0)
+                else if(!Bot.HasInGraveyard(CardId.ThunderDragonroar) && Bot.HasInDeck(CardId.ThunderDragonroar))
                     AI.SelectCard(CardId.ThunderDragonroar);
-                else if(!Bot.HasInGraveyard(CardId.ThunderDragondark) && CheckRemainInDeck(CardId.ThunderDragondark) > 0)
+                else if(!Bot.HasInGraveyard(CardId.ThunderDragondark) && Bot.HasInDeck(CardId.ThunderDragondark))
                     AI.SelectCard(CardId.ThunderDragondark);
                 else AI.SelectCard(CardId.ThunderDragonmatrix,CardId.NormalThunderDragon,CardId.BatterymanSolar);
                 return true;
@@ -1204,7 +1147,7 @@ namespace WindBot.Game.AI.Decks
         }
         private bool PredaplantVerteAnacondaSummon()
         {
-            if (CheckRemainInDeck(CardId.ThunderDragonFusion) <= 0) return false;
+            if (!Bot.HasInDeck(CardId.ThunderDragonFusion)) return false;
             List<ClientCard> g_card = Bot.Graveyard.ToList();
             List<ClientCard> b_card = Bot.Banished.ToList();
             g_card.AddRange(b_card);
@@ -1542,7 +1485,7 @@ namespace WindBot.Game.AI.Decks
         }
         private bool StrikerDragonSummon()
         {
-            if ((summon_WhiteDragonWyverburster && summon_BlackDragonCollapserpent) || CheckRemainInDeck(CardId.WhiteDragonWyverburster) <= 0 || CheckRemainInDeck(CardId.BlackDragonCollapserpent) <= 0) return false;
+            if ((summon_WhiteDragonWyverburster && summon_BlackDragonCollapserpent) || !Bot.HasInDeck(CardId.WhiteDragonWyverburster) || !Bot.HasInDeck(CardId.BlackDragonCollapserpent)) return false;
             return Bot.GetMonsters().Count(card => card != null && card.HasRace(CardRace.Dragon) && card.Level > 1) > 0;
         }
         private bool DefaultSummon()
@@ -1660,7 +1603,7 @@ namespace WindBot.Game.AI.Decks
         private bool BlackDragonCollapserpentSummon()
         {
             if (Bot.Graveyard.Count(card => card != null && card.HasAttribute(CardAttribute.Light)) <= 1
-                && Bot.HasInGraveyard(CardId.TheBystialLubellion) && CheckRemainInDeck(CardId.BrandedRegained) > 0 && !summon_TheBystialLubellion)
+                && Bot.HasInGraveyard(CardId.TheBystialLubellion) && Bot.HasInDeck(CardId.BrandedRegained) && !summon_TheBystialLubellion)
                 return false;
             return BlackDragonCollapserpentSummon_2();
         }
@@ -1682,7 +1625,7 @@ namespace WindBot.Game.AI.Decks
         }
         private bool UnionCarrierSummon()
         {
-            if (CheckRemainInDeck(CardId.DragonBusterDestructionSword) <= 0 || !Bot.HasInMonstersZone(CardId.ThunderDragonColossus,false,false,true)) return false;
+            if (!Bot.HasInDeck(CardId.DragonBusterDestructionSword) || !Bot.HasInMonstersZone(CardId.ThunderDragonColossus,false,false,true)) return false;
             return UnionCarrierSummon_2(); 
         }
         private bool LinkCheck(bool exZone_1)
@@ -2125,7 +2068,7 @@ namespace WindBot.Game.AI.Decks
         {
             switch (location)
             {
-                case CardLocation.Deck: if (CheckRemainInDeck(cardId) <= 0) return false;  break;
+                case CardLocation.Deck: if (!Bot.HasInDeck(cardId)) return false;  break;
                 case CardLocation.Hand: if (!Bot.HasInHand(cardId)) return false;  break;
                 case CardLocation.Grave: if (!Bot.HasInGraveyard(cardId)) return false;  break;
                 case CardLocation.Removed: if (!Bot.HasInBanished(cardId)) return false; break;
@@ -2187,7 +2130,7 @@ namespace WindBot.Game.AI.Decks
                 else if (HasInZoneNoActivate(CardId.ThunderDragonmatrix, CardLocation.Deck) && !_ThunderDragonmatrix
                       && !Bot.HasInMonstersZone(CardId.ThunderDragonmatrix, false, false, true))
                     AI.SelectNextCard(CardId.ThunderDragonmatrix);
-                else if(Bot.HasInGraveyard(CardId.TheChaosCreator) && !activate_ChaosSpace_grave && CheckRemainInDeck(CardId.ThunderDragonlord) > 0)
+                else if(Bot.HasInGraveyard(CardId.TheChaosCreator) && !activate_ChaosSpace_grave && Bot.HasInDeck(CardId.ThunderDragonlord))
                     AI.SelectNextCard(CardId.ThunderDragonlord);
                 else
                     AI.SelectNextCard(CardId.NormalThunderDragon);
@@ -2259,21 +2202,21 @@ namespace WindBot.Game.AI.Decks
             {
                 if (Bot.Graveyard.Count(card => card != null && card.HasAttribute(CardAttribute.Dark)) > 0
                     && Bot.Graveyard.Count(card => card != null && card.HasAttribute(CardAttribute.Light)) > 0
-                    && CheckRemainInDeck(CardId.TheChaosCreator) > 0)
+                    && Bot.HasInDeck(CardId.TheChaosCreator))
                     AI.SelectCard(CardId.TheChaosCreator);
                 else if(Bot.HasInGraveyardOrInBanished(CardId.ThunderDragonroar) || Bot.HasInGraveyardOrInBanished(CardId.ThunderDragondark)
                          || Bot.HasInGraveyardOrInBanished(CardId.ThunderDragonlord) || Bot.HasInGraveyardOrInBanished(CardId.ThunderDragonmatrix)
-                         || Bot.HasInGraveyardOrInBanished(CardId.NormalThunderDragon) && CheckRemainInDeck(CardId.ThunderDragonhawk) > 0)
+                         || Bot.HasInGraveyardOrInBanished(CardId.NormalThunderDragon) && Bot.HasInDeck(CardId.ThunderDragonhawk))
                          AI.SelectCard(CardId.ThunderDragonhawk);
                 else if((HasInZoneNoActivate(CardId.BystialDruiswurm,CardLocation.Hand) || HasInZoneNoActivate(CardId.BystialMagnamhut, CardLocation.Hand)
                         || HasInZoneNoActivate(CardId.WhiteDragonWyverburster, CardLocation.Hand) || HasInZoneNoActivate(CardId.BlackDragonCollapserpent, CardLocation.Hand)
-                        || HasInZoneNoActivate(CardId.TheChaosCreator, CardLocation.Hand)) && CheckRemainInDeck(CardId.BatterymanSolar) > 0)
+                        || HasInZoneNoActivate(CardId.TheChaosCreator, CardLocation.Hand)) && Bot.HasInDeck(CardId.BatterymanSolar))
                         AI.SelectCard(CardId.BatterymanSolar);
-                else if(Bot.HasInMonstersZone(CardId.ThunderDragonTitan,true,false,true) && CheckRemainInDeck(CardId.NormalThunderDragon)>1)
+                else if(Bot.HasInMonstersZone(CardId.ThunderDragonTitan,true,false,true) && Bot.GetRemainingCount(CardId.NormalThunderDragon)>1)
                         AI.SelectCard(CardId.NormalThunderDragon);
                 else if(!HasInZoneNoActivate(CardId.ThunderDragonroar,CardLocation.Deck))
                         AI.SelectCard(CardId.ThunderDragonroar);
-                else if(handActivated && CheckRemainInDeck(CardId.ThunderDragonlord) > 0)
+                else if(handActivated && Bot.HasInDeck(CardId.ThunderDragonlord))
                         AI.SelectCard(CardId.ThunderDragonlord);
                 else
                     AI.SelectCard(CardId.TheChaosCreator,CardId.ThunderDragondark,CardId.ThunderDragonlord);
@@ -2322,7 +2265,7 @@ namespace WindBot.Game.AI.Decks
         {
             if (Card.Location == CardLocation.Grave)
             {
-                if((CheckRemainInDeck(CardId.ThunderDragonFusion)>0 || Bot.HasInHandOrInSpellZone(CardId.ThunderDragonFusion))
+                if((Bot.HasInDeck(CardId.ThunderDragonFusion) || Bot.HasInHandOrInSpellZone(CardId.ThunderDragonFusion))
                    && !Bot.HasInExtra(CardId.ThunderDragonTitan))
                     AI.SelectCard(CardId.ThunderDragonTitan,CardId.ThunderDragonColossus, CardId.BlackDragonCollapserpent, CardId.WhiteDragonWyverburster, CardId.TheBystialLubellion);
                 else 
@@ -2429,7 +2372,7 @@ namespace WindBot.Game.AI.Decks
                         return true;
                     }
                     if (Duel.CurrentChain.Count > 0 || Duel.Phase < DuelPhase.Main1) return false;
-                    if (handActivated || (Bot.HasInHand(CardId.NormalThunderDragon) && CheckRemainInDeck(CardId.NormalThunderDragon) > 0) || !Bot.HasInExtra(CardId.ThunderDragonColossus)) return false;
+                    if (handActivated || (Bot.HasInHand(CardId.NormalThunderDragon) && Bot.HasInDeck(CardId.NormalThunderDragon)) || !Bot.HasInExtra(CardId.ThunderDragonColossus)) return false;
                     if (!isSummoned && (Bot.HasInHand(CardId.BatterymanSolar) || Bot.HasInHand(CardId.AloofLupine))) return false;
                     activate_ThunderDragondark = true;
                     handActivated = true;
@@ -2458,25 +2401,25 @@ namespace WindBot.Game.AI.Decks
             {
                 if (Duel.Player == 0)
                 {
-                    if (handActivated && CheckRemainInDeck(CardId.ThunderDragonlord) > 0 &&
+                    if (handActivated && Bot.HasInDeck(CardId.ThunderDragonlord) &&
                         Bot.Hand.Count(card => card != null && card.HasRace(CardRace.Thunder)) > 0 &&
                         (Bot.HasInMonstersZone(CardId.ThunderDragonColossus) || (!isSummoned && Bot.Hand.Count(card => card != null && card.HasRace(CardRace.Thunder)) > 1)))
                         AI.SelectCard(CardId.ThunderDragonlord);
                     else if (HasInZoneNoActivate(CardId.ThunderDragonhawk, CardLocation.Deck) && !Bot.HasInHand(CardId.ThunderDragonhawk))
                         AI.SelectCard(CardId.ThunderDragonhawk);
                     else if (handActivated && Bot.Hand.Count(card => card != null && card.HasRace(CardRace.Thunder) && card.Level < 8) > 0
-                        && Bot.HasInMonstersZone(CardId.ThunderDragonColossus) && CheckRemainInDeck(CardId.ThunderDragonlord) > 0)
+                        && Bot.HasInMonstersZone(CardId.ThunderDragonColossus) && Bot.HasInDeck(CardId.ThunderDragonlord))
                         AI.SelectCard(CardId.ThunderDragonlord);
                     else if (HasInZoneNoActivate(CardId.ThunderDragonmatrix, CardLocation.Deck))
                         AI.SelectCard(CardId.ThunderDragonmatrix);
                     else if (HasInZoneNoActivate(CardId.ThunderDragonroar, CardLocation.Hand) && handActivated
-                            && CheckRemainInDeck(CardId.ThunderDragonlord) > 0)
+                            && Bot.HasInDeck(CardId.ThunderDragonlord))
                         AI.SelectCard(CardId.ThunderDragonlord);
-                    else if (CheckRemainInDeck(CardId.ThunderDragonlord) > 0 && CheckRemainInDeck(CardId.NormalThunderDragon) > 1)
+                    else if (Bot.HasInDeck(CardId.ThunderDragonlord) && Bot.GetRemainingCount(CardId.NormalThunderDragon) > 1)
                         AI.SelectCard(CardId.ThunderDragonlord);
-                    else if (handActivated && Bot.HasInHand(CardId.ThunderDragonlord) && CheckRemainInDeck(CardId.ThunderDragonroar) > 0)
+                    else if (handActivated && Bot.HasInHand(CardId.ThunderDragonlord) && Bot.HasInDeck(CardId.ThunderDragonroar))
                         AI.SelectCard(CardId.ThunderDragonroar);
-                    else if (CheckRemainInDeck(CardId.NormalThunderDragon) > 1 && !handActivated)
+                    else if (Bot.GetRemainingCount(CardId.NormalThunderDragon) > 1 && !handActivated)
                         AI.SelectCard(CardId.NormalThunderDragon);
                     else
                         AI.SelectCard(CardId.ThunderDragonmatrix, CardId.ThunderDragondark, CardId.ThunderDragonroar, CardId.NormalThunderDragon);
@@ -2516,9 +2459,9 @@ namespace WindBot.Game.AI.Decks
                     AI.SelectCard(CardId.ThunderDragondark);
                 else if ((HasInZoneNoActivate(CardId.ThunderDragonmatrix, CardLocation.Deck)))
                     AI.SelectCard(CardId.ThunderDragonmatrix);
-                else if (CheckRemainInDeck(CardId.NormalThunderDragon) > 0)
+                else if (Bot.HasInDeck(CardId.NormalThunderDragon))
                     AI.SelectCard(CardId.NormalThunderDragon);
-                else if (CheckRemainInDeck(CardId.TheChaosCreator) > 0)
+                else if (Bot.HasInDeck(CardId.TheChaosCreator))
                     AI.SelectCard(CardId.TheChaosCreator);
                 else AI.SelectCard(CardId.ThunderDragonmatrix);
             }
@@ -2528,7 +2471,7 @@ namespace WindBot.Game.AI.Decks
                     AI.SelectCard(CardId.ThunderDragonroar);
                 else if (HasInZoneNoActivate(CardId.ThunderDragondark, CardLocation.Deck))
                     AI.SelectCard(CardId.ThunderDragondark);
-                else if (CheckRemainInDeck(CardId.TheChaosCreator) > 0)
+                else if (Bot.HasInDeck(CardId.TheChaosCreator))
                     AI.SelectCard(CardId.TheChaosCreator);
                 else AI.SelectCard(CardId.ThunderDragonmatrix);
 

--- a/Game/AI/Decks/TrickstarExecutor.cs
+++ b/Game/AI/Decks/TrickstarExecutor.cs
@@ -412,7 +412,7 @@ namespace WindBot.Game.AI.Decks
                 };
                 if (!Util.ChainContainsCard(CardId.Awaken))
                 {
-                    if (!judge && Bot.GetRemainingCount(CardId.Ghost, 2) > 0)
+                    if (!judge && Bot.HasInDeck(CardId.Ghost))
                     {
                         AI.SelectCard(CardId.Ghost);
                         AI.SelectPosition(CardPosition.FaceUpDefence);
@@ -565,7 +565,7 @@ namespace WindBot.Game.AI.Decks
                     stage_locked = null;
                     return true;
                 }
-                else if (Enemy.LifePoints <= 1000 && Bot.GetRemainingCount(CardId.Pink,1) > 0)
+                else if (Enemy.LifePoints <= 1000 && Bot.HasInDeck(CardId.Pink))
                 {
                     AI.SelectCard(CardId.Pink, CardId.Yellow, CardId.Red, CardId.White);
                     stage_locked = null;
@@ -594,7 +594,7 @@ namespace WindBot.Game.AI.Decks
 
             if (NormalSummoned)
             {
-                if (Enemy.LifePoints <= 1000 && !pink_ss && Bot.GetRemainingCount(CardId.Pink,1) > 0)
+                if (Enemy.LifePoints <= 1000 && !pink_ss && Bot.HasInDeck(CardId.Pink))
                 {
                     AI.SelectCard(CardId.Pink, CardId.Yellow, CardId.Red, CardId.White);
                     stage_locked = null;
@@ -848,19 +848,19 @@ namespace WindBot.Game.AI.Decks
 
         public bool Yellow_eff()
         {
-            if (!Bot.HasInHand(CardId.Stage) && !Bot.HasInSpellZone(CardId.Stage) && Bot.GetRemainingCount(CardId.Stage, 3) > 0)
+            if (!Bot.HasInHand(CardId.Stage) && !Bot.HasInSpellZone(CardId.Stage) && Bot.HasInDeck(CardId.Stage))
             {
                 AI.SelectCard(CardId.Stage, CardId.Red, CardId.White, CardId.Pink, CardId.Re, CardId.Crown, CardId.Yellow);
                 return true;
             }
             if (Enemy.LifePoints <= 1000)
             {
-                if (Bot.GetRemainingCount(CardId.Pink, 1) > 0 && !pink_ss)
+                if (Bot.HasInDeck(CardId.Pink) && !pink_ss)
                 {
                     AI.SelectCard(CardId.Pink, CardId.Stage, CardId.Red, CardId.White, CardId.Re, CardId.Crown, CardId.Yellow);
                     return true;
                 }
-                else if (Bot.HasInGraveyard(CardId.Pink) && Bot.GetRemainingCount(CardId.Crown, 1) > 0)
+                else if (Bot.HasInGraveyard(CardId.Pink) && Bot.HasInDeck(CardId.Crown))
                 {
                     AI.SelectCard(CardId.Crown, CardId.Pink, CardId.Re, CardId.Stage, CardId.Red, CardId.White, CardId.Yellow);
                     return true;
@@ -868,19 +868,19 @@ namespace WindBot.Game.AI.Decks
             }
             if (Enemy.GetMonsterCount() == 0 && !Util.IsTurn1OrMain2())
             {
-                if (Bot.HasInGraveyard(CardId.Red) && Bot.GetRemainingCount(CardId.Pink, 1) > 0 && !pink_ss)
+                if (Bot.HasInGraveyard(CardId.Red) && Bot.HasInDeck(CardId.Pink) && !pink_ss)
                 {
                     AI.SelectCard(CardId.Pink, CardId.Red, CardId.White, CardId.Re, CardId.Stage, CardId.Crown, CardId.Yellow);
                 }
-                else if (Bot.HasInGraveyard(CardId.Pink) && Bot.HasInGraveyard(CardId.Red) && Bot.GetRemainingCount(CardId.Ring, 1) > 0)
+                else if (Bot.HasInGraveyard(CardId.Pink) && Bot.HasInGraveyard(CardId.Red) && Bot.HasInDeck(CardId.Ring))
                 {
                     AI.SelectCard(CardId.Crown, CardId.Red, CardId.White, CardId.Re, CardId.Stage, CardId.Pink, CardId.Yellow);
                 }
-                else if (Bot.GetRemainingCount(CardId.White, 2) > 0 && Enemy.LifePoints <= 4000)
+                else if (Bot.HasInDeck(CardId.White) && Enemy.LifePoints <= 4000)
                 {
                     AI.SelectCard(CardId.White, CardId.Red, CardId.Pink, CardId.Re, CardId.Stage, CardId.Crown, CardId.Yellow);
                 }
-                else if (Bot.HasInGraveyard(CardId.White) && Bot.GetRemainingCount(CardId.Crown, 1) > 0)
+                else if (Bot.HasInGraveyard(CardId.White) && Bot.HasInDeck(CardId.Crown))
                 {
                     AI.SelectCard(CardId.Crown, CardId.Red, CardId.Pink, CardId.Re, CardId.Stage, CardId.White, CardId.Yellow);
                 }
@@ -893,7 +893,7 @@ namespace WindBot.Game.AI.Decks
             if (Util.GetProblematicEnemyMonster() != null)
             {
                 int power = Util.GetProblematicEnemyMonster().GetDefensePower();
-                if (power >= 1800 && power <= 3600 && Bot.GetRemainingCount(CardId.White, 2) > 0 && !Bot.HasInHand(CardId.White))
+                if (power >= 1800 && power <= 3600 && Bot.HasInDeck(CardId.White) && !Bot.HasInHand(CardId.White))
                 {
                     AI.SelectCard(CardId.White, CardId.Red, CardId.Pink, CardId.Re, CardId.Stage, CardId.Crown, CardId.Yellow);
                 }
@@ -903,7 +903,7 @@ namespace WindBot.Game.AI.Decks
                 }
                 return true;
             }
-            if ((Bot.HasInHand(CardId.Red) || Bot.HasInHand(CardId.Stage) || Bot.HasInHand(CardId.Yellow)) && Bot.GetRemainingCount(CardId.Re,1) > 0) {
+            if ((Bot.HasInHand(CardId.Red) || Bot.HasInHand(CardId.Stage) || Bot.HasInHand(CardId.Yellow)) && Bot.HasInDeck(CardId.Re)) {
                 AI.SelectCard(CardId.Re, CardId.Red, CardId.White, CardId.Crown, CardId.Pink, CardId.Stage, CardId.Yellow);
                 return true;
             }
@@ -1106,7 +1106,7 @@ namespace WindBot.Game.AI.Decks
         {
             if (crystal_eff_used || Bot.HasInMonstersZone(CardId.Crystal)) return false;
             if (Bot.GetMonsterCount() == 0 || !Bot.HasInExtra(CardId.Crystal)) return false;
-            if (Card.IsCode(CardId.Ghost) && Bot.GetRemainingCount(CardId.Ghost, 2) <= 0) return false;
+            if (Card.IsCode(CardId.Ghost) && !Bot.HasInDeck(CardId.Ghost)) return false;
             int count = 0;
             if (!Card.IsCode(CardId.Urara)) count += 1;
             foreach(ClientCard hand in Bot.Hand)

--- a/Game/AI/Decks/VoicelessExecutor.cs
+++ b/Game/AI/Decks/VoicelessExecutor.cs
@@ -762,27 +762,27 @@ namespace WindBot.Game.AI.Decks
 
         private int GetCardToSearch()
         {
-            if (NoLo() && !Bot.HasInHand(CardId.Lo) && !Bot.HasInHand(CardId.Diviner) && Bot.GetRemainingCount(CardId.Lo, 3) > 0)
+            if (NoLo() && !Bot.HasInHand(CardId.Lo) && !Bot.HasInHand(CardId.Diviner) && Bot.HasInDeck(CardId.Lo))
             {
                 return CardId.Lo;
             }
-            else if (!Bot.HasInHand(CardId.Saffira) && Bot.GetRemainingCount(CardId.Saffira, 3) > 0)
+            else if (!Bot.HasInHand(CardId.Saffira) && Bot.HasInDeck(CardId.Saffira))
             {
                 return CardId.Saffira;
             }
-            else if (EmptyMainMonsterZone() && !Bot.HasInHand(CardId.VVSkullGuard) && Bot.GetRemainingCount(CardId.VVSkullGuard, 3) > 0)
+            else if (EmptyMainMonsterZone() && !Bot.HasInHand(CardId.VVSkullGuard) && Bot.HasInDeck(CardId.VVSkullGuard))
             {
                 return CardId.VVSkullGuard;
             }
-            else if (Bot.GetRemainingCount(CardId.VVRadiance, 1) > 0)
+            else if (Bot.HasInDeck(CardId.VVRadiance))
             {
                 return CardId.VVRadiance;
             }
-            else if (Bot.GetRemainingCount(CardId.VVSauravis, 1) > 0) //if there's >= 2 spells in grave
+            else if (Bot.HasInDeck(CardId.VVSauravis)) //if there's >= 2 spells in grave
             {
                 return CardId.VVSauravis;
             }
-            // else if (Util.GetProblematicEnemyMonster() != null && Bot.GetRemainingCount(CardId.WidowAnchor, 3) > 0)
+            // else if (Util.GetProblematicEnemyMonster() != null && Bot.HasInDeck(CardId.WidowAnchor))
             // {
             //     return CardId.WidowAnchor;
             // }

--- a/Game/AI/Decks/WitchcraftExecutor.cs
+++ b/Game/AI/Decks/WitchcraftExecutor.cs
@@ -445,7 +445,7 @@ namespace WindBot.Game.AI.Decks
         {
             int discardable_hands = 0;
             int count_witchcraftspell = Bot.Hand.GetMatchingCardsCount(card => (card.IsSpell() && (card.HasSetcode(Witchcraft_setcode)) && card != except));
-            int count_remainhands = CheckRemainInDeck(CardId.MagiciansLeftHand, CardId.MagicianRightHand);
+            int count_remainhands = Bot.GetRemainingCount(new[] { CardId.MagiciansLeftHand, CardId.MagicianRightHand });
             int count_MagiciansRestage = Bot.Hand.GetMatchingCardsCount(card => card.Id == CardId.MagiciansRestage && card != except);
             int count_MetalfoesFusion = Bot.Hand.GetCardCount(CardId.MetalfoesFusion);
             int count_WitchcrafterBystreet = Bot.SpellZone.GetMatchingCardsCount(card => card.IsFaceup() && card.Id == CardId.WitchcrafterBystreet && !card.IsDisabled());
@@ -660,96 +660,7 @@ namespace WindBot.Game.AI.Decks
             return result;
         }
 
-        /// <summary>
-        /// Check remain cards in deck
-        /// </summary>
-        /// <param name="id">Card's ID</param>
-        public int CheckRemainInDeck(int id)
-        {
-            switch (id)
-            {
-                case CardId.PSYDriver:
-                    return Bot.GetRemainingCount(CardId.PSYDriver, 1);
-                case CardId.GolemAruru:
-                    return Bot.GetRemainingCount(CardId.GolemAruru, 1);
-                case CardId.MadameVerre:
-                    return Bot.GetRemainingCount(CardId.MadameVerre, 1);
-                case CardId.Haine:
-                    return Bot.GetRemainingCount(CardId.Haine, 2);
-                case CardId.Schmietta:
-                    return Bot.GetRemainingCount(CardId.Schmietta, 3);
-                case CardId.Pittore:
-                    return Bot.GetRemainingCount(CardId.Pittore, 3);
-                case _CardId.AshBlossom:
-                    return Bot.GetRemainingCount(_CardId.AshBlossom, 1);
-                case CardId.PSYGamma:
-                    return Bot.GetRemainingCount(CardId.PSYGamma, 3);
-                case _CardId.MaxxC:
-                    return Bot.GetRemainingCount(_CardId.MaxxC, 1);
-                case CardId.Potterie:
-                    return Bot.GetRemainingCount(CardId.Potterie, 1);
-                case CardId.Genni:
-                    return Bot.GetRemainingCount(CardId.Genni, 2);
-                case CardId.Collaboration:
-                    return Bot.GetRemainingCount(CardId.Collaboration, 1);
-                case CardId.ThatGrassLooksGreener:
-                    return Bot.GetRemainingCount(CardId.ThatGrassLooksGreener, 2);
-                case _CardId.LightningStorm:
-                    return Bot.GetRemainingCount(_CardId.LightningStorm, 2);
-                case CardId.PotofExtravagance:
-                    return Bot.GetRemainingCount(CardId.PotofExtravagance, 3);
-                case CardId.DarkRulerNoMore:
-                    return Bot.GetRemainingCount(CardId.DarkRulerNoMore, 2);
-                case CardId.Creation:
-                    return Bot.GetRemainingCount(CardId.Creation, 3);
-                case CardId.Reasoning:
-                    return Bot.GetRemainingCount(CardId.Reasoning, 3);
-                case CardId.MetalfoesFusion:
-                    return Bot.GetRemainingCount(CardId.MetalfoesFusion, 1);
-                case CardId.Holiday:
-                    return Bot.GetRemainingCount(CardId.Holiday, 3);
-                case _CardId.CalledByTheGrave:
-                    return Bot.GetRemainingCount(_CardId.CalledByTheGrave, 3);
-                case CardId.Draping:
-                    return Bot.GetRemainingCount(CardId.Draping, 1);
-                case _CardId.CrossoutDesignator:
-                    return Bot.GetRemainingCount(_CardId.CrossoutDesignator, 2);
-                case CardId.Unveiling:
-                    return Bot.GetRemainingCount(CardId.Unveiling, 1);
-                case CardId.MagiciansLeftHand:
-                    return Bot.GetRemainingCount(CardId.MagiciansLeftHand, 1);
-                case CardId.Scroll:
-                    return Bot.GetRemainingCount(CardId.Scroll, 1);
-                case CardId.MagiciansRestage:
-                    return Bot.GetRemainingCount(CardId.MagiciansRestage, 2);
-                case CardId.WitchcrafterBystreet:
-                    return Bot.GetRemainingCount(CardId.WitchcrafterBystreet, 3);
-                case CardId.MagicianRightHand:
-                    return Bot.GetRemainingCount(CardId.MagicianRightHand, 1);
-                case _CardId.InfiniteImpermanence:
-                    return Bot.GetRemainingCount(_CardId.InfiniteImpermanence, 3);
-                case CardId.Masterpiece:
-                    return Bot.GetRemainingCount(CardId.Masterpiece, 1);
-                case CardId.Patronus:
-                    return Bot.GetRemainingCount(CardId.Patronus, 2);
-                default:
-                    return 0;
-            }
-        }
 
-        /// <summary>
-        /// Check remain cards in deck
-        /// </summary>
-        /// <param name="ids">Card's ID list</param>
-        public int CheckRemainInDeck(params int[] ids)
-        {
-            int result = 0;
-            foreach (int cardid in ids)
-            {
-                result += CheckRemainInDeck(cardid);
-            }
-            return result;
-        }
 
         /// <summary>
         /// Check whether cards will be removed. If so, do not send cards to grave.
@@ -1029,7 +940,7 @@ namespace WindBot.Game.AI.Decks
         /// </summary>
         public void SelectDiscardSpell()
         {
-            int count_remainhands = CheckRemainInDeck(CardId.MagiciansLeftHand, CardId.MagicianRightHand);
+            int count_remainhands = Bot.GetRemainingCount(new[] { CardId.MagiciansLeftHand, CardId.MagicianRightHand });
             int count_witchcraftspell = Bot.Hand.GetMatchingCardsCount(card => (card.IsSpell() && (card.HasSetcode(Witchcraft_setcode))));
             int WitchcrafterBystreet_count = Bot.SpellZone.GetMatchingCardsCount(card => card.IsFaceup() && card.Id == CardId.WitchcrafterBystreet);
             if (Bot.HasInHand(CardId.MagiciansRestage) && count_remainhands > 0)
@@ -1152,7 +1063,7 @@ namespace WindBot.Game.AI.Decks
         {
             if (UseSSEffect.Contains(Card.Id)) return false;
             int count_spell = Bot.Hand.GetMatchingCardsCount(card => (card.IsSpell()));
-            int count_target = CheckRemainInDeck(CardId.MadameVerre, CardId.Haine, CardId.GolemAruru);
+            int count_target = Bot.GetRemainingCount(new[] { CardId.MadameVerre, CardId.Haine, CardId.GolemAruru });
             if (count_spell > 0 && count_target > 0)
             {
                 summoned = true;
@@ -1253,7 +1164,7 @@ namespace WindBot.Game.AI.Decks
             bool lesssummon = false;
             int extra_attack = CheckPlusAttackforMadameVerre(true, false, true);
             int best_power = Util.GetBestAttack(Bot);
-            if (CheckRemainInDeck(CardId.Haine) > 0 && best_power < 2400) best_power = 2400;
+            if (Bot.HasInDeck(CardId.Haine) && best_power < 2400) best_power = 2400;
             Logger.DebugWriteLine("less summon check: " + (best_power + extra_attack - 1000).ToString() + " to " + (best_power + extra_attack).ToString());
             if (Util.GetOneEnemyBetterThanValue(best_power) != null 
                 && Util.GetOneEnemyBetterThanValue(best_power + extra_attack) == null
@@ -1268,7 +1179,7 @@ namespace WindBot.Game.AI.Decks
                 int[] SS_priority = { CardId.Schmietta, CardId.Pittore, CardId.Genni, CardId.Potterie };
                 foreach (int cardid in SS_priority)
                 {
-                    if (!UseSSEffect.Contains(cardid) && Card.Id != cardid && CheckRemainInDeck(cardid) > 0
+                    if (!UseSSEffect.Contains(cardid) && Card.Id != cardid && Bot.HasInDeck(cardid)
                         && Bot.MonsterZone.GetFirstMatchingCard(card => card.Id == cardid && card.IsFaceup()) == null)
                     {
                         UseSSEffect.Add(Card.Id);
@@ -1281,7 +1192,7 @@ namespace WindBot.Game.AI.Decks
             // check whether continue to ss
             bool should_attack = Util.GetOneEnemyBetterThanValue(Card.Attack) == null;
             if ((should_attack ^ Card.IsDefense()) && Duel.Player == 1) return false;
-            if (CheckRemainInDeck(CardId.Haine, CardId.MadameVerre, CardId.GolemAruru) == 0) return false;
+            if (!Bot.HasInDeck(CardId.Haine, CardId.MadameVerre, CardId.GolemAruru)) return false;
 
             // SS higer level
             if (Bot.HasInMonstersZone(CardId.Haine) || (lesssummon && !Bot.HasInMonstersZone(CardId.MadameVerre, true)))
@@ -1509,7 +1420,7 @@ namespace WindBot.Game.AI.Decks
                 int[] spell_checklist = { CardId.WitchcrafterBystreet, CardId.Holiday, CardId.Creation, CardId.Draping, CardId.Scroll, CardId.Unveiling, CardId.Collaboration };
                 foreach (int cardid in spell_checklist)
                 {
-                    if (CheckRemainInDeck(cardid) > 0 && !Bot.HasInHandOrInSpellZone(cardid) && !Bot.HasInGraveyard(cardid) && !ActivatedCards.Contains(cardid))
+                    if (Bot.HasInDeck(cardid) && !Bot.HasInHandOrInSpellZone(cardid) && !Bot.HasInGraveyard(cardid) && !ActivatedCards.Contains(cardid))
                     {
                         AI.SelectCard(cardid);
                         ActivatedCards.Add(CardId.Schmietta);
@@ -1521,7 +1432,7 @@ namespace WindBot.Game.AI.Decks
             bool can_find_Holiday = Bot.HasInHandOrInSpellZone(CardId.Holiday) || (can_recycle && Bot.HasInGraveyard(CardId.Holiday) && !(ActivatedCards.Contains(CardId.Holiday)));
             // monster check
             if (Bot.HasInHand(important_witchcraft)  && !Bot.HasInGraveyard(CardId.Pittore) 
-                && !ActivatedCards.Contains(CardId.Pittore) && CheckRemainInDeck(CardId.Pittore) > 0 && can_find_Holiday){
+                && !ActivatedCards.Contains(CardId.Pittore) && Bot.HasInDeck(CardId.Pittore) && can_find_Holiday){
                 AI.SelectCard(CardId.Pittore);
                 ActivatedCards.Add(CardId.Schmietta);
                 return true;
@@ -1577,7 +1488,7 @@ namespace WindBot.Game.AI.Decks
             }
 
             // trap check
-            if (CheckRemainInDeck(CardId.Masterpiece) >= 2){
+            if (Bot.GetRemainingCount(CardId.Masterpiece) >= 2){
                 AI.SelectCard(CardId.Masterpiece);
                 ActivatedCards.Add(CardId.Schmietta);
                 return true;
@@ -2014,7 +1925,7 @@ namespace WindBot.Game.AI.Decks
                 int code = Util.GetLastChainCard().GetOriginCode();
                 if (code == 0) return false;
                 if (CheckCalledbytheGrave(code) > 0) return false;
-                if (CheckRemainInDeck(code) > 0)
+                if (Bot.HasInDeck(code))
                 {
                     if (!(Card.Location == CardLocation.SpellZone))
                     {
@@ -2243,8 +2154,8 @@ namespace WindBot.Game.AI.Decks
             {
                 if (NegatedCheck(true)) return false;
                 // select randomly (TODO)
-                IList<ClientCard> target_1 = Bot.Graveyard.GetMatchingCards(card => card.IsSpell() && CheckRemainInDeck(card.Id) > 0);
-                IList<ClientCard> target_2 = Enemy.Graveyard.GetMatchingCards(card => card.IsSpell() && CheckRemainInDeck(card.Id) > 0);
+                IList<ClientCard> target_1 = Bot.Graveyard.GetMatchingCards(card => card.IsSpell() && Bot.HasInDeck(card.Id));
+                IList<ClientCard> target_2 = Enemy.Graveyard.GetMatchingCards(card => card.IsSpell() && Bot.HasInDeck(card.Id));
                 List<ClientCard> targets = target_1.Union(target_2).ToList();
                 Util.ShuffleListInPlace(targets);
                 AI.SelectCard(targets);
@@ -2292,7 +2203,7 @@ namespace WindBot.Game.AI.Decks
                     foreach (int cardid in SS_priority)
                     {
                         int level = witchcraft_level[cardid];
-                        if (!UseSSEffect.Contains(cardid) & CheckRemainInDeck(cardid) > 0 && level <= max_level)
+                        if (!UseSSEffect.Contains(cardid) & Bot.HasInDeck(cardid) && level <= max_level)
                         {
                             AI.SelectNumber(level);
                             AI.SelectCard(tobanish_spells);
@@ -2318,7 +2229,7 @@ namespace WindBot.Game.AI.Decks
                 foreach (int cardid in ss_priority)
                 {
                     int level = witchcraft_level[cardid];
-                    if (CheckRemainInDeck(cardid) > 0 && level <= max_level)
+                    if (Bot.HasInDeck(cardid) && level <= max_level)
                     {
                         AI.SelectNumber(level);
                         AI.SelectCard(tobanish_spells);
@@ -2705,7 +2616,7 @@ namespace WindBot.Game.AI.Decks
             if (materials.Count < 2) return empty_list;
 
             // need CrystronHalqifibrax?
-            if (CheckRemainInDeck(CardId.PSYGamma, _CardId.AshBlossom) == 0) return empty_list;
+            if (!Bot.HasInDeck(CardId.PSYGamma, _CardId.AshBlossom)) return empty_list;
 
 
             return empty_list;

--- a/Game/AI/Decks/WitchcraftExecutor.cs
+++ b/Game/AI/Decks/WitchcraftExecutor.cs
@@ -2154,8 +2154,8 @@ namespace WindBot.Game.AI.Decks
             {
                 if (NegatedCheck(true)) return false;
                 // select randomly (TODO)
-                IList<ClientCard> target_1 = Bot.Graveyard.GetMatchingCards(card => card.IsSpell() && Bot.HasInDeck(card.Id));
-                IList<ClientCard> target_2 = Enemy.Graveyard.GetMatchingCards(card => card.IsSpell() && Bot.HasInDeck(card.Id));
+                IList<ClientCard> target_1 = Bot.Graveyard.GetMatchingCards(card => card.IsSpell() && Bot.HasInDeck(card.GetNonAltartCode()));
+                IList<ClientCard> target_2 = Enemy.Graveyard.GetMatchingCards(card => card.IsSpell() && Bot.HasInDeck(card.GetNonAltartCode()));
                 List<ClientCard> targets = target_1.Union(target_2).ToList();
                 Util.ShuffleListInPlace(targets);
                 AI.SelectCard(targets);

--- a/Game/AI/Decks/WitchcraftExecutor.cs
+++ b/Game/AI/Decks/WitchcraftExecutor.cs
@@ -445,7 +445,7 @@ namespace WindBot.Game.AI.Decks
         {
             int discardable_hands = 0;
             int count_witchcraftspell = Bot.Hand.GetMatchingCardsCount(card => (card.IsSpell() && (card.HasSetcode(Witchcraft_setcode)) && card != except));
-            int count_remainhands = Bot.GetRemainingCount(new[] { CardId.MagiciansLeftHand, CardId.MagicianRightHand });
+            int count_remainhands = Bot.GetCardCountInDeck(new[] { CardId.MagiciansLeftHand, CardId.MagicianRightHand });
             int count_MagiciansRestage = Bot.Hand.GetMatchingCardsCount(card => card.Id == CardId.MagiciansRestage && card != except);
             int count_MetalfoesFusion = Bot.Hand.GetCardCount(CardId.MetalfoesFusion);
             int count_WitchcrafterBystreet = Bot.SpellZone.GetMatchingCardsCount(card => card.IsFaceup() && card.Id == CardId.WitchcrafterBystreet && !card.IsDisabled());
@@ -940,7 +940,7 @@ namespace WindBot.Game.AI.Decks
         /// </summary>
         public void SelectDiscardSpell()
         {
-            int count_remainhands = Bot.GetRemainingCount(new[] { CardId.MagiciansLeftHand, CardId.MagicianRightHand });
+            int count_remainhands = Bot.GetCardCountInDeck(new[] { CardId.MagiciansLeftHand, CardId.MagicianRightHand });
             int count_witchcraftspell = Bot.Hand.GetMatchingCardsCount(card => (card.IsSpell() && (card.HasSetcode(Witchcraft_setcode))));
             int WitchcrafterBystreet_count = Bot.SpellZone.GetMatchingCardsCount(card => card.IsFaceup() && card.Id == CardId.WitchcrafterBystreet);
             if (Bot.HasInHand(CardId.MagiciansRestage) && count_remainhands > 0)
@@ -1063,7 +1063,7 @@ namespace WindBot.Game.AI.Decks
         {
             if (UseSSEffect.Contains(Card.Id)) return false;
             int count_spell = Bot.Hand.GetMatchingCardsCount(card => (card.IsSpell()));
-            int count_target = Bot.GetRemainingCount(new[] { CardId.MadameVerre, CardId.Haine, CardId.GolemAruru });
+            int count_target = Bot.GetCardCountInDeck(new[] { CardId.MadameVerre, CardId.Haine, CardId.GolemAruru });
             if (count_spell > 0 && count_target > 0)
             {
                 summoned = true;
@@ -1488,7 +1488,7 @@ namespace WindBot.Game.AI.Decks
             }
 
             // trap check
-            if (Bot.GetRemainingCount(CardId.Masterpiece) >= 2){
+            if (Bot.GetCardCountInDeck(CardId.Masterpiece) >= 2){
                 AI.SelectCard(CardId.Masterpiece);
                 ActivatedCards.Add(CardId.Schmietta);
                 return true;

--- a/Game/AI/Decks/YubelExecutor.cs
+++ b/Game/AI/Decks/YubelExecutor.cs
@@ -92,17 +92,6 @@ namespace WindBot.Game.AI.Decks
         const int SetcodeOrcust = 0x11b;
         const int SetcodeHorus = 0x19d;
 
-        Dictionary<int, List<int>> DeckCountTable = new Dictionary<int, List<int>>{
-            {3, new List<int> { CardId.SPIRIT_OF_YUBEL, CardId.SAMSARA_D_LOTUS,CardId.NIGHTMARE_THRONE, CardId.SPIRIT_GATES,
-                                 _CardId.AshBlossom, CardId.DARK_BECKONING_BEAST,_CardId.InfiniteImpermanence } },
-            {2, new List<int> { _CardId.MaxxC, _CardId.CalledByTheGrave,CardId.GRUESOME_GRAVE_SQUIRMER}},
-            {1, new List<int> { CardId.FIENDSMITH_ENGRAVER, CardId.FIENDSMITHS_PARADISE,
-                                CardId.YUBEL, CardId.YUBEL_TERROR_INCARNATE, CardId.ABOMINABLE_CHAMBER,
-                                _CardId.CrossoutDesignator, CardId.GRUESOME_GRAVE_SQUIRMER, CardId.FABLED_LURRIE,
-                                CardId.NIGHTMARE_PAIN, CardId.TERRAFORMING, CardId.FIENDSMITH_TRACT,CardId.SHARVARA,
-                                CardId.CHAOS_SUMMONING_BEAST, CardId.LACRIMA_CT 
-                                } }
-        };
 
         List<int> notToNegateIdList = new List<int> { 58699500, 20343502, 19403423 };
         List<int> notToDestroySpellTrap = new List<int> { 50005218, 6767771 };
@@ -260,17 +249,6 @@ namespace WindBot.Game.AI.Decks
 
         public override bool OnSelectHand() { return true; }
 
-        public int CheckRemainInDeck(int id)
-        {
-            for (int count = 1; count < 4; ++count)
-            {
-                if (DeckCountTable[count].Contains(id))
-                {
-                    return Bot.GetRemainingCount(id, count);
-                }
-            }
-            return 0;
-        }
 
         private bool MonsterRepos()
         {
@@ -479,7 +457,7 @@ namespace WindBot.Game.AI.Decks
                 if (alias != 0 && alias - code < 10) code = alias;
                 if (code == 0) return false;
                 if (DefaultCheckWhetherCardIdIsNegated(code)) return false;
-                if (CheckRemainInDeck(code) > 0)
+                if (Bot.HasInDeck(code))
                 {
                     if (!(Card.Location == CardLocation.SpellZone))
                     {
@@ -1138,11 +1116,11 @@ namespace WindBot.Game.AI.Decks
             if (Card.Location == CardLocation.Hand && Bot.HasInSpellZone(CardId.NIGHTMARE_THRONE)) return false;
 
             int pick = 0;
-            if (!Bot.HasInHand(CardId.SAMSARA_D_LOTUS) && CheckRemainInDeck(CardId.SAMSARA_D_LOTUS) > 0)
+            if (!Bot.HasInHand(CardId.SAMSARA_D_LOTUS) && Bot.HasInDeck(CardId.SAMSARA_D_LOTUS))
                 pick = CardId.SAMSARA_D_LOTUS;
-            else if (Bot.HasInHand(CardId.SAMSARA_D_LOTUS) && !Bot.HasInHand(CardId.DARK_BECKONING_BEAST) && CheckRemainInDeck(CardId.DARK_BECKONING_BEAST) > 0)
+            else if (Bot.HasInHand(CardId.SAMSARA_D_LOTUS) && !Bot.HasInHand(CardId.DARK_BECKONING_BEAST) && Bot.HasInDeck(CardId.DARK_BECKONING_BEAST))
                 pick = CardId.DARK_BECKONING_BEAST;
-            else if (Bot.HasInHand(CardId.SAMSARA_D_LOTUS) && Bot.HasInHand(CardId.DARK_BECKONING_BEAST) && !Bot.HasInHand(CardId.CHAOS_SUMMONING_BEAST) && CheckRemainInDeck(CardId.CHAOS_SUMMONING_BEAST) > 0)
+            else if (Bot.HasInHand(CardId.SAMSARA_D_LOTUS) && Bot.HasInHand(CardId.DARK_BECKONING_BEAST) && !Bot.HasInHand(CardId.CHAOS_SUMMONING_BEAST) && Bot.HasInDeck(CardId.CHAOS_SUMMONING_BEAST))
                 pick = CardId.CHAOS_SUMMONING_BEAST;
 
             thronePending = true;
@@ -1171,9 +1149,9 @@ namespace WindBot.Game.AI.Decks
         private bool ActDarkBeckoningBeast()
         {
             if (Duel.Phase != DuelPhase.Main1) return false;
-            if ((CheckRemainInDeck(CardId.SPIRIT_GATES) > 0) && !Bot.HasInSpellZone(CardId.SPIRIT_GATES))
+            if (Bot.HasInDeck(CardId.SPIRIT_GATES) && !Bot.HasInSpellZone(CardId.SPIRIT_GATES))
             { AI.SelectCard(CardId.SPIRIT_GATES); return true; }
-            else if (CheckRemainInDeck(CardId.CHAOS_SUMMONING_BEAST) > 0)
+            else if (Bot.HasInDeck(CardId.CHAOS_SUMMONING_BEAST))
             { AI.SelectCard(CardId.CHAOS_SUMMONING_BEAST); return true; }
             else { return false; }
         }
@@ -1189,11 +1167,11 @@ namespace WindBot.Game.AI.Decks
             int pick = 0;
             bool dbbOnField = Bot.HasInMonstersZone(CardId.DARK_BECKONING_BEAST, false, false, true);
 
-            if (dbbOnField && CheckRemainInDeck(CardId.CHAOS_SUMMONING_BEAST) > 0)
+            if (dbbOnField && Bot.HasInDeck(CardId.CHAOS_SUMMONING_BEAST))
                 pick = CardId.CHAOS_SUMMONING_BEAST;
-            else if (CheckRemainInDeck(CardId.DARK_BECKONING_BEAST) > 0)
+            else if (Bot.HasInDeck(CardId.DARK_BECKONING_BEAST))
                 pick = CardId.DARK_BECKONING_BEAST;
-            else if (CheckRemainInDeck(CardId.CHAOS_SUMMONING_BEAST) > 0)
+            else if (Bot.HasInDeck(CardId.CHAOS_SUMMONING_BEAST))
                 pick = CardId.CHAOS_SUMMONING_BEAST;
 
             if (pick == 0) return false;
@@ -1324,7 +1302,7 @@ namespace WindBot.Game.AI.Decks
         {
             if (Card.Location == CardLocation.SpellZone)
             {
-                if(CheckRemainInDeck(CardId.GRUESOME_GRAVE_SQUIRMER)==0)return false;
+                if(!Bot.HasInDeck(CardId.GRUESOME_GRAVE_SQUIRMER))return false;
 
                 if (Bot.HasInMonstersZone(CardId.SPIRIT_OF_YUBEL) || Bot.HasInHand(CardId.SPIRIT_OF_YUBEL))
                 {
@@ -1396,12 +1374,12 @@ namespace WindBot.Game.AI.Decks
             return true;
             /*if (Card.Location == CardLocation.Hand)
             {
-                if (CheckRemainInDeck(CardId.FIENDSMITH_ENGRAVER) == 0 &&
-                    CheckRemainInDeck(CardId.LACRIMA_CT) == 0)
+                if (!Bot.HasInDeck(CardId.FIENDSMITH_ENGRAVER) &&
+                    !Bot.HasInDeck(CardId.LACRIMA_CT))
                 {
                     return false;
                 }
-                if(CheckRemainInDeck(CardId.FABLED_LURRIE) == 0){ return false; }
+                if(!Bot.HasInDeck(CardId.FABLED_LURRIE)){ return false; }
                 AI.SelectCard(CardId.FABLED_LURRIE);
                 AI.SelectNextCard(CardId.FABLED_LURRIE);
                 return true;
@@ -1457,13 +1435,13 @@ namespace WindBot.Game.AI.Decks
         private bool ActRequiemMZ()
         {
             if (Card.Location != CardLocation.MonsterZone) { return false; }
-            if (Bot.HasInHand(CardId.LACRIMA_CT) || CheckRemainInDeck(CardId.LACRIMA_CT) > 0)
+            if (Bot.HasInHand(CardId.LACRIMA_CT) || Bot.HasInDeck(CardId.LACRIMA_CT))
             { 
                 AI.SelectCard(CardId.LACRIMA_CT);
                 AI.SelectPosition(CardPosition.FaceUpDefence);
                 return true; 
             }
-            else if (Bot.HasInHand(CardId.FIENDSMITH_ENGRAVER) || CheckRemainInDeck(CardId.FIENDSMITH_ENGRAVER) > 0)
+            else if (Bot.HasInHand(CardId.FIENDSMITH_ENGRAVER) || Bot.HasInDeck(CardId.FIENDSMITH_ENGRAVER))
             {
                 AI.SelectCard(CardId.FIENDSMITH_ENGRAVER);
                 AI.SelectPosition(CardPosition.FaceUpDefence);
@@ -1929,13 +1907,13 @@ namespace WindBot.Game.AI.Decks
         }
         private bool ActYamaMZ()
         {
-            if (CheckRemainInDeck(CardId.SHARVARA) == 0 ) return false;
+            if (!Bot.HasInDeck(CardId.SHARVARA) ) return false;
             AI.SelectCard(CardId.SHARVARA);
             return true;
         }
         private bool SSRequiem()
         {
-            if (CheckRemainInDeck(CardId.LACRIMA_CT) == 0 && !Bot.HasInHand(CardId.LACRIMA_CT)) { return false; }
+            if (!Bot.HasInDeck(CardId.LACRIMA_CT) && !Bot.HasInHand(CardId.LACRIMA_CT)) { return false; }
             requiemSummoned = true;
             return true;
         }

--- a/Game/AI/Decks/ZefraExecutor.cs
+++ b/Game/AI/Decks/ZefraExecutor.cs
@@ -600,9 +600,9 @@ namespace WindBot.Game.AI.Decks
             if (!Bot.HasInExtra(CardId.CrystronHalqifibrax)) extra_ids.Remove(CardId.CrystronHalqifibrax);
             if (extra_ids.Count <= 0) return extra_ids;
             bool DD_summon_check = false;
-            if (Bot.HasInExtra(CardId.CrystronHalqifibrax) && ((!summoned && HasInDeck(CardId.DDSavantKepler) && (HasInDeck(CardId.DarkContractwiththGate) || Bot.HasInHandOrInSpellZone(CardId.DarkContractwiththGate)
-                ) && !activate_DarkContractwiththGate && HasInDeck(CardId.DDLamia)) || (func.CardsCheckAny(Bot.Hand, func.HasType, CardType.Tuner) &&
-                (HasInDeck(CardId.AstrographSorcerer) || Bot.HasInHand(CardId.AstrographSorcerer)))))
+            if (Bot.HasInExtra(CardId.CrystronHalqifibrax) && ((!summoned && Bot.HasInDeck(CardId.DDSavantKepler) && (Bot.HasInDeck(CardId.DarkContractwiththGate) || Bot.HasInHandOrInSpellZone(CardId.DarkContractwiththGate)
+                ) && !activate_DarkContractwiththGate && Bot.HasInDeck(CardId.DDLamia)) || (func.CardsCheckAny(Bot.Hand, func.HasType, CardType.Tuner) &&
+                (Bot.HasInDeck(CardId.AstrographSorcerer) || Bot.HasInHand(CardId.AstrographSorcerer)))))
             {
                 DD_summon_check = true;
             }
@@ -646,10 +646,10 @@ namespace WindBot.Game.AI.Decks
         }
         private bool XyzModeCheck(bool flag1 = false)
         {
-            return !link_summoned && !(!Bot.HasInExtra(CardId.Raidraptor_ArsenalFalcon) & flag1) && HasInDeck(CardId.Blackwing_ZephyrostheElite) && Bot.HasInExtra(CardId.Raidraptor_ForceStrix) && Bot.HasInExtra(CardId.Raidraptor_WiseStrix)
-                && Bot.HasInExtra(CardId.TruKingofAllCalamities) && (HasInDeck(CardId.Raider_Wing) || Bot.HasInHand(CardId.Raider_Wing))
-                && (HasInDeck(CardId.Raidraptor_SingingLanius) || Bot.HasInHand(CardId.Raidraptor_SingingLanius))
-                && (HasInDeck(CardId.Rank_Up_MagicSoulShaveForce) || Bot.HasInHand(CardId.Rank_Up_MagicSoulShaveForce));
+            return !link_summoned && !(!Bot.HasInExtra(CardId.Raidraptor_ArsenalFalcon) & flag1) && Bot.HasInDeck(CardId.Blackwing_ZephyrostheElite) && Bot.HasInExtra(CardId.Raidraptor_ForceStrix) && Bot.HasInExtra(CardId.Raidraptor_WiseStrix)
+                && Bot.HasInExtra(CardId.TruKingofAllCalamities) && (Bot.HasInDeck(CardId.Raider_Wing) || Bot.HasInHand(CardId.Raider_Wing))
+                && (Bot.HasInDeck(CardId.Raidraptor_SingingLanius) || Bot.HasInHand(CardId.Raidraptor_SingingLanius))
+                && (Bot.HasInDeck(CardId.Rank_Up_MagicSoulShaveForce) || Bot.HasInHand(CardId.Rank_Up_MagicSoulShaveForce));
         }
         private bool Raidraptor_ForceStrixEffect()
         {
@@ -757,9 +757,9 @@ namespace WindBot.Game.AI.Decks
             if (ActivateDescription == -1)
             {
                 int count = 0;
-                if (HasInDeck(CardId.Raidraptor_SingingLanius)) ++count;
-                if (HasInDeck(CardId.Blackwing_ZephyrostheElite)) ++count;
-                if (HasInDeck(CardId.Raider_Wing)) ++count;
+                if (Bot.HasInDeck(CardId.Raidraptor_SingingLanius)) ++count;
+                if (Bot.HasInDeck(CardId.Blackwing_ZephyrostheElite)) ++count;
+                if (Bot.HasInDeck(CardId.Raider_Wing)) ++count;
                 if (count <= 1) return false;
                 AI.SelectCard(CardId.Raider_Wing);
                 return BeforeResult(ExecutorType.Activate);
@@ -821,7 +821,7 @@ namespace WindBot.Game.AI.Decks
         }
         private bool DDSavantKeplerSummon()
         {
-            if (HasInDeck(CardId.DarkContractwiththGate))
+            if (Bot.HasInDeck(CardId.DarkContractwiththGate))
             {
                 summoned = true;
                 return BeforeResult(ExecutorType.Summon);
@@ -854,14 +854,14 @@ namespace WindBot.Game.AI.Decks
         {
             int count = 0;
             if (!activate_DragonShrine && func.CardsCheckAny(Bot.Hand, func.IsCode, CardId.DragonShrine) &&
-                (HasInDeck(CardId.FlameBeastoftheNekroz) || HasInDeck(CardId.DestrudotheLostDragon_Frisson) || HasInDeck(CardId.SupremeKingDragonDarkwurm))) ++count;
+                (Bot.HasInDeck(CardId.FlameBeastoftheNekroz) || Bot.HasInDeck(CardId.DestrudotheLostDragon_Frisson) || Bot.HasInDeck(CardId.SupremeKingDragonDarkwurm))) ++count;
             if (!activate_SpellPowerMastery && func.CardsCheckAny(Bot.Hand, func.IsCode, CardId.SpellPowerMastery)
-                && (HasInDeck(CardId.TheMightyMasterofMagic) || HasInDeck(CardId.ServantofEndymion))) ++count;
+                && (Bot.HasInDeck(CardId.TheMightyMasterofMagic) || Bot.HasInDeck(CardId.ServantofEndymion))) ++count;
             if (func.CardsCheckAny(Bot.Hand, func.IsCode, CardId.DarkContractwiththGate)) ++count;
             if (!activate_ZefraProvidence && func.CardsCheckAny(Bot.Hand, func.IsCode, CardId.ZefraProvidence))
             {
                 if (func.CardsCheckCount(Bot.Hand, func.IsCode, CardId.OracleofZefra) <= 0 && !activate_OracleofZefra
-                    && HasInDeck(CardId.OracleofZefra))
+                    && Bot.HasInDeck(CardId.OracleofZefra))
                 {
                     count += 2;
                 }
@@ -871,11 +871,11 @@ namespace WindBot.Game.AI.Decks
                 }
             }
             if (!activate_OracleofZefra && func.CardsCheckAny(Bot.Hand, func.IsCode, CardId.OracleofZefra)) ++count;
-            if (func.CardsCheckAny(Bot.Hand, func.IsCode, CardId.Terraforming) && HasInDeck(CardId.OracleofZefra)) ++count;
+            if (func.CardsCheckAny(Bot.Hand, func.IsCode, CardId.Terraforming) && Bot.HasInDeck(CardId.OracleofZefra)) ++count;
             if (func.CardsCheckAny(Bot.Hand, func.IsCode, CardId.FoolishBurial)) ++count;
             if (func.CardsCheckCount(Bot.Hand, func.HasType, CardType.Pendulum) > 1 && Bot.SpellZone[0] == null &&
                 Bot.SpellZone[4] == null) ++count;
-            if (!summoned && Bot.HasInHand(CardId.DDSavantKepler) && HasInDeck(CardId.DarkContractwiththGate)) ++count;
+            if (!summoned && Bot.HasInHand(CardId.DDSavantKepler) && Bot.HasInDeck(CardId.DarkContractwiththGate)) ++count;
             return count;
         }
         private bool ServantofEndymionEffect_3()
@@ -915,7 +915,7 @@ namespace WindBot.Game.AI.Decks
             if (PendulumActivate())
             {
                 if (IsActivateBlackwing_ZephyrostheElite()) return BeforeResult(ExecutorType.Activate);
-                if ((!HasInDeck(CardId.TheMightyMasterofMagic) && !HasInDeck(CardId.MythicalBeastJackalKing) || GetSpellActivateCount() < 2)) return false;
+                if ((!Bot.HasInDeck(CardId.TheMightyMasterofMagic) && !Bot.HasInDeck(CardId.MythicalBeastJackalKing)) || GetSpellActivateCount() < 2) return false;
                 return BeforeResult(ExecutorType.Activate);
             }
             else if (Card.Location == CardLocation.SpellZone)
@@ -1303,7 +1303,7 @@ namespace WindBot.Game.AI.Decks
         }
         private bool MechaPhantomBeastAuroradonSummon()
         {
-            if (Bot.GetMonstersInMainZone().Count >= 4 || (!HasInDeck(CardId.MechaPhantomBeastO_Lion) && !IsCanSPSummonTunerLevel1()
+            if (Bot.GetMonstersInMainZone().Count >= 4 || (!Bot.HasInDeck(CardId.MechaPhantomBeastO_Lion) && !IsCanSPSummonTunerLevel1()
                 && !func.CardsCheckAny(Func.GetZoneCards(Bot, CardLocation.MonsterZone | CardLocation.Grave, true), func.IsCode, CardId.Deskbot001))) return false;
             if (XyzModeCheck())
             {
@@ -1462,7 +1462,7 @@ namespace WindBot.Game.AI.Decks
         {
             if (SpellActivate())
             {
-                return (HasInDeck(CardId.DDLamia) || func.HasInZone(Bot, CardLocation.PendulumZone, CardId.ServantofEndymion, true, true)) && BeforeResult(ExecutorType.Activate);
+                return (Bot.HasInDeck(CardId.DDLamia) || func.HasInZone(Bot, CardLocation.PendulumZone, CardId.ServantofEndymion, true, true)) && BeforeResult(ExecutorType.Activate);
             }
             return BeforeResult(ExecutorType.Activate);
         }
@@ -1547,7 +1547,7 @@ namespace WindBot.Game.AI.Decks
             if (ActivateDescription == -1) { link_summoned = true; return true; }
             else
             {
-                if (!HasInDeck(CardId.MechaPhantomBeastO_Lion)
+                if (!Bot.HasInDeck(CardId.MechaPhantomBeastO_Lion)
                     && Func.GetZoneCards(Enemy, CardLocation.Onfield).Count <= 0) return false;
                 List<ClientCard> tRelease = new List<ClientCard>();
                 List<ClientCard> nRelease = new List<ClientCard>();
@@ -1561,7 +1561,7 @@ namespace WindBot.Game.AI.Decks
                 opt_1 = false;
                 opt_2 = false;
                 if (count >= 3 && func.CardsCheckCount(Bot.Graveyard, func.HasType, CardType.Trap) > 0) opt_2 = true;
-                if (count >= 2 && CheckRemainInDeck(CardId.MechaPhantomBeastO_Lion) > 0) opt_1 = true;
+                if (count >= 2 && Bot.HasInDeck(CardId.MechaPhantomBeastO_Lion)) opt_1 = true;
                 if (count >= 1 && Func.GetZoneCards(Enemy, CardLocation.Onfield).Count > 0) opt_0 = true;
                 if (!opt_0 && !opt_1 && !opt_2) return false;
                 return true;
@@ -1583,7 +1583,7 @@ namespace WindBot.Game.AI.Decks
         }
         private bool SupremeKingDragonDarkwurmSummon()
         {
-            if ((!activate_p_Zefraath && Bot.HasInHand(CardId.Zefraath) && !activate_SupremeKingDragonDarkwurm_1 && HasInDeck(CardId.SupremeKingGateZero) && func.CardsCheckAny(Bot.Hand, func.HasType, CardType.Tuner))
+            if ((!activate_p_Zefraath && Bot.HasInHand(CardId.Zefraath) && !activate_SupremeKingDragonDarkwurm_1 && Bot.HasInDeck(CardId.SupremeKingGateZero) && func.CardsCheckAny(Bot.Hand, func.HasType, CardType.Tuner))
                 || (func.CardsCheckAny(Func.GetZoneCards(Bot, CardLocation.Hand), card => { return card.LinkCount > 5; }) &&
                 !Bot.HasInHand(CardId.SupremeKingGateZero) && !activate_SupremeKingDragonDarkwurm_2))
             {
@@ -1632,7 +1632,7 @@ namespace WindBot.Game.AI.Decks
         }
         private void HeavymetalfoesElectrumiteAddIds(List<int> ids)
         {
-            if (!summoned && HasInDeck(CardId.DarkContractwiththGate) && HasInDeck(CardId.DDLamia))
+            if (!summoned && Bot.HasInDeck(CardId.DarkContractwiththGate) && Bot.HasInDeck(CardId.DDLamia))
             {
                 if (!func.CardsCheckAny(Func.GetZoneCards(Bot, CardLocation.MonsterZone, true), func.HasType, CardType.Tuner))
                 {
@@ -1909,7 +1909,7 @@ namespace WindBot.Game.AI.Decks
                 else if (func.CardsCheckALL(cards, func.HasSetCode, true, 0x12a))
                 {
                     if (!func.HasInZone(Bot, CardLocation.PendulumZone | CardLocation.Hand, CardId.ServantofEndymion, true) ||
-                        (func.HasInZone(Bot, CardLocation.PendulumZone | CardLocation.Hand, CardId.ServantofEndymion, true) && (!HasInDeck(CardId.TheMightyMasterofMagic) || !HasInDeck(CardId.MythicalBeastJackalKing)))) ids.Add(CardId.ServantofEndymion);
+                        (func.HasInZone(Bot, CardLocation.PendulumZone | CardLocation.Hand, CardId.ServantofEndymion, true) && (!Bot.HasInDeck(CardId.TheMightyMasterofMagic) || !Bot.HasInDeck(CardId.MythicalBeastJackalKing)))) ids.Add(CardId.ServantofEndymion);
                     ids.Add(CardId.TheMightyMasterofMagic);
                     ids.Add(CardId.MythicalBeastJackalKing);
                     result = func.CardsIdToClientCards(ids, cards);
@@ -2118,96 +2118,6 @@ namespace WindBot.Game.AI.Decks
             IList<ClientCard> selectResult = Func.CheckSelectCount(Util, result, cards, min, max);
             if (selectResult == null) return base.OnSelectCard(cards, min, max, hint, cancelable);
             return selectResult;
-        }
-        private bool HasInDeck(int id)
-        {
-            return CheckRemainInDeck(id) > 0;
-        }
-        private int CheckRemainInDeck(int id)
-        {
-            switch (id)
-            {
-                case CardId.PSY_FrameDriver:
-                    return Bot.GetRemainingCount(CardId.PSY_FrameDriver, 1);
-                case CardId.Zefraath:
-                    return Bot.GetRemainingCount(CardId.Zefraath, 3);
-                case CardId.TheMightyMasterofMagic:
-                    return Bot.GetRemainingCount(CardId.TheMightyMasterofMagic, 1);
-                case CardId.AstrographSorcerer:
-                    return Bot.GetRemainingCount(CardId.AstrographSorcerer, 1);
-                case CardId.DestrudotheLostDragon_Frisson:
-                    return Bot.GetRemainingCount(CardId.DestrudotheLostDragon_Frisson, 1);
-                case CardId.SupremeKingGateZero:
-                    return Bot.GetRemainingCount(CardId.SupremeKingGateZero, 2);
-                case CardId.MythicalBeastJackalKing:
-                    return Bot.GetRemainingCount(CardId.MythicalBeastJackalKing, 1);
-                case CardId.SecretoftheYangZing:
-                    return Bot.GetRemainingCount(CardId.SecretoftheYangZing, 3);
-                case CardId.FlameBeastoftheNekroz:
-                    return Bot.GetRemainingCount(CardId.FlameBeastoftheNekroz, 1);
-                case CardId.StellarknightZefraxciton:
-                    return Bot.GetRemainingCount(CardId.StellarknightZefraxciton, 1);
-                case CardId.SupremeKingDragonDarkwurm:
-                    return Bot.GetRemainingCount(CardId.SupremeKingDragonDarkwurm, 1);
-                case CardId.Blackwing_ZephyrostheElite:
-                    return Bot.GetRemainingCount(CardId.Blackwing_ZephyrostheElite, 1);
-                case CardId.ShaddollZefracore:
-                    return Bot.GetRemainingCount(CardId.ShaddollZefracore, 1);
-                case CardId.Raidraptor_SingingLanius:
-                    return Bot.GetRemainingCount(CardId.Raidraptor_SingingLanius, 1);
-                case CardId.SatellarknightZefrathuban:
-                    return Bot.GetRemainingCount(CardId.SatellarknightZefrathuban, 1);
-                case CardId.Raider_Wing:
-                    return Bot.GetRemainingCount(CardId.Raider_Wing, 1);
-                case CardId.Zefraxi_TreasureoftheYangZing:
-                    return Bot.GetRemainingCount(CardId.Zefraxi_TreasureoftheYangZing, 2);
-                case CardId.RitualBeastTamerZeframpilica:
-                    return Bot.GetRemainingCount(CardId.RitualBeastTamerZeframpilica, 1);
-                case CardId.ServantofEndymion:
-                    return Bot.GetRemainingCount(CardId.ServantofEndymion, 3);
-                case CardId.PSY_FramegearGamma:
-                    return Bot.GetRemainingCount(CardId.PSY_FramegearGamma, 3);
-                case CardId.MechaPhantomBeastO_Lion:
-                    return Bot.GetRemainingCount(CardId.MechaPhantomBeastO_Lion, 1);
-                case CardId.MaxxC:
-                    return Bot.GetRemainingCount(CardId.MaxxC, 3);
-                case CardId.Deskbot001:
-                    return Bot.GetRemainingCount(CardId.Deskbot001, 1);
-                case CardId.JetSynchron:
-                    return Bot.GetRemainingCount(CardId.JetSynchron, 1);
-                case CardId.DDLamia:
-                    return Bot.GetRemainingCount(CardId.DDLamia, 1);
-                case CardId.DDSavantKepler:
-                    return Bot.GetRemainingCount(CardId.DDSavantKepler, 1);
-                case CardId.LightoftheYangZing:
-                    return Bot.GetRemainingCount(CardId.LightoftheYangZing, 1);
-                case CardId.Rank_Up_MagicSoulShaveForce:
-                    return Bot.GetRemainingCount(CardId.Rank_Up_MagicSoulShaveForce, 1);
-                case CardId.SpellPowerMastery:
-                    return Bot.GetRemainingCount(CardId.SpellPowerMastery, 3);
-                case CardId.DragonShrine:
-                    return Bot.GetRemainingCount(CardId.DragonShrine, 3);
-                case CardId.Terraforming:
-                    return Bot.GetRemainingCount(CardId.Terraforming, 1);
-                case CardId.ZefraProvidence:
-                    return Bot.GetRemainingCount(CardId.ZefraProvidence, 3);
-                case CardId.FoolishBurial:
-                    return Bot.GetRemainingCount(CardId.FoolishBurial, 1);
-                case CardId.CalledbytheGrave:
-                    return Bot.GetRemainingCount(CardId.CalledbytheGrave, 2);
-                case CardId.DarkContractwiththGate:
-                    return Bot.GetRemainingCount(CardId.DarkContractwiththGate, 1);
-                case CardId.OracleofZefra:
-                    return Bot.GetRemainingCount(CardId.OracleofZefra, 3);
-                case CardId.ZefraWar:
-                    return Bot.GetRemainingCount(CardId.ZefraWar, 1);
-                case CardId.ZefraDivineStrike:
-                    return Bot.GetRemainingCount(CardId.ZefraDivineStrike, 1);
-                case CardId.NinePillarsofYangZing:
-                    return Bot.GetRemainingCount(CardId.NinePillarsofYangZing, 1);
-                default:
-                    return 0;
-            }
         }
     }
 }

--- a/Game/ClientCard.cs
+++ b/Game/ClientCard.cs
@@ -32,6 +32,7 @@ namespace WindBot.Game
         public int BaseDefense { get; private set; }
         public int RealPower { get; set; }
         public List<int> Overlays { get; private set; }
+        internal List<int> OverlayOwners { get; private set; }
         public int Owner { get; internal set; }
         public int Controller { get; set; }
         public int Disabled { get; private set; }
@@ -66,6 +67,7 @@ namespace WindBot.Game
             Sequence = sequence;
             Position = position;
             Overlays = new List<int>();
+            OverlayOwners = new List<int>();
             EquipCards = new List<ClientCard>();
             OwnTargets = new List<ClientCard>();
             TargetCards = new List<ClientCard>();
@@ -136,10 +138,21 @@ namespace WindBot.Game
             }
             if ((flag & (int)Query.OverlayCard) != 0)
             {
+                List<int> previousOverlays = new List<int>(Overlays);
+                List<int> previousOverlayOwners = new List<int>(OverlayOwners);
                 Overlays.Clear();
+                OverlayOwners.Clear();
                 int count = packet.ReadInt32();
                 for (int i = 0; i < count; ++i)
-                    Overlays.Add(packet.ReadInt32());
+                {
+                    int overlayId = packet.ReadInt32();
+                    int overlayOwner = Controller;
+                    // QUERY_OVERLAY_CARD omits the owner, so preserve ownership learned from MSG_MOVE.
+                    if (i < previousOverlays.Count && i < previousOverlayOwners.Count && previousOverlays[i] == overlayId)
+                        overlayOwner = previousOverlayOwners[i];
+                    Overlays.Add(overlayId);
+                    OverlayOwners.Add(overlayOwner);
+                }
             }
             if ((flag & (int)Query.Counters) != 0)
             {

--- a/Game/ClientCard.cs
+++ b/Game/ClientCard.cs
@@ -32,7 +32,6 @@ namespace WindBot.Game
         public int BaseDefense { get; private set; }
         public int RealPower { get; set; }
         public List<int> Overlays { get; private set; }
-        internal List<int> OverlayOwners { get; private set; }
         public int Owner { get; internal set; }
         public int Controller { get; set; }
         public int Disabled { get; private set; }
@@ -67,7 +66,6 @@ namespace WindBot.Game
             Sequence = sequence;
             Position = position;
             Overlays = new List<int>();
-            OverlayOwners = new List<int>();
             EquipCards = new List<ClientCard>();
             OwnTargets = new List<ClientCard>();
             TargetCards = new List<ClientCard>();
@@ -138,21 +136,10 @@ namespace WindBot.Game
             }
             if ((flag & (int)Query.OverlayCard) != 0)
             {
-                List<int> previousOverlays = new List<int>(Overlays);
-                List<int> previousOverlayOwners = new List<int>(OverlayOwners);
                 Overlays.Clear();
-                OverlayOwners.Clear();
                 int count = packet.ReadInt32();
                 for (int i = 0; i < count; ++i)
-                {
-                    int overlayId = packet.ReadInt32();
-                    int overlayOwner = Controller;
-                    // QUERY_OVERLAY_CARD omits the owner, so preserve ownership learned from MSG_MOVE.
-                    if (i < previousOverlays.Count && i < previousOverlayOwners.Count && previousOverlays[i] == overlayId)
-                        overlayOwner = previousOverlayOwners[i];
-                    Overlays.Add(overlayId);
-                    OverlayOwners.Add(overlayOwner);
-                }
+                    Overlays.Add(packet.ReadInt32());
             }
             if ((flag & (int)Query.Counters) != 0)
             {

--- a/Game/ClientCard.cs
+++ b/Game/ClientCard.cs
@@ -376,6 +376,9 @@ namespace WindBot.Game
             return IsAttack() ? Attack : Defense;
         }
 
+        /// <summary>
+        /// Returns the database alias when present, including both alternate-artwork aliases and rule-name aliases.
+        /// </summary>
         public int GetOriginCode()
         {
             int code = Id;
@@ -385,6 +388,15 @@ namespace WindBot.Game
                 else code = Data.Id;
             }
             return code;
+        }
+
+        /// <summary>
+        /// Returns the original artwork card's code for alternate artwork card, while preserving the
+        /// card's own code for rule-name aliases.
+        /// </summary>
+        public int GetNonAltartCode()
+        {
+            return NamedCard.IsAltartAlias(Id, Alias) ? Alias : Id;
         }
 
         public bool Equals(ClientCard card)

--- a/Game/ClientField.cs
+++ b/Game/ClientField.cs
@@ -8,9 +8,9 @@ namespace WindBot.Game
 {
     public class ClientField
     {
-        private int _player;
-        private ClientField _opponent;
-        private IDictionary<int, int> _initialDeckCounts;
+        private IDictionary<int, int> _deckCounts;
+        private bool _deckCountsExact;
+        private bool _deckTrackingActive;
 
         public IList<ClientCard> Hand { get; private set; }
         public ClientCard[] MonsterZone { get; private set; }
@@ -32,7 +32,6 @@ namespace WindBot.Game
 
         public void Init(int deck, int extra, int player)
         {
-            _player = player;
             Hand = new List<ClientCard>();
             MonsterZone = new ClientCard[7];
             SpellZone = new ClientCard[8];
@@ -58,27 +57,97 @@ namespace WindBot.Game
             }
         }
 
-        internal void SetOpponent(ClientField opponent)
-        {
-            _opponent = opponent;
-        }
-
         public void SetInitialDeck(IEnumerable<NamedCard> cards)
         {
-            _initialDeckCounts = new Dictionary<int, int>();
+            _deckCounts = new Dictionary<int, int>();
+            _deckCountsExact = true;
+            _deckTrackingActive = true;
             foreach (NamedCard card in cards)
+                IncrementDeckCount(card.Id);
+        }
+
+        internal void SetDeckTrackingActive(bool active)
+        {
+            _deckTrackingActive = active;
+        }
+
+        internal void AddToDeck(int cardId)
+        {
+            if (!_deckTrackingActive || _deckCounts == null)
+                return;
+
+            if (cardId == 0)
             {
-                IncrementInitialDeckCount(card.Id);
-                if (card.Alias != 0 && System.Math.Abs(card.Alias - card.Id) < 20)
-                    IncrementInitialDeckCount(card.Alias);
+                _deckCountsExact = false;
+                Logger.DebugWriteLine("Deck tracking: an unknown card entered the deck.");
+                return;
+            }
+            IncrementDeckCount(cardId);
+        }
+
+        internal void RemoveFromDeck(int cardId)
+        {
+            if (!_deckTrackingActive || _deckCounts == null)
+                return;
+
+            int count = 0;
+            if (cardId != 0 && _deckCounts.TryGetValue(cardId, out count) && count > 0)
+            {
+                _deckCounts[cardId] = count - 1;
+                return;
+            }
+
+            // The server hides the code when a card moves directly from this deck to an
+            // opponent's hidden hand or deck. Reduce every per-card lower bound so callers
+            // never assume that the unknown departing card is still available.
+            foreach (int id in _deckCounts.Keys.ToList())
+                _deckCounts[id] = System.Math.Max(0, _deckCounts[id] - 1);
+            _deckCountsExact = false;
+            Logger.DebugWriteLine("Deck tracking: an unknown or untracked card left the deck.");
+        }
+
+        internal void ReplaceDeck(IEnumerable<ClientCard> cards)
+        {
+            if (!_deckTrackingActive || _deckCounts == null)
+                return;
+
+            _deckCounts.Clear();
+            _deckCountsExact = true;
+            foreach (ClientCard card in cards)
+            {
+                if (card == null || card.Id == 0)
+                {
+                    _deckCountsExact = false;
+                    continue;
+                }
+                IncrementDeckCount(card.Id);
             }
         }
 
-        private void IncrementInitialDeckCount(int cardId)
+        internal void ValidateDeckCount(int actualCount)
+        {
+            if (!_deckTrackingActive || _deckCounts == null || !_deckCountsExact)
+                return;
+
+            int trackedCount = _deckCounts.Values.Sum();
+            if (trackedCount == actualCount)
+                return;
+
+            if (trackedCount > actualCount)
+            {
+                int unknownDepartures = trackedCount - actualCount;
+                foreach (int id in _deckCounts.Keys.ToList())
+                    _deckCounts[id] = System.Math.Max(0, _deckCounts[id] - unknownDepartures);
+            }
+            _deckCountsExact = false;
+            Logger.DebugWriteLine("Deck tracking count mismatch: tracked=" + trackedCount + ", actual=" + actualCount + ".");
+        }
+
+        private void IncrementDeckCount(int cardId)
         {
             int count = 0;
-            _initialDeckCounts.TryGetValue(cardId, out count);
-            _initialDeckCounts[cardId] = count + 1;
+            _deckCounts.TryGetValue(cardId, out count);
+            _deckCounts[cardId] = count + 1;
         }
 
         public int GetMonstersExtraZoneCount()
@@ -207,22 +276,22 @@ namespace WindBot.Game
 
         /// <summary>
         /// Checks if the deck contains a specific card.
-        /// The bot can only check this by counting the appearances of the card outside the deck.
+        /// The bot tracks cards entering and leaving its own Main Deck.
         /// </summary>
         public bool HasInDeck(int cardId)
         {
             if (!CanQueryDeck()) return false;
-            return GetRemainingCount(cardId) > 0;
+            return GetTrackedDeckCount(cardId) > 0;
         }
 
         /// <summary>
         /// Checks if the deck contains specific cards.
-        /// The bot can only check this by counting the appearances of the card outside the deck.
+        /// The bot tracks cards entering and leaving its own Main Deck.
         /// </summary>
         public bool HasInDeck(params int[] cardIds)
         {
             if (!CanQueryDeck()) return false;
-            return cardIds.Any(id => GetRemainingCount(id) > 0);
+            return cardIds.Any(id => GetTrackedDeckCount(id) > 0);
         }
 
         public bool HasInHand(int cardId)
@@ -372,60 +441,41 @@ namespace WindBot.Game
 
         /// <summary>
         /// Deprecated. Will be removed in the future.
-        /// Use GetRemainingCount(int cardId) instead, which counts based on the initial deck.
+        /// Use GetRemainingCount(int cardId) instead.
         /// </summary>
-        /// <param name="initalCount_deprecated">The param is ignored.</param>
-        public int GetRemainingCount(int cardId, int initalCount_deprecated)
+        /// <param name="initialCount_deprecated">The param is ignored.</param>
+        public int GetRemainingCount(int cardId, int initialCount_deprecated)
         {
             return GetRemainingCount(cardId);
         }
 
         public int GetRemainingCount(int cardId)
         {
+            if (!CanQueryDeck()) return 0;
+            return GetTrackedDeckCount(cardId);
+        }
+
+        private int GetTrackedDeckCount(int cardId)
+        {
             int remaining = 0;
-            if (_initialDeckCounts?.TryGetValue(cardId, out remaining) != true)
-                Logger.DebugWriteLine($"GetRemainingCount: cardId {cardId} not found in the deck being used.");
-
-            // Known limitation: In tag duels, Owner identifies only the team. Cards left by a teammate in
-            // shared zones may therefore be subtracted from this bot's initial deck count.
-            remaining -= Hand.Count(card => card != null && card.Owner == _player && card.IsOriginalCode(cardId));
-            remaining -= SpellZone.Count(card => card != null && card.Owner == _player && card.IsOriginalCode(cardId));
-            remaining -= MonsterZone.Count(card => card != null && card.Owner == _player && card.IsOriginalCode(cardId));
-            remaining -= Graveyard.Count(card => card != null && card.Owner == _player && card.IsOriginalCode(cardId));
-            remaining -= Banished.Count(card => card != null && card.Owner == _player && card.IsOriginalCode(cardId));
-            remaining -= ExtraDeck.Count(card => card != null && card.Owner == _player && card.IsFaceup() && card.IsOriginalCode(cardId));
-            remaining -= MonsterZone.Where(card => card != null).Sum(card => CountMatchingOverlays(card, cardId));
-
-            // Known limitation: Cards moved into an opponent's hand or deck cannot be matched to stable slots
-            // after a shuffle, so those known copies are not included here.
-            if (_opponent != null && _opponent.MonsterZone != null)
+            bool found = false;
+            foreach (KeyValuePair<int, int> pair in _deckCounts)
             {
-                remaining -= _opponent.SpellZone.Count(card => card != null && card.Owner == _player && card.IsOriginalCode(cardId));
-                remaining -= _opponent.MonsterZone.Count(card => card != null && card.Owner == _player && card.IsOriginalCode(cardId));
-                remaining -= _opponent.MonsterZone.Where(card => card != null).Sum(card => CountMatchingOverlays(card, cardId));
-            }
-            return (remaining < 0) ? 0 : remaining;
-        }
-
-        public int GetRemainingCount(IList<int> cardIds) // params int[] will conflict with deprecated initalCount
-        {
-            return cardIds.Sum(id => GetRemainingCount(id));
-        }
-
-        private int CountMatchingOverlays(ClientCard card, int cardId)
-        {
-            int count = 0;
-            for (int i = 0; i < card.Overlays.Count; ++i)
-            {
-                if (i >= card.OverlayOwners.Count || card.OverlayOwners[i] != _player)
+                NamedCard card = NamedCard.Get(pair.Key);
+                if (pair.Key != cardId && (card == null || card.Alias != cardId || System.Math.Abs(card.Alias - card.Id) >= 20))
                     continue;
-
-                int overlayId = card.Overlays[i];
-                NamedCard overlayData = NamedCard.Get(overlayId);
-                if (overlayId == cardId || (overlayData != null && System.Math.Abs(overlayData.Alias - overlayId) < 20 && overlayData.Alias == cardId))
-                    count++;
+                found = true;
+                remaining += pair.Value;
             }
-            return count;
+            if (!found)
+                Logger.DebugWriteLine($"GetRemainingCount: cardId {cardId} not found in the deck being used.");
+            return remaining;
+        }
+
+        public int GetRemainingCount(IList<int> cardIds) // params int[] will conflict with deprecated initialCount
+        {
+            if (!CanQueryDeck()) return 0;
+            return cardIds.Sum(id => GetTrackedDeckCount(id));
         }
 
         private static int GetCount(IEnumerable<ClientCard> cards)
@@ -465,8 +515,13 @@ namespace WindBot.Game
 
         private bool CanQueryDeck()
         {
-            if (_initialDeckCounts != null) return true;
-            Logger.WriteErrorLine("Enemy.HasInDeck cannot be used because the opponent's deck is hidden to AI.");
+            if (_deckCounts != null && _deckTrackingActive) return true;
+            if (_deckCounts != null)
+            {
+                Logger.DebugWriteLine("Deck contents cannot be queried while this bot's deck is inactive in a tag duel.");
+                return false;
+            }
+            Logger.WriteErrorLine("Deck contents cannot be queried because this field's deck is hidden to AI.");
             return false;
         }
     }

--- a/Game/ClientField.cs
+++ b/Game/ClientField.cs
@@ -9,7 +9,6 @@ namespace WindBot.Game
     public class ClientField
     {
         private IDictionary<int, int> _deckCounts;
-        private bool _deckCountsExact;
         private bool _deckTrackingActive;
 
         public IList<ClientCard> Hand { get; private set; }
@@ -60,7 +59,6 @@ namespace WindBot.Game
         public void SetInitialDeck(IEnumerable<NamedCard> cards)
         {
             _deckCounts = new Dictionary<int, int>();
-            _deckCountsExact = true;
             _deckTrackingActive = true;
             foreach (NamedCard card in cards)
                 IncrementDeckCount(card.Id);
@@ -78,8 +76,7 @@ namespace WindBot.Game
 
             if (cardId == 0)
             {
-                _deckCountsExact = false;
-                Logger.DebugWriteLine("Deck tracking: an unknown card entered the deck.");
+                Logger.WriteErrorLine("Deck tracking: an unknown card entered the deck.");
                 return;
             }
             IncrementDeckCount(cardId);
@@ -97,12 +94,6 @@ namespace WindBot.Game
                 return;
             }
 
-            // The server hides the code when a card moves directly from this deck to an
-            // opponent's hidden hand or deck. Reduce every per-card lower bound so callers
-            // never assume that the unknown departing card is still available.
-            foreach (int id in _deckCounts.Keys.ToList())
-                _deckCounts[id] = System.Math.Max(0, _deckCounts[id] - 1);
-            _deckCountsExact = false;
             Logger.WriteErrorLine("Deck tracking: an unknown or untracked card left the deck.");
         }
 
@@ -112,12 +103,11 @@ namespace WindBot.Game
                 return;
 
             _deckCounts.Clear();
-            _deckCountsExact = true;
             foreach (ClientCard card in cards)
             {
                 if (card == null || card.Id == 0)
                 {
-                    _deckCountsExact = false;
+                    Logger.WriteErrorLine("Deck tracking: an unknown card was found while replacing the deck.");
                     continue;
                 }
                 IncrementDeckCount(card.Id);
@@ -126,21 +116,14 @@ namespace WindBot.Game
 
         internal void ValidateDeckCount(int actualCount)
         {
-            if (!_deckTrackingActive || _deckCounts == null || !_deckCountsExact)
+            if (!_deckTrackingActive || _deckCounts == null)
                 return;
 
             int trackedCount = _deckCounts.Values.Sum();
             if (trackedCount == actualCount)
                 return;
 
-            if (trackedCount > actualCount)
-            {
-                int unknownDepartures = trackedCount - actualCount;
-                foreach (int id in _deckCounts.Keys.ToList())
-                    _deckCounts[id] = System.Math.Max(0, _deckCounts[id] - unknownDepartures);
-            }
-            _deckCountsExact = false;
-            Logger.DebugWriteLine("Deck tracking count mismatch: tracked=" + trackedCount + ", actual=" + actualCount + ".");
+            Logger.WriteErrorLine("Deck tracking count mismatch: tracked=" + trackedCount + ", actual=" + actualCount + ".");
         }
 
         private void IncrementDeckCount(int cardId)

--- a/Game/ClientField.cs
+++ b/Game/ClientField.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using WindBot.Game.AI;
@@ -443,22 +444,21 @@ namespace WindBot.Game
 
         /// <summary>
         /// Deprecated. Will be removed in the future.
-        /// Use GetRemainingCount(int cardId) instead.
         /// </summary>
         /// <param name="initialCount">The param is ignored now.</param>
-        [System.Obsolete]
-        public int GetRemainingCount(int cardId, int initialCount)
+        [Obsolete("Use GetCardCountInDeck instead.")]
+        public int GetRemainingCount(int cardId, int initialCount = 0)
         {
-            return GetRemainingCount(cardId);
+            return GetCardCountInDeck(cardId);
         }
 
-        public int GetRemainingCount(int cardId)
+        public int GetCardCountInDeck(int cardId)
         {
             if (!CanQueryDeck()) return 0;
             return GetTrackedDeckCount(cardId);
         }
 
-        public int GetRemainingCount(IList<int> cardIds) // params int[] will conflict with deprecated initialCount
+        public int GetCardCountInDeck(IList<int> cardIds)
         {
             if (!CanQueryDeck()) return 0;
             return cardIds.Sum(id => GetTrackedDeckCount(id));

--- a/Game/ClientField.cs
+++ b/Game/ClientField.cs
@@ -1,12 +1,17 @@
 using System.Collections.Generic;
 using System.Linq;
 using WindBot.Game.AI;
+using YGOSharp.OCGWrapper;
 using YGOSharp.OCGWrapper.Enums;
 
 namespace WindBot.Game
 {
     public class ClientField
     {
+        private int _player;
+        private ClientField _opponent;
+        private IDictionary<int, int> _initialDeckCounts;
+
         public IList<ClientCard> Hand { get; private set; }
         public ClientCard[] MonsterZone { get; private set; }
         public ClientCard[] SpellZone { get; private set; }
@@ -27,6 +32,7 @@ namespace WindBot.Game
 
         public void Init(int deck, int extra, int player)
         {
+            _player = player;
             Hand = new List<ClientCard>();
             MonsterZone = new ClientCard[7];
             SpellZone = new ClientCard[8];
@@ -50,6 +56,29 @@ namespace WindBot.Game
                 card.Controller = player;
                 ExtraDeck.Add(card);
             }
+        }
+
+        internal void SetOpponent(ClientField opponent)
+        {
+            _opponent = opponent;
+        }
+
+        public void SetInitialDeck(IEnumerable<NamedCard> cards)
+        {
+            _initialDeckCounts = new Dictionary<int, int>();
+            foreach (NamedCard card in cards)
+            {
+                IncrementInitialDeckCount(card.Id);
+                if (card.Alias != 0 && System.Math.Abs(card.Alias - card.Id) < 20)
+                    IncrementInitialDeckCount(card.Alias);
+            }
+        }
+
+        private void IncrementInitialDeckCount(int cardId)
+        {
+            int count = 0;
+            _initialDeckCounts.TryGetValue(cardId, out count);
+            _initialDeckCounts[cardId] = count + 1;
         }
 
         public int GetMonstersExtraZoneCount()
@@ -174,6 +203,26 @@ namespace WindBot.Game
         public ClientCard GetFieldSpellCard()
         {
             return SpellZone[5];
+        }
+
+        /// <summary>
+        /// Checks if the deck contains a specific card.
+        /// The bot can only check this by counting the appearances of the card outside the deck.
+        /// </summary>
+        public bool HasInDeck(int cardId)
+        {
+            if (!CanQueryDeck()) return false;
+            return GetRemainingCount(cardId) > 0;
+        }
+
+        /// <summary>
+        /// Checks if the deck contains specific cards.
+        /// The bot can only check this by counting the appearances of the card outside the deck.
+        /// </summary>
+        public bool HasInDeck(IList<int> cardId)
+        {
+            if (!CanQueryDeck()) return false;
+            return cardId.Any(id => GetRemainingCount(id) > 0);
         }
 
         public bool HasInHand(int cardId)
@@ -321,15 +370,53 @@ namespace WindBot.Game
             return HasInHand(cardId) || HasInSpellZone(cardId) || HasInGraveyard(cardId);
         }
 
-        public int GetRemainingCount(int cardId, int initialCount)
+        /// <param name="initalCount_deprecated">Deprecated now. The param is ignored.</param>
+        public int GetRemainingCount(int cardId, int initalCount_deprecated)
         {
-            int remaining = initialCount;
-            remaining = remaining - Hand.Count(card => card != null && card.IsOriginalCode(cardId));
-            remaining = remaining - SpellZone.Count(card => card != null && card.IsOriginalCode(cardId));
-            remaining = remaining - MonsterZone.Count(card => card != null && card.IsOriginalCode(cardId));
-            remaining = remaining - Graveyard.Count(card => card != null && card.IsOriginalCode(cardId));
-            remaining = remaining - Banished.Count(card => card != null && card.IsOriginalCode(cardId));
+            return GetRemainingCount(cardId);
+        }
+
+        public int GetRemainingCount(int cardId)
+        {
+            int remaining = 0;
+            if (_initialDeckCounts?.TryGetValue(cardId, out remaining) != true)
+                Logger.DebugWriteLine($"GetRemainingCount: cardId {cardId} not found in the deck being used.");
+
+            // Known limitation: In tag duels, Owner identifies only the team. Cards left by a teammate in
+            // shared zones may therefore be subtracted from this bot's initial deck count.
+            remaining -= Hand.Count(card => card != null && card.Owner == _player && card.IsOriginalCode(cardId));
+            remaining -= SpellZone.Count(card => card != null && card.Owner == _player && card.IsOriginalCode(cardId));
+            remaining -= MonsterZone.Count(card => card != null && card.Owner == _player && card.IsOriginalCode(cardId));
+            remaining -= Graveyard.Count(card => card != null && card.Owner == _player && card.IsOriginalCode(cardId));
+            remaining -= Banished.Count(card => card != null && card.Owner == _player && card.IsOriginalCode(cardId));
+            remaining -= ExtraDeck.Count(card => card != null && card.Owner == _player && card.IsFaceup() && card.IsOriginalCode(cardId));
+            remaining -= MonsterZone.Where(card => card != null).Sum(card => CountMatchingOverlays(card, cardId));
+
+            // Known limitation: Cards moved into an opponent's hand or deck cannot be matched to stable slots
+            // after a shuffle, so those known copies are not included here.
+            if (_opponent != null && _opponent.MonsterZone != null)
+            {
+                remaining -= _opponent.SpellZone.Count(card => card != null && card.Owner == _player && card.IsOriginalCode(cardId));
+                remaining -= _opponent.MonsterZone.Count(card => card != null && card.Owner == _player && card.IsOriginalCode(cardId));
+                remaining -= _opponent.MonsterZone.Where(card => card != null).Sum(card => CountMatchingOverlays(card, cardId));
+            }
             return (remaining < 0) ? 0 : remaining;
+        }
+
+        private int CountMatchingOverlays(ClientCard card, int cardId)
+        {
+            int count = 0;
+            for (int i = 0; i < card.Overlays.Count; ++i)
+            {
+                if (i >= card.OverlayOwners.Count || card.OverlayOwners[i] != _player)
+                    continue;
+
+                int overlayId = card.Overlays[i];
+                NamedCard overlayData = NamedCard.Get(overlayId);
+                if (overlayId == cardId || (overlayData != null && System.Math.Abs(overlayData.Alias - overlayId) < 20 && overlayData.Alias == cardId))
+                    count++;
+            }
+            return count;
         }
 
         private static int GetCount(IEnumerable<ClientCard> cards)
@@ -365,6 +452,13 @@ namespace WindBot.Game
         private static bool HasInCards(IEnumerable<ClientCard> cards, IList<int> cardId, bool notDisabled = false, bool hasXyzMaterial = false, bool faceUp = false)
         {
             return cards.Any(card => card != null && card.IsCode(cardId) && !(notDisabled && card.IsDisabled()) && !(hasXyzMaterial && !card.HasXyzMaterial()) && !(faceUp && card.IsFacedown()));
+        }
+
+        private bool CanQueryDeck()
+        {
+            if (_initialDeckCounts != null) return true;
+            Logger.WriteErrorLine("Enemy.HasInDeck cannot be used because the opponent's deck is hidden to AI.");
+            return false;
         }
     }
 }

--- a/Game/ClientField.cs
+++ b/Game/ClientField.cs
@@ -219,10 +219,10 @@ namespace WindBot.Game
         /// Checks if the deck contains specific cards.
         /// The bot can only check this by counting the appearances of the card outside the deck.
         /// </summary>
-        public bool HasInDeck(IList<int> cardId)
+        public bool HasInDeck(params int[] cardIds)
         {
             if (!CanQueryDeck()) return false;
-            return cardId.Any(id => GetRemainingCount(id) > 0);
+            return cardIds.Any(id => GetRemainingCount(id) > 0);
         }
 
         public bool HasInHand(int cardId)
@@ -370,7 +370,11 @@ namespace WindBot.Game
             return HasInHand(cardId) || HasInSpellZone(cardId) || HasInGraveyard(cardId);
         }
 
-        /// <param name="initalCount_deprecated">Deprecated now. The param is ignored.</param>
+        /// <summary>
+        /// Deprecated. Will be removed in the future.
+        /// Use GetRemainingCount(int cardId) instead, which counts based on the initial deck.
+        /// </summary>
+        /// <param name="initalCount_deprecated">The param is ignored.</param>
         public int GetRemainingCount(int cardId, int initalCount_deprecated)
         {
             return GetRemainingCount(cardId);
@@ -401,6 +405,11 @@ namespace WindBot.Game
                 remaining -= _opponent.MonsterZone.Where(card => card != null).Sum(card => CountMatchingOverlays(card, cardId));
             }
             return (remaining < 0) ? 0 : remaining;
+        }
+
+        public int GetRemainingCount(IList<int> cardIds) // params int[] will conflict with deprecated initalCount
+        {
+            return cardIds.Sum(id => GetRemainingCount(id));
         }
 
         private int CountMatchingOverlays(ClientCard card, int cardId)

--- a/Game/ClientField.cs
+++ b/Game/ClientField.cs
@@ -103,7 +103,7 @@ namespace WindBot.Game
             foreach (int id in _deckCounts.Keys.ToList())
                 _deckCounts[id] = System.Math.Max(0, _deckCounts[id] - 1);
             _deckCountsExact = false;
-            Logger.DebugWriteLine("Deck tracking: an unknown or untracked card left the deck.");
+            Logger.WriteErrorLine("Deck tracking: an unknown or untracked card left the deck.");
         }
 
         internal void ReplaceDeck(IEnumerable<ClientCard> cards)

--- a/Game/ClientField.cs
+++ b/Game/ClientField.cs
@@ -8,8 +8,8 @@ namespace WindBot.Game
 {
     public class ClientField
     {
-        private IDictionary<int, int> _deckCounts;
-        private bool _deckTrackingActive;
+        private IDictionary<int, int> _deckCardCounts;
+        public bool DeckTrackingActive;
 
         public IList<ClientCard> Hand { get; private set; }
         public ClientCard[] MonsterZone { get; private set; }
@@ -58,20 +58,42 @@ namespace WindBot.Game
 
         public void SetInitialDeck(IEnumerable<NamedCard> cards)
         {
-            _deckCounts = new Dictionary<int, int>();
-            _deckTrackingActive = true;
+            _deckCardCounts = new Dictionary<int, int>();
+            DeckTrackingActive = true;
             foreach (NamedCard card in cards)
-                IncrementDeckCount(card.Id);
+                IncrementDeckCardCount(card.Id);
         }
 
-        internal void SetDeckTrackingActive(bool active)
+        private void IncrementDeckCardCount(int cardId)
         {
-            _deckTrackingActive = active;
+            int count;
+            _deckCardCounts.TryGetValue(cardId, out count);
+            _deckCardCounts[cardId] = count + 1;
         }
 
-        internal void AddToDeck(int cardId)
+        private int GetTrackedDeckCount(int cardId)
         {
-            if (!_deckTrackingActive || _deckCounts == null)
+            int remaining = 0;
+            bool found = false;
+            foreach (KeyValuePair<int, int> pair in _deckCardCounts)
+            {
+                NamedCard card = NamedCard.Get(pair.Key);
+                if (pair.Key != cardId && (card == null || card.Alias != cardId || !NamedCard.IsAltartAlias(card.Id, card.Alias)))
+                    continue;
+                found = true;
+                remaining += pair.Value;
+            }
+            if (!found)
+            {
+                // at most cases we don't want to log this
+                // Logger.DebugWriteLine($"GetTrackedDeckCount: cardId {cardId} not found in the deck being used.");
+            }
+            return remaining;
+        }
+
+        internal void TrackAddToDeck(int cardId)
+        {
+            if (!DeckTrackingActive || _deckCardCounts == null)
                 return;
 
             if (cardId == 0)
@@ -79,30 +101,30 @@ namespace WindBot.Game
                 Logger.WriteErrorLine("Deck tracking: an unknown card entered the deck.");
                 return;
             }
-            IncrementDeckCount(cardId);
+            IncrementDeckCardCount(cardId);
         }
 
-        internal void RemoveFromDeck(int cardId)
+        internal void TrackRemoveFromDeck(int cardId)
         {
-            if (!_deckTrackingActive || _deckCounts == null)
+            if (!DeckTrackingActive || _deckCardCounts == null)
                 return;
 
             int count = 0;
-            if (cardId != 0 && _deckCounts.TryGetValue(cardId, out count) && count > 0)
+            if (cardId != 0 && _deckCardCounts.TryGetValue(cardId, out count) && count > 0)
             {
-                _deckCounts[cardId] = count - 1;
+                _deckCardCounts[cardId] = count - 1;
                 return;
             }
 
             Logger.WriteErrorLine("Deck tracking: an unknown or untracked card left the deck.");
         }
 
-        internal void ReplaceDeck(IEnumerable<ClientCard> cards)
+        internal void TrackReplaceDeck(IEnumerable<ClientCard> cards)
         {
-            if (!_deckTrackingActive || _deckCounts == null)
+            if (!DeckTrackingActive || _deckCardCounts == null)
                 return;
 
-            _deckCounts.Clear();
+            _deckCardCounts.Clear();
             foreach (ClientCard card in cards)
             {
                 if (card == null || card.Id == 0)
@@ -110,27 +132,32 @@ namespace WindBot.Game
                     Logger.WriteErrorLine("Deck tracking: an unknown card was found while replacing the deck.");
                     continue;
                 }
-                IncrementDeckCount(card.Id);
+                IncrementDeckCardCount(card.Id);
             }
         }
 
-        internal void ValidateDeckCount(int actualCount)
+        internal void ValidateTrackedDeckCount(int actualCount)
         {
-            if (!_deckTrackingActive || _deckCounts == null)
+            if (!DeckTrackingActive || _deckCardCounts == null)
                 return;
 
-            int trackedCount = _deckCounts.Values.Sum();
+            int trackedCount = _deckCardCounts.Values.Sum();
             if (trackedCount == actualCount)
                 return;
 
             Logger.WriteErrorLine("Deck tracking count mismatch: tracked=" + trackedCount + ", actual=" + actualCount + ".");
         }
 
-        private void IncrementDeckCount(int cardId)
+        private bool CanQueryDeck()
         {
-            int count = 0;
-            _deckCounts.TryGetValue(cardId, out count);
-            _deckCounts[cardId] = count + 1;
+            if (_deckCardCounts != null && DeckTrackingActive) return true;
+            if (_deckCardCounts != null)
+            {
+                Logger.DebugWriteLine("Deck contents cannot be queried while this bot's deck is inactive in a tag duel.");
+                return false;
+            }
+            Logger.WriteErrorLine("Deck contents cannot be queried because the opponent's deck is hidden to AI.");
+            return false;
         }
 
         public int GetMonstersExtraZoneCount()
@@ -257,20 +284,12 @@ namespace WindBot.Game
             return SpellZone[5];
         }
 
-        /// <summary>
-        /// Checks if the deck contains a specific card.
-        /// The bot tracks cards entering and leaving its own Main Deck.
-        /// </summary>
         public bool HasInDeck(int cardId)
         {
             if (!CanQueryDeck()) return false;
             return GetTrackedDeckCount(cardId) > 0;
         }
 
-        /// <summary>
-        /// Checks if the deck contains specific cards.
-        /// The bot tracks cards entering and leaving its own Main Deck.
-        /// </summary>
         public bool HasInDeck(params int[] cardIds)
         {
             if (!CanQueryDeck()) return false;
@@ -426,8 +445,9 @@ namespace WindBot.Game
         /// Deprecated. Will be removed in the future.
         /// Use GetRemainingCount(int cardId) instead.
         /// </summary>
-        /// <param name="initialCount_deprecated">The param is ignored.</param>
-        public int GetRemainingCount(int cardId, int initialCount_deprecated)
+        /// <param name="initialCount">The param is ignored now.</param>
+        [System.Obsolete]
+        public int GetRemainingCount(int cardId, int initialCount)
         {
             return GetRemainingCount(cardId);
         }
@@ -436,23 +456,6 @@ namespace WindBot.Game
         {
             if (!CanQueryDeck()) return 0;
             return GetTrackedDeckCount(cardId);
-        }
-
-        private int GetTrackedDeckCount(int cardId)
-        {
-            int remaining = 0;
-            bool found = false;
-            foreach (KeyValuePair<int, int> pair in _deckCounts)
-            {
-                NamedCard card = NamedCard.Get(pair.Key);
-                if (pair.Key != cardId && (card == null || card.Alias != cardId || !NamedCard.IsAltartAlias(card.Id, card.Alias)))
-                    continue;
-                found = true;
-                remaining += pair.Value;
-            }
-            if (!found)
-                Logger.DebugWriteLine($"GetRemainingCount: cardId {cardId} not found in the deck being used.");
-            return remaining;
         }
 
         public int GetRemainingCount(IList<int> cardIds) // params int[] will conflict with deprecated initialCount
@@ -494,18 +497,6 @@ namespace WindBot.Game
         private static bool HasInCards(IEnumerable<ClientCard> cards, IList<int> cardId, bool notDisabled = false, bool hasXyzMaterial = false, bool faceUp = false)
         {
             return cards.Any(card => card != null && card.IsCode(cardId) && !(notDisabled && card.IsDisabled()) && !(hasXyzMaterial && !card.HasXyzMaterial()) && !(faceUp && card.IsFacedown()));
-        }
-
-        private bool CanQueryDeck()
-        {
-            if (_deckCounts != null && _deckTrackingActive) return true;
-            if (_deckCounts != null)
-            {
-                Logger.DebugWriteLine("Deck contents cannot be queried while this bot's deck is inactive in a tag duel.");
-                return false;
-            }
-            Logger.WriteErrorLine("Deck contents cannot be queried because this field's deck is hidden to AI.");
-            return false;
         }
     }
 }

--- a/Game/ClientField.cs
+++ b/Game/ClientField.cs
@@ -117,6 +117,8 @@ namespace WindBot.Game
                 return;
             }
 
+            // No currently OCG card moves a card directly from one player's Deck to another zone hidden to that player,
+            // so an unknown or untracked departure indicates a protocol parsing or state-sync error.
             Logger.WriteErrorLine("Deck tracking: an unknown or untracked card left the deck.");
         }
 

--- a/Game/ClientField.cs
+++ b/Game/ClientField.cs
@@ -462,7 +462,7 @@ namespace WindBot.Game
             foreach (KeyValuePair<int, int> pair in _deckCounts)
             {
                 NamedCard card = NamedCard.Get(pair.Key);
-                if (pair.Key != cardId && (card == null || card.Alias != cardId || System.Math.Abs(card.Alias - card.Id) >= 20))
+                if (pair.Key != cardId && (card == null || card.Alias != cardId || !NamedCard.IsAltartAlias(card.Id, card.Alias)))
                     continue;
                 found = true;
                 remaining += pair.Value;

--- a/Game/Duel.cs
+++ b/Game/Duel.cs
@@ -36,8 +36,6 @@ namespace WindBot.Game
             Fields = new ClientField[2];
             Fields[0] = new ClientField();
             Fields[1] = new ClientField();
-            Fields[0].SetOpponent(Fields[1]);
-            Fields[1].SetOpponent(Fields[0]);
             LastChainPlayer = -1;
             LastChainLocation = 0;
             CurrentChain = new List<ClientCard>();
@@ -104,10 +102,7 @@ namespace WindBot.Game
                 ClientCard card = cards[seq];
                 if (card == null || subSeq >= card.Overlays.Count)
                     return null;
-                ClientCard overlay = new ClientCard(card.Overlays[subSeq], CardLocation.Overlay, 0, 0);
-                if (subSeq < card.OverlayOwners.Count)
-                    overlay.Owner = card.OverlayOwners[subSeq];
-                return overlay;
+                return new ClientCard(card.Overlays[subSeq], CardLocation.Overlay, 0, 0);
             }
 
             return cards[seq];

--- a/Game/Duel.cs
+++ b/Game/Duel.cs
@@ -36,6 +36,8 @@ namespace WindBot.Game
             Fields = new ClientField[2];
             Fields[0] = new ClientField();
             Fields[1] = new ClientField();
+            Fields[0].SetOpponent(Fields[1]);
+            Fields[1].SetOpponent(Fields[0]);
             LastChainPlayer = -1;
             LastChainLocation = 0;
             CurrentChain = new List<ClientCard>();
@@ -102,7 +104,10 @@ namespace WindBot.Game
                 ClientCard card = cards[seq];
                 if (card == null || subSeq >= card.Overlays.Count)
                     return null;
-                return new ClientCard(card.Overlays[subSeq], CardLocation.Overlay, 0, 0);
+                ClientCard overlay = new ClientCard(card.Overlays[subSeq], CardLocation.Overlay, 0, 0);
+                if (subSeq < card.OverlayOwners.Count)
+                    overlay.Owner = card.OverlayOwners[subSeq];
+                return overlay;
             }
 
             return cards[seq];

--- a/Game/GameBehavior.cs
+++ b/Game/GameBehavior.cs
@@ -50,6 +50,7 @@ namespace WindBot.Game
             _ai.Executor = DecksManager.Instantiate(_ai, _duel);
             Game.SetDeckContext(_ai.Executor.GetType().Name);
             Deck = Deck.Load(Game.DeckFile ?? _ai.Executor.Deck);
+            _duel.Fields[0].SetInitialDeck(Deck.Cards);
 
             _select_hint = 0;
         }
@@ -745,6 +746,8 @@ namespace WindBot.Game
                     if (_debug)
                         Logger.WriteLine("(" + previousControler.ToString() + " 's " + (overlayTarget.Name ?? "UnKnowCard") + " deattach " + (NamedCard.Get(cardId)?.Name) + ")");
                     overlayTarget.Overlays.RemoveAt(previousPosition);
+                    if (previousPosition < overlayTarget.OverlayOwners.Count)
+                        overlayTarget.OverlayOwners.RemoveAt(previousPosition);
                 }
                 if (card == null)
                     card = new ClientCard(cardId, CardLocation.Overlay, 0, 0);
@@ -767,6 +770,7 @@ namespace WindBot.Game
                     if (_debug)
                         Logger.WriteLine("(" + previousControler.ToString() + " 's " + (overlayTarget.Name ?? "UnKnowCard") + " overlay " + (NamedCard.Get(cardId)?.Name) + ")");
                     overlayTarget.Overlays.Add(cardId);
+                    overlayTarget.OverlayOwners.Add(card != null && card.Owner >= 0 ? card.Owner : previousControler);
                 }
                 if (card != null)
                 {

--- a/Game/GameBehavior.cs
+++ b/Game/GameBehavior.cs
@@ -72,15 +72,15 @@ namespace WindBot.Game
                 return;
 
             if (leavesBotDeck)
-                _duel.Fields[0].RemoveFromDeck(cardId);
+                _duel.Fields[0].TrackRemoveFromDeck(cardId);
             else
-                _duel.Fields[0].AddToDeck(cardId);
+                _duel.Fields[0].TrackAddToDeck(cardId);
         }
 
         private void ValidateBotDeckCount()
         {
             if (_botDeckActive)
-                _duel.Fields[0].ValidateDeckCount(_duel.Fields[0].Deck.Count);
+                _duel.Fields[0].ValidateTrackedDeckCount(_duel.Fields[0].Deck.Count);
         }
 
         public void OnPacket(BinaryReader packet)
@@ -451,7 +451,7 @@ namespace WindBot.Game
                 ? _room.Position % 2 == 0
                 : _room.Position % 2 == 1);
             _botDeckNeedsInitialHandSync = _isTag && !_botDeckActive;
-            _duel.Fields[0].SetDeckTrackingActive(_botDeckActive);
+            _duel.Fields[0].DeckTrackingActive = _botDeckActive;
             ValidateBotDeckCount();
 
             // in case of ending duel in chain's solving
@@ -582,7 +582,7 @@ namespace WindBot.Game
             IList<ClientCard> oldDeck = field.Deck.ToList();
             IList<ClientCard> oldGraveyard = field.Graveyard.ToList();
             if (player == 0 && _botDeckActive)
-                field.ReplaceDeck(oldGraveyard.Where(card => card != null && !card.IsExtraCard()));
+                field.TrackReplaceDeck(oldGraveyard.Where(card => card != null && !card.IsExtraCard()));
             field.Deck.Clear();
             field.Graveyard.Clear();
 
@@ -635,7 +635,7 @@ namespace WindBot.Game
                 if (_botDeckActive)
                     ValidateBotDeckCount();
                 _botDeckActive = !_botDeckActive;
-                field.SetDeckTrackingActive(_botDeckActive);
+                field.DeckTrackingActive = _botDeckActive;
             }
 
             field.Deck.Clear();
@@ -655,7 +655,7 @@ namespace WindBot.Game
                 // ocgcore draws an inactive tag partner's opening hand without sending DRAW
                 // to that client, so its first visible hand must be deducted here.
                 if (player == 0 && _botDeckActive && _botDeckNeedsInitialHandSync)
-                    field.RemoveFromDeck(code);
+                    field.TrackRemoveFromDeck(code);
                 int position = (encodedCode & 0x80000000) != 0
                     ? (int)CardPosition.FaceUp
                     : (int)CardPosition.FaceDown;

--- a/Game/GameBehavior.cs
+++ b/Game/GameBehavior.cs
@@ -29,6 +29,8 @@ namespace WindBot.Game
         private int _hand;
         private bool _debug;
         private bool _isTag;
+        private bool _botDeckActive;
+        private bool _botDeckNeedsInitialHandSync;
         private bool _chatPlayerOrderSwapped;
         private int _select_hint;
         private GameMessage _lastMessage;
@@ -50,7 +52,6 @@ namespace WindBot.Game
             _ai.Executor = DecksManager.Instantiate(_ai, _duel);
             Game.SetDeckContext(_ai.Executor.GetType().Name);
             Deck = Deck.Load(Game.DeckFile ?? _ai.Executor.Deck);
-            _duel.Fields[0].SetInitialDeck(Deck.Cards);
 
             _select_hint = 0;
         }
@@ -58,6 +59,28 @@ namespace WindBot.Game
         public int GetLocalPlayer(int player)
         {
             return _duel.IsFirst ? player : 1 - player;
+        }
+
+        private void TrackDeckMove(int cardId, int previousController, int previousLocation, int currentController, int currentLocation)
+        {
+            if (!_botDeckActive)
+                return;
+
+            bool leavesBotDeck = previousController == 0 && previousLocation == (int)CardLocation.Deck;
+            bool entersBotDeck = currentController == 0 && currentLocation == (int)CardLocation.Deck;
+            if (leavesBotDeck == entersBotDeck)
+                return;
+
+            if (leavesBotDeck)
+                _duel.Fields[0].RemoveFromDeck(cardId);
+            else
+                _duel.Fields[0].AddToDeck(cardId);
+        }
+
+        private void ValidateBotDeckCount()
+        {
+            if (_botDeckActive)
+                _duel.Fields[0].ValidateDeckCount(_duel.Fields[0].Deck.Count);
         }
 
         public void OnPacket(BinaryReader packet)
@@ -420,6 +443,17 @@ namespace WindBot.Game
             extra = packet.ReadInt16();
             _duel.Fields[GetLocalPlayer(1)].Init(deck, extra, GetLocalPlayer(1));
 
+            _duel.Fields[0].SetInitialDeck(Deck.Cards);
+            // In tag duels the first team's lower lobby slot and the second team's upper
+            // lobby slot begin with their physical deck active. Later TAG_SWAP messages
+            // toggle the active teammate for that side.
+            _botDeckActive = !_isTag || (_duel.IsFirst
+                ? _room.Position % 2 == 0
+                : _room.Position % 2 == 1);
+            _botDeckNeedsInitialHandSync = _isTag && !_botDeckActive;
+            _duel.Fields[0].SetDeckTrackingActive(_botDeckActive);
+            ValidateBotDeckCount();
+
             // in case of ending duel in chain's solving
             _duel.CurrentChain.Clear();
             _duel.CurrentChainInfo.Clear();
@@ -470,11 +504,13 @@ namespace WindBot.Game
             for (int i = 0; i < count; ++i)
             {
                 int cardId = packet.ReadInt32() & 0x7fffffff;
+                TrackDeckMove(cardId, player, (int)CardLocation.Deck, player, (int)CardLocation.Hand);
                 int deckIndex = _duel.Fields[player].Deck.Count - 1;
                 ClientCard card = _duel.Fields[player].Deck[deckIndex];
                 _duel.Fields[player].Deck.RemoveAt(deckIndex);
                 _duel.AddCard(CardLocation.Hand, card, player, -1, 0, cardId);
             }
+            ValidateBotDeckCount();
             _ai.OnDraw(player);
         }
 
@@ -545,6 +581,8 @@ namespace WindBot.Game
             ClientField field = _duel.Fields[player];
             IList<ClientCard> oldDeck = field.Deck.ToList();
             IList<ClientCard> oldGraveyard = field.Graveyard.ToList();
+            if (player == 0 && _botDeckActive)
+                field.ReplaceDeck(oldGraveyard.Where(card => card != null && !card.IsExtraCard()));
             field.Deck.Clear();
             field.Graveyard.Clear();
 
@@ -572,6 +610,7 @@ namespace WindBot.Game
                 _duel.AddCard(CardLocation.Grave, card, player, graveSequence++,
                     (int)CardPosition.FaceUp, card.Id);
             }
+            ValidateBotDeckCount();
         }
 
         private void OnReverseDeck(BinaryReader packet)
@@ -591,6 +630,14 @@ namespace WindBot.Game
             /*int topcode = */ packet.ReadInt32();
             ClientField field = _duel.Fields[player];
 
+            if (player == 0)
+            {
+                if (_botDeckActive)
+                    ValidateBotDeckCount();
+                _botDeckActive = !_botDeckActive;
+                field.SetDeckTrackingActive(_botDeckActive);
+            }
+
             field.Deck.Clear();
             for (int i = 0; i < mcount; ++i)
             {
@@ -605,6 +652,10 @@ namespace WindBot.Game
             {
                 uint encodedCode = packet.ReadUInt32();
                 int code = (int)(encodedCode & 0x7fffffff);
+                // ocgcore draws an inactive tag partner's opening hand without sending DRAW
+                // to that client, so its first visible hand must be deducted here.
+                if (player == 0 && _botDeckActive && _botDeckNeedsInitialHandSync)
+                    field.RemoveFromDeck(code);
                 int position = (encodedCode & 0x80000000) != 0
                     ? (int)CardPosition.FaceUp
                     : (int)CardPosition.FaceDown;
@@ -628,6 +679,12 @@ namespace WindBot.Game
                 card.Owner = player;
                 card.Controller = player;
                 field.ExtraDeck.Add(card);
+            }
+            if (player == 0)
+            {
+                if (_botDeckActive)
+                    _botDeckNeedsInitialHandSync = false;
+                ValidateBotDeckCount();
             }
         }
 
@@ -735,6 +792,10 @@ namespace WindBot.Game
             {
                 card.LastLocation = (CardLocation)previousLocation;
             }
+            int trackedCardId = cardId;
+            if (trackedCardId == 0 && card != null)
+                trackedCardId = card.Id;
+            TrackDeckMove(trackedCardId, previousControler, previousLocation, currentControler, currentLocation);
             if ((previousLocation & (int)CardLocation.Overlay) != 0)
             {
                 // Detach by index rather than ID because a host may have multiple materials
@@ -746,8 +807,6 @@ namespace WindBot.Game
                     if (_debug)
                         Logger.WriteLine("(" + previousControler.ToString() + " 's " + (overlayTarget.Name ?? "UnKnowCard") + " deattach " + (NamedCard.Get(cardId)?.Name) + ")");
                     overlayTarget.Overlays.RemoveAt(previousPosition);
-                    if (previousPosition < overlayTarget.OverlayOwners.Count)
-                        overlayTarget.OverlayOwners.RemoveAt(previousPosition);
                 }
                 if (card == null)
                     card = new ClientCard(cardId, CardLocation.Overlay, 0, 0);
@@ -770,7 +829,6 @@ namespace WindBot.Game
                     if (_debug)
                         Logger.WriteLine("(" + previousControler.ToString() + " 's " + (overlayTarget.Name ?? "UnKnowCard") + " overlay " + (NamedCard.Get(cardId)?.Name) + ")");
                     overlayTarget.Overlays.Add(cardId);
-                    overlayTarget.OverlayOwners.Add(card != null && card.Owner >= 0 ? card.Owner : previousControler);
                 }
                 if (card != null)
                 {
@@ -808,6 +866,7 @@ namespace WindBot.Game
 
             // Report Overlay as the material's location instead of the encoded host zone. This
             // prevents deck executors from treating material attachment as entry to a field zone.
+            ValidateBotDeckCount();
             _ai.OnMove(card, previousControler, previousMoveLocation, currentControler, currentMoveLocation);
         }
 
@@ -826,10 +885,15 @@ namespace WindBot.Game
             ClientCard card1 = _duel.GetCard(controler1, (CardLocation)location1, sequence1);
             ClientCard card2 = _duel.GetCard(controler2, (CardLocation)location2, sequence2);
             if (card1 == null || card2 == null) return;
+            int trackedCardId1 = cardId1 != 0 ? cardId1 : card1.Id;
+            int trackedCardId2 = cardId2 != 0 ? cardId2 : card2.Id;
+            TrackDeckMove(trackedCardId1, controler1, location1, controler2, location2);
+            TrackDeckMove(trackedCardId2, controler2, location2, controler1, location1);
             _duel.RemoveCard((CardLocation)location1, card1, controler1, sequence1);
             _duel.RemoveCard((CardLocation)location2, card2, controler2, sequence2);
             _duel.AddCard((CardLocation)location2, card1, controler2, sequence2, card1.Position, cardId1);
             _duel.AddCard((CardLocation)location1, card2, controler1, sequence1, card2.Position, cardId2);
+            ValidateBotDeckCount();
         }
 
         private void OnAttack(BinaryReader packet)


### PR DESCRIPTION
- Track remaining Main Deck card counts by recording the initial deck and tracking cards moving into and out of it.
- Add `GetCardCountInDeck` and `HasInDeck` for querying the current deck contents.
- Add `GetNonAltartCode` to normalize alternate-artwork IDs while preserving rule-name aliases. Unlike `GetOriginCode`, it does not convert rule-name aliases to their database alias.
- Replace existing `GetRemainingCount` calls and deck-specific counting helpers with the new APIs.