### PR TITLE
Reduce combo under Maxx C / Mulcharmy by summon location

### DIFF
--- a/Game/AI/Decks/AlbazExecutor.cs
+++ b/Game/AI/Decks/AlbazExecutor.cs
@@ -196,7 +196,6 @@ namespace WindBot.Game.AI.Decks
         };
 
         bool summoned = false;
-        bool enemyActivateMaxxC = false;
         bool enemyActivateLockBird = false;
         int dimensionShifterCount = 0;
         bool enemyActivateInfiniteImpermanenceFromHand = false;
@@ -322,10 +321,22 @@ namespace WindBot.Game.AI.Decks
 
         public bool CheckShouldNoMoreSpSummon()
         {
-            if (CheckAtAdvantage() && enemyActivateMaxxC && !enemyActivateLockBird && (Duel.Turn == 1 || Duel.Phase >= DuelPhase.Main2))
+            if (CheckAtAdvantage() && enemyResolvedEffectIdList.Contains(_CardId.MaxxC) && DefaultCheckWhetherEnemyCanDraw()
+                && (Duel.Turn == 1 || Duel.Phase >= DuelPhase.Main2))
             {
                 return true;
             }
+            return false;
+        }
+
+        public bool CheckShouldNoMoreSpSummon(CardLocation loc)
+        {
+            if (CheckShouldNoMoreSpSummon()) return true;
+            if (!DefaultCheckWhetherEnemyCanDraw() || (Duel.Turn > 1 && Duel.Phase < DuelPhase.Main2)) return false;
+            if (enemyResolvedEffectIdList.Contains(_CardId.MulcharmyPurulia) && (loc & CardLocation.Hand) != 0) return true;
+            if (enemyResolvedEffectIdList.Contains(_CardId.MulcharmyFuwalos) && (loc & (CardLocation.Deck | CardLocation.Extra)) != 0) return true;
+            if (enemyResolvedEffectIdList.Contains(_CardId.MulcharmyNyalus) && (loc & (CardLocation.Grave | CardLocation.Removed)) != 0) return true;
+
             return false;
         }
 
@@ -668,7 +679,7 @@ namespace WindBot.Game.AI.Decks
                                 {CardId.SpringansKitt, () => CheckWhetherCanSummon() && !activatedCardIdList.Contains(CardId.SpringansKitt + 1) },
                                 {CardId.FallenOfAlbaz, () => (CheckWhetherCanSummon() && CheckAlbazFusion()) || Bot.HasInMonstersZone(CardId.BlazingCartesiaTheVirtuous) },
                                 {CardId.GuidingQuemTheVirtuous, () => CheckWhetherCanSummon() },
-                                {CardId.BlazingCartesiaTheVirtuous, () => CheckWhetherCanSummon() || (!CheckShouldNoMoreSpSummon() && Bot.HasInMonstersZoneOrInGraveyard(CardId.FallenOfAlbaz))},
+                                {CardId.BlazingCartesiaTheVirtuous, () => CheckWhetherCanSummon() || (!CheckShouldNoMoreSpSummon(CardLocation.Hand) && Bot.HasInMonstersZoneOrInGraveyard(CardId.FallenOfAlbaz))},
                                 {CardId.AlbionTheShroudedDragon, () => !CheckWhetherWillbeRemoved() && !activatedCardIdList.Contains(CardId.AlbionTheShroudedDragon) },
                             };
                             break;
@@ -1097,7 +1108,7 @@ namespace WindBot.Game.AI.Decks
                             {
                                 {CardId.TitanikladTheAshDragon, () => Enemy.HasInMonstersZone(CardId.KashtiraAriseHeart) },
                                 {CardId.RindbrummTheStrikingDragon,  () => CheckWhetherWillbeRemoved() && Bot.HasInDeck(CardId.TriBrigadeMercourier)},
-                                {CardId.AlbionTheSanctifireDragon, () => CheckShouldNoMoreSpSummon()},
+                                {CardId.AlbionTheSanctifireDragon, () => CheckShouldNoMoreSpSummon(CardLocation.Extra)},
                                 {CardId.AlbionTheBrandedDragon, () => {
                                     bool checkFlag = Bot.Graveyard.Any(c => c != null && c.IsMonster() && c.HasAttribute(CardAttribute.Dark) && !c.IsCode(cannotBeFusionMaterialIdList));
                                     checkFlag |= Bot.HasInHandOrHasInMonstersZone(CardId.TriBrigadeMercourier);
@@ -1409,7 +1420,6 @@ namespace WindBot.Game.AI.Decks
 
                             return Util.CheckSelectCount(targetList, cards, min, max);
                         }
-                        break;
 
                     // for sanctifire
                     case CardId.AlbionTheSanctifireDragon:
@@ -2139,7 +2149,7 @@ namespace WindBot.Game.AI.Decks
                 {
                     if (currentSolvingChain.IsActivateCode(CardId.BrandedOpening))
                     {
-                        return (CheckShouldNoMoreSpSummon() && !summoned && Duel.Player == 0) ? options.IndexOf(1190) : options.IndexOf(1152);
+                        return (CheckShouldNoMoreSpSummon(CardLocation.Deck) && !summoned && Duel.Player == 0) ? options.IndexOf(1190) : options.IndexOf(1152);
                     }
 
                     if (fusionTarget != null && (
@@ -2154,13 +2164,13 @@ namespace WindBot.Game.AI.Decks
                         }
                         if (fusionTarget.IsCode(CardId.GuidingQuemTheVirtuous, CardId.SpringansKitt))
                         {
-                            return CheckShouldNoMoreSpSummon() ? options.IndexOf(1190) : options.IndexOf(1152);
+                            return CheckShouldNoMoreSpSummon(CardLocation.Grave) ? options.IndexOf(1190) : options.IndexOf(1152);
                         }
                         if (fusionTarget.IsCode(CardId.AluberTheJesterOfDespia))
                         {
                             return activatedCardIdList.Contains(CardId.AluberTheJesterOfDespia) ? options.IndexOf(1190) : options.IndexOf(1152);
                         }
-                        return (CheckShouldNoMoreSpSummon() && !summoned) ? options.IndexOf(1190) : options.IndexOf(1152);
+                        return (CheckShouldNoMoreSpSummon(CardLocation.Grave) && !summoned) ? options.IndexOf(1190) : options.IndexOf(1152);
                     }
                 }
 
@@ -2334,7 +2344,6 @@ namespace WindBot.Game.AI.Decks
             }
 
             summoned = false;
-            enemyActivateMaxxC = false;
             enemyActivateLockBird = false;
             enemyActivateInfiniteImpermanenceFromHand = false;
             nadirActivated = false;
@@ -2402,8 +2411,6 @@ namespace WindBot.Game.AI.Decks
                 {
                     if (currentChain.ActivatePlayer == 1)
                     {
-                        if (currentChain.IsActivateCode(_CardId.MaxxC))
-                            enemyActivateMaxxC = true;
                         if (currentChain.IsActivateCode(_CardId.LockBird))
                             enemyActivateLockBird = true;
                         if (currentChain.IsActivateCode(CardId.DimensionShifter))
@@ -2637,7 +2644,7 @@ namespace WindBot.Game.AI.Decks
                 }
 
                 // banish cards with effect
-                if (!CheckShouldNoMoreSpSummon())
+                if (!CheckShouldNoMoreSpSummon(CardLocation.Hand))
                 {
                     ClientCard mercourier = Bot.Graveyard.FirstOrDefault(c => c != null && c.IsCode(CardId.TriBrigadeMercourier));
                     if (mercourier != null && !activatedCardIdList.Contains(CardId.TriBrigadeMercourier + 1))
@@ -2951,7 +2958,7 @@ namespace WindBot.Game.AI.Decks
             if (Card.Location == CardLocation.Hand)
             {
                 if (CheckWhetherNegated(true, true, CardType.Monster)) return false;
-                if (CheckShouldNoMoreSpSummon())
+                if (CheckShouldNoMoreSpSummon(CardLocation.Hand))
                 {
                     bool skipFlag = !summoned;
                     skipFlag |= activatedCardIdList.Contains(CardId.BrandedFusion);
@@ -3095,7 +3102,7 @@ namespace WindBot.Game.AI.Decks
             // sp summon
             if (Card.Location == CardLocation.Hand)
             {
-                if (CheckShouldNoMoreSpSummon() || CheckWhetherNegated(true, true, CardType.Monster)) return false;
+                if (CheckShouldNoMoreSpSummon(CardLocation.Hand) || CheckWhetherNegated(true, true, CardType.Monster)) return false;
                 activatedCardIdList.Add(Card.Id);
                 return true;
             }
@@ -3159,7 +3166,7 @@ namespace WindBot.Game.AI.Decks
                     }
                 }
 
-                bool shouldActivateFlag = Duel.Player == 0 && !CheckShouldNoMoreSpSummon() || Duel.Player == 1;
+                bool shouldActivateFlag = Duel.Player == 0 && !CheckShouldNoMoreSpSummon(CardLocation.Extra) || Duel.Player == 1;
 
                 // summon mirrorjade
                 bool checkMirrorJadeFlag = !(Bot.HasInMonstersZone(CardId.MirrorjadeTheIcebladeDragon, faceUp: true) || Bot.HasInSpellZone(CardId.MirrorjadeTheIcebladeDragon, faceUp: true))
@@ -3605,7 +3612,7 @@ namespace WindBot.Game.AI.Decks
         public bool _BrandedInWhiteActivateCheck(bool activate = false)
         {
             if (CheckWhetherNegated(true, true, CardType.Spell) || activatedCardIdList.Contains(CardId.BrandedInWhite) || nadirActivated) return false;
-            if (CheckShouldNoMoreSpSummon() && Bot.MonsterZone.Any(c => c != null && c.GetDefensePower() >= 2000)) return false;
+            if (CheckShouldNoMoreSpSummon(CardLocation.Extra) && Bot.MonsterZone.Any(c => c != null && c.GetDefensePower() >= 2000)) return false;
             if (BrandedInWhiteFusionTarget(Bot.ExtraDeck, out ClientCard _fusionTarget) > 0)
             {
                 if (activate) Logger.DebugWriteLine("White prepare fusion: " + _fusionTarget?.Name);
@@ -4152,7 +4159,7 @@ namespace WindBot.Game.AI.Decks
                 if (Bot.HasInHand(CardId.AlbionTheShroudedDragon) && !CheckWhetherWillbeRemoved() && !activatedCardIdList.Contains(CardId.AlbionTheShroudedDragon)) return false;
                 bool canCallCartesia = Bot.HasInHand(CardId.BlazingCartesiaTheVirtuous) && !summoned;
                 canCallCartesia |= !activatedCardIdList.Contains(CardId.FusionDeployment) && Bot.HasInHandOrInSpellZone(CardId.FusionDeployment)
-                    && !CheckShouldNoMoreSpSummon() && Bot.HasInExtra(CardId.GranguignolTheDuskDragon) && Bot.HasInDeck(CardId.BlazingCartesiaTheVirtuous);
+                    && !CheckShouldNoMoreSpSummon(CardLocation.Deck) && Bot.HasInExtra(CardId.GranguignolTheDuskDragon) && Bot.HasInDeck(CardId.BlazingCartesiaTheVirtuous);
                 if (canCallCartesia) return false;
             }
             bool goal = Bot.HasInDeck(CardId.AluberTheJesterOfDespia) && !activatedCardIdList.Contains(CardId.AluberTheJesterOfDespia) && !enemyActivateLockBird;
@@ -5484,7 +5491,7 @@ namespace WindBot.Game.AI.Decks
             Dictionary<int, Func<bool>> checkDict = new Dictionary<int, Func<bool>>
             {
                 {CardId.MirrorjadeTheIcebladeDragon, () => {
-                    bool checkFlag = !CheckWhetherNegated() && CheckShouldNoMoreSpSummon();
+                    bool checkFlag = !CheckWhetherNegated() && CheckShouldNoMoreSpSummon(CardLocation.Extra);
                     checkFlag |= Bot.Graveyard.Any(c => c != null && !sendToGYThisTurn.Contains(c) && !c.IsCode(cannotBeFusionMaterialIdList)
                         && c.HasType(CardType.Fusion | CardType.Synchro | CardType.Xyz | CardType.Link));
                     return checkFlag;

--- a/Game/AI/Decks/DogmatikaExecutor.cs
+++ b/Game/AI/Decks/DogmatikaExecutor.cs
@@ -143,7 +143,6 @@ namespace WindBot.Game.AI.Decks
         };
 
         List<int> currentNegatingIdList = new List<int>();
-        bool enemyActivateMaxxC = false;
         bool enemyActivateLockBird = false;
         List<int> infiniteImpermanenceList = new List<int>();
         bool summoned = false;
@@ -569,7 +568,6 @@ namespace WindBot.Game.AI.Decks
             ClientCard lastChainCard = Util.GetLastChainCard();
             if (lastChainCard != null && Duel.LastChainPlayer == 1)
             {
-                if (lastChainCard.IsCode(_CardId.MaxxC)) enemyActivateMaxxC = false;
                 if (lastChainCard.IsCode(_CardId.LockBird)) enemyActivateLockBird = false;
                 if (lastChainCard.IsCode(CardId.DimensionShifter)) dimensionShifterCount = 0;
                 if (lastChainCard.Controller == 1 && lastChainCard.Location == CardLocation.MonsterZone)
@@ -697,16 +695,34 @@ namespace WindBot.Game.AI.Decks
 
         public bool CheckShouldNoMoreSpSummon()
         {
-            if (CheckAtAdvantage() && enemyActivateMaxxC && Util.IsTurn1OrMain2())
+            if (CheckAtAdvantage() && enemyResolvedEffectIdList.Contains(_CardId.MaxxC) && DefaultCheckWhetherEnemyCanDraw()
+                && Util.IsTurn1OrMain2())
             {
-                bool successFlag = false;
-                successFlag |= Bot.HasInHandOrInSpellZone(CardId.DogmatikaPunishment);
-                successFlag |= Bot.GetMonsters().Any(card => card.IsFaceup() && card.Level >= 7 && card.HasRace(CardRace.SpellCaster));
-                successFlag |= Bot.HasInHand(CardId.DogmatikaFleurdelis)
-                    && Bot.GetMonsters().Any(card => card.IsFaceup() && card.HasSetcode(SetcodeDogmatika));
-                return successFlag;
+                return CheckDogmatikaCanStopCombo();
             }
             return false;
+        }
+
+        public bool CheckShouldNoMoreSpSummon(CardLocation loc)
+        {
+            if (CheckShouldNoMoreSpSummon()) return true;
+            if (!DefaultCheckWhetherEnemyCanDraw() || !Util.IsTurn1OrMain2()) return false;
+            if (!CheckDogmatikaCanStopCombo()) return false;
+            if (enemyResolvedEffectIdList.Contains(_CardId.MulcharmyPurulia) && (loc & CardLocation.Hand) != 0) return true;
+            if (enemyResolvedEffectIdList.Contains(_CardId.MulcharmyFuwalos) && (loc & (CardLocation.Deck | CardLocation.Extra)) != 0) return true;
+            if (enemyResolvedEffectIdList.Contains(_CardId.MulcharmyNyalus) && (loc & (CardLocation.Grave | CardLocation.Removed)) != 0) return true;
+
+            return false;
+        }
+
+        public bool CheckDogmatikaCanStopCombo()
+        {
+            bool successFlag = false;
+            successFlag |= Bot.HasInHandOrInSpellZone(CardId.DogmatikaPunishment);
+            successFlag |= Bot.GetMonsters().Any(card => card.IsFaceup() && card.Level >= 7 && card.HasRace(CardRace.SpellCaster));
+            successFlag |= Bot.HasInHand(CardId.DogmatikaFleurdelis)
+                && Bot.GetMonsters().Any(card => card.IsFaceup() && card.HasSetcode(SetcodeDogmatika));
+            return successFlag;
         }
 
         /// <summary>
@@ -983,7 +999,6 @@ namespace WindBot.Game.AI.Decks
                 enemySpSummonFromExLastTurn = 0;
                 enemySpSummonFromExThisTurn = 0;
             }
-            enemyActivateMaxxC = false;
             enemyActivateLockBird = false;
             omegaActivateCount = 0;
             enemySpSummonFromExLastTurn = enemySpSummonFromExThisTurn;
@@ -1102,8 +1117,6 @@ namespace WindBot.Game.AI.Decks
             ChainInfo currentChain = Duel.GetCurrentSolvingChainInfo();
             if (currentChain != null && !Duel.IsCurrentSolvingChainNegated() && currentChain.ActivatePlayer == 1)
             {
-                if (currentChain.IsActivateCode(_CardId.MaxxC))
-                    enemyActivateMaxxC = true;
                 if (currentChain.IsActivateCode(_CardId.LockBird))
                     enemyActivateLockBird = true;
                 if (currentChain.IsActivateCode(CardId.DimensionShifter))
@@ -1189,7 +1202,7 @@ namespace WindBot.Game.AI.Decks
             if (CheckWhetherNegated()) return false;
             if (Card.Location == CardLocation.Hand)
             {
-                if (CheckShouldNoMoreSpSummon())
+                if (CheckShouldNoMoreSpSummon(CardLocation.Hand))
                 {
                     return false;
                 }
@@ -1329,7 +1342,7 @@ namespace WindBot.Game.AI.Decks
             if (CheckWhetherNegated()) return false;
             if (Card.Location == CardLocation.Hand)
             {
-                if (CheckShouldNoMoreSpSummon()) return false;
+                if (CheckShouldNoMoreSpSummon(CardLocation.Hand)) return false;
                 // banish dump extra
                 List<int> dumpIdCheck = new List<int>{ CardId.ElderEntityNtss, CardId.GaruraWingsOfResonantLife, CardId.DespianLuluwalilith };
                 foreach (int dumpId in dumpIdCheck)
@@ -1566,7 +1579,7 @@ namespace WindBot.Game.AI.Decks
             if (Card.Location == CardLocation.Hand)
             {
                 if (activatedCardIdList.Contains(Card.Id)) return false;
-                if (CheckShouldNoMoreSpSummon())
+                if (CheckShouldNoMoreSpSummon(CardLocation.Hand))
                 {
                     if (!Bot.HasInHand(CardId.DogmatikaFleurdelis) || Bot.GetMonsters().Any(card => card.IsFaceup() && card.HasSetcode(SetcodeDogmatika)))
                     {
@@ -1597,8 +1610,10 @@ namespace WindBot.Game.AI.Decks
                     }
                 }
 
-                // for maxxc
-                if (CheckAtAdvantage() && enemyActivateMaxxC)
+                // for maxxc / mulcharmy
+                if (CheckAtAdvantage() && DefaultCheckWhetherEnemyCanDraw()
+                    && enemyResolvedEffectIdList.Any(id => id == _CardId.MaxxC || id == _CardId.MulcharmyPurulia
+                        || id == _CardId.MulcharmyFuwalos))
                 {
                     List<int> checkIdListFirstPart = new List<int>{ CardId.DogmatikaPunishment, CardId.DogmatikaFleurdelis };
                     if (DogmatikaMatrixCanActivate())

--- a/Game/AI/Decks/ExosisterExecutor.cs
+++ b/Game/AI/Decks/ExosisterExecutor.cs
@@ -158,7 +158,6 @@ namespace WindBot.Game.AI.Decks
         List<int> ExosisterSpellTrapList = new List<int>{CardId.ExosisterPax, CardId.ExosisterArment, CardId.ExosisterVadis, CardId.ExosisterReturnia};
 
         List<int> currentNegatingIdList = new List<int>();
-        bool enemyActivateMaxxC = false;
         bool enemyActivateLockBird = false;
         bool enemyMoveGrave = false;
         bool paxCallToField = false;
@@ -175,9 +174,7 @@ namespace WindBot.Game.AI.Decks
         bool kaspitellEffect1Activated = false;
         bool kaspitellEffect3Activated = false;
         bool gibrineEffect1Activated = false;
-        bool gibrineEffect3Activated = false;
         bool asophielEffect1Activated = false;
-        bool asophielEffect3Activated = false;
         bool sakitamaEffect1Activated = false;
         List<int> exosisterTransformEffectList = new List<int>();
         List<int> oncePerTurnEffectActivatedList = new List<int>();
@@ -435,11 +432,20 @@ namespace WindBot.Game.AI.Decks
         /// </summary>
         public bool CheckLessOperation()
         {
-            if (!enemyActivateMaxxC)
-            {
-                return false;
-            }
-            return CheckAtAdvantage();
+            return CheckAtAdvantage()
+                && enemyResolvedEffectIdList.Contains(_CardId.MaxxC)
+                && DefaultCheckWhetherEnemyCanDraw();
+        }
+
+        public bool CheckLessOperation(CardLocation loc)
+        {
+            if (CheckLessOperation()) return true;
+            if (!DefaultCheckWhetherEnemyCanDraw()) return false;
+            if (enemyResolvedEffectIdList.Contains(_CardId.MulcharmyPurulia) && (loc & CardLocation.Hand) != 0) return true;
+            if (enemyResolvedEffectIdList.Contains(_CardId.MulcharmyFuwalos) && (loc & (CardLocation.Deck | CardLocation.Extra)) != 0) return true;
+            if (enemyResolvedEffectIdList.Contains(_CardId.MulcharmyNyalus) && (loc & (CardLocation.Grave | CardLocation.Removed)) != 0) return true;
+
+            return false;
         }
 
         /// <summary>
@@ -676,10 +682,6 @@ namespace WindBot.Game.AI.Decks
 
             if (player == 1)
             {
-                if (card.IsCode(_CardId.MaxxC) && CheckCalledbytheGrave(_CardId.MaxxC) == 0)
-                {
-                    enemyActivateMaxxC = true;
-                }
                 if (card.IsCode(_CardId.LockBird) && CheckCalledbytheGrave(_CardId.LockBird) == 0)
                 {
                     enemyActivateLockBird = true;
@@ -727,8 +729,6 @@ namespace WindBot.Game.AI.Decks
             ChainInfo currentChain = Duel.GetCurrentSolvingChainInfo();
             if (currentChain != null && !Duel.IsCurrentSolvingChainNegated() && currentChain.ActivatePlayer == 1)
             {
-                if (currentChain.IsActivateCode(_CardId.MaxxC))
-                    enemyActivateMaxxC = true;
                 if (currentChain.IsActivateCode(_CardId.LockBird))
                     enemyActivateLockBird = true;
                 if (currentChain.IsActivateCode(_CardId.InfiniteImpermanence))
@@ -784,7 +784,6 @@ namespace WindBot.Game.AI.Decks
 
         public override void OnNewTurn()
         {
-            enemyActivateMaxxC = false;
             enemyActivateLockBird = false;
             infiniteImpermanenceList.Clear();
             currentNegatingIdList.Clear();
@@ -800,9 +799,7 @@ namespace WindBot.Game.AI.Decks
             kaspitellEffect1Activated = false;
             kaspitellEffect3Activated = false;
             gibrineEffect1Activated = false;
-            gibrineEffect3Activated = false;
             asophielEffect1Activated = false;
-            asophielEffect3Activated = false;
             sakitamaEffect1Activated = false;
             exosisterTransformEffectList.Clear();
             oncePerTurnEffectActivatedList.Clear();
@@ -1432,7 +1429,7 @@ namespace WindBot.Game.AI.Decks
                 }
 
                 // summon for summon donner
-                if (!CheckLessOperation() && Bot.HasInExtra(CardId.DonnerDaggerFurHire) &&
+                if (!CheckLessOperation(CardLocation.Hand) && Bot.HasInExtra(CardId.DonnerDaggerFurHire) &&
                     !Bot.HasInHand(CardId.ExosisterMartha) || Bot.HasInHandOrInSpellZone(CardId.ExosisterReturnia))
                 {
                     List<ClientCard> illegalList = Bot.GetMonsters().Where(card => card.IsFaceup() && !card.HasType(CardType.Xyz) && card.Level != 4
@@ -1529,7 +1526,7 @@ namespace WindBot.Game.AI.Decks
 
             bool ableToXyz = Bot.GetMonsters().Count(card => CheckAbleForXyz(card)) >= 2;
 
-            if (CheckLessOperation() && ableToXyz)
+            if (CheckLessOperation(CardLocation.Hand) && ableToXyz)
             {
                 return false;
             }
@@ -1595,7 +1592,7 @@ namespace WindBot.Game.AI.Decks
             if (ActivateDescription != Util.GetStringId(CardId.ExosisterMartha, 0)) {
                 return false;
             }
-            if (CheckLessOperation() && Bot.GetMonsterCount() > 0)
+            if (CheckLessOperation(CardLocation.Hand | CardLocation.Deck) && Bot.GetMonsterCount() > 0)
             {
                 return false;
             }
@@ -1841,7 +1838,6 @@ namespace WindBot.Game.AI.Decks
             {
                 return false;
             }
-            gibrineEffect3Activated = true;
             SelectDetachMaterial(Card);
             return true;
         }
@@ -1867,7 +1863,6 @@ namespace WindBot.Game.AI.Decks
             ClientCard targetCard = Util.GetProblematicEnemyMonster(0, true);
             if (targetCard != null)
             {
-                asophielEffect3Activated = true;
                 SelectDetachMaterial(Card);
                 AI.SelectNextCard(targetCard);
                 return true;
@@ -2032,7 +2027,7 @@ namespace WindBot.Game.AI.Decks
                     // try to search stella
                     if (Bot.Hand.Count(card => card.IsCode(CardId.ExosisterStella)) == 0 && Bot.HasInDeck(CardId.ExosisterStella))
                     {
-                        bool shouldSpSummon = !CheckLessOperation() && summoned && Bot.HasInMonstersZoneOrInGraveyard(CardId.ExosisterElis);
+                        bool shouldSpSummon = !CheckLessOperation(CardLocation.Hand) && summoned && Bot.HasInMonstersZoneOrInGraveyard(CardId.ExosisterElis);
                         if (Bot.Hand.Any(card => card?.Data != null && card.IsMonster() && card.HasSetcode(SetcodeExosister)))
                         {
                             if (!(Card.Location == CardLocation.SpellZone))
@@ -2070,7 +2065,7 @@ namespace WindBot.Game.AI.Decks
                 }
 
                 // addition summon
-                if (Bot.GetMonsters().Count(card => CheckAbleForXyz(card)) == 1 && summoned && !CheckLessOperation())
+                if (Bot.GetMonsters().Count(card => CheckAbleForXyz(card)) == 1 && summoned && !CheckLessOperation(CardLocation.Hand))
                 {
                     if (    (sakitamaEffect1Activated || !Bot.HasInHand(CardId.Sakitama))
                         &&  (stellaEffect1Activated   || !Bot.HasInMonstersZone(CardId.ExosisterStella))
@@ -2199,7 +2194,7 @@ namespace WindBot.Game.AI.Decks
                 bool decided = false;
 
                 // addition summon
-                if (Bot.GetMonsters().Count(card => CheckAbleForXyz(card)) == 1 && summoned && !CheckLessOperation())
+                if (Bot.GetMonsters().Count(card => CheckAbleForXyz(card)) == 1 && summoned && !CheckLessOperation(CardLocation.Extra))
                 {
                     if (    (sakitamaEffect1Activated || !Bot.HasInHand(CardId.Sakitama))
                         &&  (stellaEffect1Activated   || !Bot.HasInMonstersZone(CardId.ExosisterStella))
@@ -2341,7 +2336,7 @@ namespace WindBot.Game.AI.Decks
             bool checkTransform = false;
 
             // special summon for xyz
-            if (Duel.Player == 0 && Duel.Phase > DuelPhase.Draw && !CheckLessOperation())
+            if (Duel.Player == 0 && Duel.Phase > DuelPhase.Draw && !CheckLessOperation(CardLocation.Deck))
             {
                 decideToActivate = true;
             }
@@ -2494,7 +2489,7 @@ namespace WindBot.Game.AI.Decks
         /// </summary>
         public bool ExosisterStellaSummonCheck()
         {
-            if (stellaEffect1Activated || Bot.HasInMonstersZone(CardId.ExosisterStella, true) || CheckWhetherNegated(true) || CheckLessOperation())
+            if (stellaEffect1Activated || Bot.HasInMonstersZone(CardId.ExosisterStella, true) || CheckWhetherNegated(true) || CheckLessOperation(CardLocation.Hand))
             {
                 return false;
             }
@@ -2519,7 +2514,7 @@ namespace WindBot.Game.AI.Decks
         /// </summary>
         public bool ExosisterIreneSummonCheck()
         {
-            if (irenaEffect1Activated || CheckLessOperation()
+            if (irenaEffect1Activated || CheckLessOperation(CardLocation.Hand)
                 || CheckWhetherNegated(true) || CheckCalledbytheGrave(CardId.ExosisterElis) > 0 || CheckCalledbytheGrave(CardId.ExosisterIrene) > 0)
             {
                 return false;
@@ -2542,7 +2537,7 @@ namespace WindBot.Game.AI.Decks
         /// </summary>
         public bool ExosisterForElisSummonCheck()
         {
-            if (elisEffect1Activated || CheckCalledbytheGrave(CardId.ExosisterElis) > 0 || CheckLessOperation())
+            if (elisEffect1Activated || CheckCalledbytheGrave(CardId.ExosisterElis) > 0 || CheckLessOperation(CardLocation.Hand))
             {
                 return false;
             }
@@ -2588,7 +2583,7 @@ namespace WindBot.Game.AI.Decks
 
         public bool ForSakitamaSummonCheck()
         {
-            if (sakitamaEffect1Activated || CheckCalledbytheGrave(CardId.Sakitama) > 0 || CheckLessOperation())
+            if (sakitamaEffect1Activated || CheckCalledbytheGrave(CardId.Sakitama) > 0 || CheckLessOperation(CardLocation.Hand))
             {
                 return false;
             }
@@ -2629,7 +2624,7 @@ namespace WindBot.Game.AI.Decks
             {
                 return false;
             }
-            if (CheckLessOperation())
+            if (CheckLessOperation(CardLocation.Extra))
             {
                 return false;
             }
@@ -2707,7 +2702,7 @@ namespace WindBot.Game.AI.Decks
 
         public bool ExosisterMikailisSpSummonCheckInner(bool shouldCheckLessOperation = true)
         {
-            if (Bot.HasInMonstersZone(CardId.ExosisterMikailis) || mikailisEffect3Activated || (CheckLessOperation() && shouldCheckLessOperation))
+            if (Bot.HasInMonstersZone(CardId.ExosisterMikailis) || mikailisEffect3Activated || (CheckLessOperation(CardLocation.Extra) && shouldCheckLessOperation))
             {
                 return false;
             }
@@ -2759,7 +2754,7 @@ namespace WindBot.Game.AI.Decks
 
         public bool ExosisterKaspitellSpSummonCheckInner(bool shouldCheckLessOperation = true)
         {
-            if (Bot.HasInMonstersZone(CardId.ExosisterKaspitell) || kaspitellEffect3Activated || (shouldCheckLessOperation && CheckLessOperation()))
+            if (Bot.HasInMonstersZone(CardId.ExosisterKaspitell) || kaspitellEffect3Activated || (shouldCheckLessOperation && CheckLessOperation(CardLocation.Extra)))
             {
                 return false;
             }
@@ -2810,7 +2805,7 @@ namespace WindBot.Game.AI.Decks
 
         public bool ExosistersMagnificaSpSummonCheck()
         {
-            if (CheckLessOperation())
+            if (CheckLessOperation(CardLocation.Extra))
             {
                 return false;
             }
@@ -2863,7 +2858,7 @@ namespace WindBot.Game.AI.Decks
                 return false;
             }
 
-            if (CheckLessOperation())
+            if (CheckLessOperation(CardLocation.Extra))
             {
                 return false;
             }

--- a/Game/AI/Decks/LabrynthExecutor.cs
+++ b/Game/AI/Decks/LabrynthExecutor.cs
@@ -171,7 +171,6 @@ namespace WindBot.Game.AI.Decks
         };
         List<int> notToDestroySpellTrap = new List<int> { 50005218, 6767771 };
 
-        bool enemyActivateMaxxC = false;
         List<int> infiniteImpermanenceList = new List<int>();
         bool summoned = false;
         List<int> activatedCardIdList = new List<int>();
@@ -536,19 +535,37 @@ namespace WindBot.Game.AI.Decks
 
         public bool CheckShouldNoMoreSpSummon(bool isLabrynth = true)
         {
-            if (CheckAtAdvantage() && enemyActivateMaxxC && (Duel.Turn == 1 || Duel.Phase >= DuelPhase.Main2))
+            if (CheckAtAdvantage() && enemyResolvedEffectIdList.Contains(_CardId.MaxxC) && DefaultCheckWhetherEnemyCanDraw()
+                && (Duel.Turn == 1 || Duel.Phase >= DuelPhase.Main2))
             {
-                if (!isLabrynth) return true;
-                if (cooclockAffected)
-                {
-                    if (Bot.GetMonsters().Any(card => card.IsFaceup() && card.HasSetcode(SetcodeLabrynth))) return true;
-                    if (Duel.Player == 0 && !summoned) return true;
-                    if (setTrapThisTurn.Count() == 0) return true;
-                    return false;
-                }
-                return true;
+                return CheckLabrynthShouldStopAfterDrawThreat(isLabrynth);
             }
             return false;
+        }
+
+        public bool CheckShouldNoMoreSpSummon(CardLocation loc, bool isLabrynth = true)
+        {
+            if (CheckShouldNoMoreSpSummon(isLabrynth)) return true;
+            if (!CheckAtAdvantage() || !DefaultCheckWhetherEnemyCanDraw() || (Duel.Turn > 1 && Duel.Phase < DuelPhase.Main2)) return false;
+            bool match = false;
+            if (enemyResolvedEffectIdList.Contains(_CardId.MulcharmyPurulia) && (loc & CardLocation.Hand) != 0) match = true;
+            if (enemyResolvedEffectIdList.Contains(_CardId.MulcharmyFuwalos) && (loc & (CardLocation.Deck | CardLocation.Extra)) != 0) match = true;
+            if (enemyResolvedEffectIdList.Contains(_CardId.MulcharmyNyalus) && (loc & (CardLocation.Grave | CardLocation.Removed)) != 0) match = true;
+            if (!match) return false;
+            return CheckLabrynthShouldStopAfterDrawThreat(isLabrynth);
+        }
+
+        public bool CheckLabrynthShouldStopAfterDrawThreat(bool isLabrynth)
+        {
+            if (!isLabrynth) return true;
+            if (cooclockAffected)
+            {
+                if (Bot.GetMonsters().Any(card => card.IsFaceup() && card.HasSetcode(SetcodeLabrynth))) return true;
+                if (Duel.Player == 0 && !summoned) return true;
+                if (setTrapThisTurn.Count() == 0) return true;
+                return false;
+            }
+            return true;
         }
 
         /// <summary>
@@ -861,7 +878,7 @@ namespace WindBot.Game.AI.Decks
                         {
                             return Util.CheckSelectCount(new List<ClientCard> { arianna }, cards, min, max);
                         }
-                        if (!CheckShouldNoMoreSpSummon())
+                        if (!CheckShouldNoMoreSpSummon(CardLocation.Deck))
                         {
                             if (bigWelcome != null && !activatedCardIdList.Contains(CardId.AriasTheLabrynthButler)
                                 && Bot.HasInHandOrHasInMonstersZone(CardId.AriasTheLabrynthButler))
@@ -1190,12 +1207,32 @@ namespace WindBot.Game.AI.Decks
         public ClientCard GetWelcomeOrBigWelcomeTarget(IList<ClientCard> cards, int cardId)
         {
             ClientCard graveTarget = cards.FirstOrDefault(card => card.IsCode(cardId) && card.Location == CardLocation.Grave);
-            if (graveTarget != null) return graveTarget;
             ClientCard deckTarget = cards.FirstOrDefault(card => card.IsCode(cardId) && card.Location == CardLocation.Deck);
-            if (deckTarget != null) return deckTarget;
             ClientCard handTarget = cards.FirstOrDefault(card => card.IsCode(cardId) && card.Location == CardLocation.Hand);
-            if (handTarget != null) return handTarget;
-            return null;
+
+            List<ClientCard> ordered = new List<ClientCard>();
+            if (graveTarget != null) ordered.Add(graveTarget);
+            if (deckTarget != null) ordered.Add(deckTarget);
+            if (handTarget != null) ordered.Add(handTarget);
+            if (ordered.Count == 0) return null;
+
+            // 尽量从不会喂抽的区域特召；Maxx C 或所有来源都会抽卡时走原优先级
+            if (DefaultCheckWhetherEnemyCanDraw())
+            {
+                List<ClientCard> safeTargets = new List<ClientCard>();
+                foreach (ClientCard target in ordered)
+                {
+                    CardLocation loc = target.Location;
+                    bool wouldDraw = enemyResolvedEffectIdList.Contains(_CardId.MaxxC);
+                    if (enemyResolvedEffectIdList.Contains(_CardId.MulcharmyPurulia) && (loc & CardLocation.Hand) != 0) wouldDraw = true;
+                    if (enemyResolvedEffectIdList.Contains(_CardId.MulcharmyFuwalos) && (loc & (CardLocation.Deck)) != 0) wouldDraw = true;
+                    if (enemyResolvedEffectIdList.Contains(_CardId.MulcharmyNyalus) && (loc & (CardLocation.Grave)) != 0) wouldDraw = true;
+                    if (!wouldDraw) safeTargets.Add(target);
+                }
+                if (safeTargets.Count > 0) return safeTargets[0];
+            }
+
+            return ordered[0];
         }
 
         public ClientCard AriannaSearchWelcomeTrap(IList<ClientCard> cards, int welcomeId)
@@ -1325,10 +1362,12 @@ namespace WindBot.Game.AI.Decks
                 {
                     return options.IndexOf(1190);
                 }
-                if (!enemyActivateMaxxC) return options.IndexOf(1152);
+                if (!DefaultCheckWhetherEnemyCanDraw()
+                    || (!enemyResolvedEffectIdList.Contains(_CardId.MaxxC) && !enemyResolvedEffectIdList.Contains(_CardId.MulcharmyNyalus)))
+                    return options.IndexOf(1152);
                 if (activatedCardIdList.Contains(CardId.LabrynthCooclock))
                 {
-                    if (!CheckShouldNoMoreSpSummon()) return options.IndexOf(1152);
+                    if (!CheckShouldNoMoreSpSummon(CardLocation.Grave)) return options.IndexOf(1152);
                 }
                 return options.IndexOf(1190);
             }
@@ -1540,7 +1579,6 @@ namespace WindBot.Game.AI.Decks
                 enemySpSummonFromExThisTurn = 0;
                 banSpSummonExceptFiendCount = 0;
             }
-            enemyActivateMaxxC = false;
             enemySpSummonFromExLastTurn = enemySpSummonFromExThisTurn;
             enemySpSummonFromExThisTurn = 0;
             rollbackCopyCardId = 0;
@@ -1596,8 +1634,6 @@ namespace WindBot.Game.AI.Decks
             {
                 if (currentChain.ActivatePlayer == 1)
                 {
-                    if (currentChain.IsActivateCode(_CardId.MaxxC))
-                        enemyActivateMaxxC = true;
                     if (currentChain.IsActivateCode(CardId.DimensionShifter))
                         dimensionShifterCount = 2;
                 }
@@ -1771,7 +1807,7 @@ namespace WindBot.Game.AI.Decks
             if (Card.Location == CardLocation.Hand)
             {
                 // sp summon from hand
-                if (CheckShouldNoMoreSpSummon(true) || Util.ChainContainsCard(_CardId.EvenlyMatched)) return false;
+                if (CheckShouldNoMoreSpSummon(CardLocation.Hand) || Util.ChainContainsCard(_CardId.EvenlyMatched)) return false;
                 bool activateFlag = false;
                 activateFlag |= CheckChainContainEnemyMaxxC();
                 if (!activateFlag && GetEmptyMainMonsterZoneCount() + chainSummoningIdList.Count() <= 0)
@@ -2008,7 +2044,7 @@ namespace WindBot.Game.AI.Decks
                             && (Bot.HasInMonstersZoneOrInGraveyard(CardId.LovelyLabrynthOfTheSilverCastle) || Bot.HasInDeck(CardId.LovelyLabrynthOfTheSilverCastle))
                             && !activatedCardIdList.Contains(CardId.LovelyLabrynthOfTheSilverCastle + 1);
                     }
-                    if (Duel.Player == 0) searchFlag |= summoned && !CheckShouldNoMoreSpSummon();
+                    if (Duel.Player == 0) searchFlag |= summoned && !CheckShouldNoMoreSpSummon(CardLocation.Hand);
                     if (searchFlag)
                     {
                         AI.SelectOption(0);
@@ -2034,7 +2070,7 @@ namespace WindBot.Game.AI.Decks
             if (!activatedCardIdList.Contains(Card.Id) && !CheckWhetherNegated(true, true) && !CheckWhetherWillbeRemoved())
             {
                 bool haveCost = Bot.Hand.Any(card => card.Type == (int)CardType.Trap) || Bot.GetSpells().Any(card => card.IsFacedown() && card.Type == (int)CardType.Trap);
-                if (haveCost && !CheckShouldNoMoreSpSummon(true))
+                if (haveCost && !CheckShouldNoMoreSpSummon(CardLocation.Hand | CardLocation.Deck))
                 {
                     summoned = true;
                     return true;
@@ -2061,7 +2097,7 @@ namespace WindBot.Game.AI.Decks
             {
                 bool haveRollback = Bot.HasInHandOrInSpellZone(CardId.TransactionRollback);
                 if (CheckWhetherNegated() && !haveRollback) return false;
-                if (CheckShouldNoMoreSpSummon() && !(haveRollback && Bot.Graveyard.Any(card => card.IsCode(CardId.WelcomeLabrynth, CardId.BigWelcomeLabrynth)))) return false;
+                if (CheckShouldNoMoreSpSummon(CardLocation.Deck) && !(haveRollback && Bot.Graveyard.Any(card => card.IsCode(CardId.WelcomeLabrynth, CardId.BigWelcomeLabrynth)))) return false;
                 int specialSummonId = 0;
                 // arianna
                 if (!activatedCardIdList.Contains(CardId.AriannaTheLabrynthServant) && Bot.HasInDeck(CardId.AriannaTheLabrynthServant))
@@ -2398,7 +2434,7 @@ namespace WindBot.Game.AI.Decks
             {
                 if (Card.IsCode(CardId.LabrynthStovieTorbie, CardId.AriasTheLabrynthButler))
                 {
-                    if (CheckShouldNoMoreSpSummon() || GetEmptyMainMonsterZoneCount() + chainSummoningIdList.Count() <= 0) return false;
+                    if (CheckShouldNoMoreSpSummon(CardLocation.Grave) || GetEmptyMainMonsterZoneCount() + chainSummoningIdList.Count() <= 0) return false;
                     chainSummoningIdList.Add(Card.Id);
                 }
                 if (Card.IsCode(CardId.WelcomeLabrynth)) SelectSTPlace(Card, false);
@@ -2413,7 +2449,7 @@ namespace WindBot.Game.AI.Decks
         {
             if (Bot.GetMonsters().Any(card => card.IsFaceup() && card.HasSetcode(SetcodeUnchained))) return false;
             if (Card.Level > 4) return false;
-            if (CheckShouldNoMoreSpSummon()) return false;
+            if (CheckShouldNoMoreSpSummon(CardLocation.Extra)) return false;
             if (!Bot.HasInExtra(CardId.UnchainedSoulLordOfYama)) return false;
 
             // check whether need summon for material count
@@ -2453,7 +2489,7 @@ namespace WindBot.Game.AI.Decks
         {
             if (Bot.GetMonsters().Any(card => card.IsFaceup() && card.HasSetcode(SetcodeUnchained))) return false;
             if (!Card.IsCode(new List<int> { CardId.LabrynthStovieTorbie, CardId.ArianeTheLabrynthServant, CardId.AriannaTheLabrynthServant })) return false;
-            if (CheckShouldNoMoreSpSummon()) return false;
+            if (CheckShouldNoMoreSpSummon(CardLocation.Extra)) return false;
             if (!Bot.HasInExtra(CardId.ChaosAngel) || dimensionalBarrierAnnouced.Contains(HintMsg.SYNCHRO)) return false;
 
             bool checkFlag = GetProblematicEnemyCardList(true, selfType: CardType.Monster).Count() > 0 && !CheckWhetherNegated(true, true, CardType.Monster);
@@ -2540,14 +2576,14 @@ namespace WindBot.Game.AI.Decks
         }
         public bool WelcomeLabrynthSetCheck()
         {
-            return !CheckShouldNoMoreSpSummon() && WelcomeLabrynthActivateCheck(true, true);
+            return !CheckShouldNoMoreSpSummon(CardLocation.Deck) && WelcomeLabrynthActivateCheck(true, true);
         }
         public bool WelcomeLabrynthActivateCheck(bool onlyCheck = false, bool noSelect = false)
         {
             if (Card.Location == CardLocation.SpellZone || onlyCheck)
             {
                 if (GetEmptyMainMonsterZoneCount() == 0) return false;
-                if (CheckShouldNoMoreSpSummon()) return false;
+                if (CheckShouldNoMoreSpSummon(CardLocation.Deck)) return false;
                 bool activateTimingFlag = Duel.Phase > DuelPhase.Main2 || (Card.IsCode(CardId.AriasTheLabrynthButler) && (CurrentTiming & hintTimingMainEnd) > 0);
 
                 bool becomeTarget = Card.Location == CardLocation.SpellZone && DefaultOnBecomeTarget();
@@ -3076,6 +3112,7 @@ namespace WindBot.Game.AI.Decks
             if (CheckWhetherNegated()) return false;
             if (Card.Location != CardLocation.SpellZone && !onlyCheck) return false;
             if (GetEmptyMainMonsterZoneCount() == 0) return false;
+            if (CheckShouldNoMoreSpSummon()) return false;
             bool activateTimingFlag = Duel.Phase > DuelPhase.Main2 || (Card.IsCode(CardId.AriasTheLabrynthButler) && (CurrentTiming & hintTimingMainEnd) > 0);
 
             bool needDestroyFlag = GetProblematicEnemyCardList(false).Count() > 0;
@@ -3284,7 +3321,7 @@ namespace WindBot.Game.AI.Decks
 
         public bool ChaosAngelSpSummonWith2Monster()
         {
-            if (CheckShouldNoMoreSpSummon(false)) return false;
+            if (CheckShouldNoMoreSpSummon(CardLocation.Extra, false)) return false;
 
             List<ClientCard> level2MonsterList = new List<ClientCard>();
             List<ClientCard> level4MonsterList = new List<ClientCard>();
@@ -3352,7 +3389,7 @@ namespace WindBot.Game.AI.Decks
         }
         public bool ChaosAngelSpSummonWith3Monster()
         {
-            if (CheckShouldNoMoreSpSummon(false)) return false;
+            if (CheckShouldNoMoreSpSummon(CardLocation.Extra, false)) return false;
 
             List<ClientCard> level2MonsterList = new List<ClientCard>();
             List<ClientCard> level4MonsterList = new List<ClientCard>();
@@ -3480,7 +3517,7 @@ namespace WindBot.Game.AI.Decks
 
         public bool UnchainedAbominationSpSummon()
         {
-            if (CheckShouldNoMoreSpSummon(false)) return false;
+            if (CheckShouldNoMoreSpSummon(CardLocation.Extra, false)) return false;
             if (Enemy.GetMonsterCount() > 0 && Bot.HasInMonstersZone(CardId.UnchainedSoulOfAnguish) && !activatedCardIdList.Contains(CardId.UnchainedSoulOfAnguish)) return false;
             List<List<ClientCard>> usableMaterialMultiList = new List<List<ClientCard>>();
             // anguish + 1
@@ -3549,7 +3586,7 @@ namespace WindBot.Game.AI.Decks
 
         public bool UnchainedSoulOfAnguishSpSummon()
         {
-            if (CheckShouldNoMoreSpSummon(false)) return false;
+            if (CheckShouldNoMoreSpSummon(CardLocation.Extra, false)) return false;
 
             ClientCard unchainedNonLink = Bot.GetMonsters().FirstOrDefault(card => card.IsFaceup() && card.HasSetcode(SetcodeUnchained) && !card.HasType(CardType.Link));
             ClientCard unchainedLink2 = Bot.GetMonsters().FirstOrDefault(card => card.IsFaceup() && card.HasSetcode(SetcodeUnchained) && card.HasType(CardType.Link) && card.LinkCount == 2);
@@ -3639,7 +3676,7 @@ namespace WindBot.Game.AI.Decks
 
         public bool UnchainedSoulLordOfYamaSpSummon()
         {
-            if (CheckShouldNoMoreSpSummon(false)) return false;
+            if (CheckShouldNoMoreSpSummon(CardLocation.Extra, false)) return false;
             if (Bot.HasInMonstersZone(CardId.UnchainedSoulLordOfYama) || activatedCardIdList.Contains(CardId.UnchainedSoulLordOfYama)) return false;
 
             bool need3Monster = Bot.HasInExtra(CardId.UnchainedSoulOfAnguish) && !Bot.HasInMonstersZone(CardId.UnchainedSoulOfAnguish)
@@ -3763,7 +3800,7 @@ namespace WindBot.Game.AI.Decks
 
         public bool UnchainedSoulOfRageSpSummon()
         {
-            if (CheckShouldNoMoreSpSummon(false) || CheckWhetherNegated(true, true, CardType.Monster | CardType.Link)) return false;
+            if (CheckShouldNoMoreSpSummon(CardLocation.Extra, false) || CheckWhetherNegated(true, true, CardType.Monster | CardType.Link)) return false;
             if (Bot.HasInMonstersZone(CardId.UnchainedSoulOfRage)) return false;
 
             ClientCard unchained = Bot.GetMonsters().FirstOrDefault(card => card.IsFaceup() && card.HasSetcode(SetcodeUnchained)

--- a/Game/AI/Decks/LabrynthExecutor.cs
+++ b/Game/AI/Decks/LabrynthExecutor.cs
@@ -1930,7 +1930,7 @@ namespace WindBot.Game.AI.Decks
 
             // sp summon
             if (Bot.HasInSpellZone(CardId.TransactionRollback) && GetEmptyMainMonsterZoneCount() > chainSummoningIdList.Count()
-                    && !CheckWhetherWillbeRemoved() && !CheckShouldNoMoreSpSummon(false))
+                    && !CheckWhetherWillbeRemoved() && !CheckShouldNoMoreSpSummon(CardLocation.Hand, false))
             {
                 AI.SelectCard(CardId.TransactionRollback);
                 activatedCardIdList.Add(Card.Id);

--- a/Game/AI/Decks/RyzealExecutor.cs
+++ b/Game/AI/Decks/RyzealExecutor.cs
@@ -174,10 +174,6 @@ namespace WindBot.Game.AI.Decks
 
         int maxSummonCount = 1;
         int summonCount = 1;
-        bool enemyActivateMaxxC = false;
-        bool enemyActivatePurulia = false;
-        bool enemyActivateFuwalos = false;
-        bool enemyActivateNyalus = false;
         bool lockBirdSolved = false;
         int dimensionShifterCount = 0;
         bool botActivateMulcharmy = false;
@@ -352,7 +348,8 @@ namespace WindBot.Game.AI.Decks
 
         public bool CheckShouldNoMoreSpSummon()
         {
-            if (CheckAtAdvantage() && enemyActivateMaxxC && !lockBirdSolved && (Duel.Turn == 1 || Duel.Phase >= DuelPhase.Main2))
+            if (CheckAtAdvantage() && enemyResolvedEffectIdList.Contains(_CardId.MaxxC) && DefaultCheckWhetherEnemyCanDraw()
+                && (Duel.Turn == 1 || Duel.Phase >= DuelPhase.Main2))
             {
                 return true;
             }
@@ -362,10 +359,10 @@ namespace WindBot.Game.AI.Decks
         public bool CheckShouldNoMoreSpSummon(CardLocation loc)
         {
             if (CheckShouldNoMoreSpSummon()) return true;
-            if (lockBirdSolved || (Duel.Turn > 1 && Duel.Phase < DuelPhase.Main2)) return false;
-            if (enemyActivatePurulia && (loc & CardLocation.Hand) != 0) return true;
-            if (enemyActivateFuwalos && (loc & (CardLocation.Deck | CardLocation.Extra)) != 0) return true;
-            if (enemyActivateNyalus && (loc & (CardLocation.Grave | CardLocation.Removed)) != 0) return true;
+            if (!DefaultCheckWhetherEnemyCanDraw() || (Duel.Turn > 1 && Duel.Phase < DuelPhase.Main2)) return false;
+            if (enemyResolvedEffectIdList.Contains(_CardId.MulcharmyPurulia) && (loc & CardLocation.Hand) != 0) return true;
+            if (enemyResolvedEffectIdList.Contains(_CardId.MulcharmyFuwalos) && (loc & (CardLocation.Deck | CardLocation.Extra)) != 0) return true;
+            if (enemyResolvedEffectIdList.Contains(_CardId.MulcharmyNyalus) && (loc & (CardLocation.Grave | CardLocation.Removed)) != 0) return true;
 
             return false;
         }
@@ -1574,10 +1571,6 @@ namespace WindBot.Game.AI.Decks
             }
 
             summonCount = maxSummonCount;
-            enemyActivateMaxxC = false;
-            enemyActivatePurulia = false;
-            enemyActivateFuwalos = false;
-            enemyActivateNyalus = false;
             lockBirdSolved = false;
             if (dimensionShifterCount > 0) dimensionShifterCount--;
             enemyActivateInfiniteImpermanenceFromHand = false;
@@ -1650,17 +1643,6 @@ namespace WindBot.Game.AI.Decks
                         lockBirdSolved = true;
                     if (currentChain.IsActivateCode(_CardId.DimensionShifter))
                         dimensionShifterCount = 2;
-                    if (currentChain.ActivatePlayer == 1)
-                    {
-                        if (currentChain.IsActivateCode(_CardId.MaxxC))
-                            enemyActivateMaxxC = true;
-                        if (currentChain.IsActivateCode(_CardId.MulcharmyPurulia))
-                            enemyActivatePurulia = true;
-                        if (currentChain.IsActivateCode(_CardId.MulcharmyFuwalos))
-                            enemyActivateFuwalos = true;
-                        if (currentChain.IsActivateCode(_CardId.MulcharmyNyalus))
-                            enemyActivateNyalus = true;
-                    }
                     if (currentChain.ActivatePlayer == 0)
                     {
                         foreach (int checkId in CheckBotSolvedList)

--- a/Game/AI/Decks/SwordsoulExecutor.cs
+++ b/Game/AI/Decks/SwordsoulExecutor.cs
@@ -151,7 +151,6 @@ namespace WindBot.Game.AI.Decks
 
 
         List<int> currentNegatingIdList = new List<int>();
-        bool enemyActivateMaxxC = false;
         bool enemyActivateLockBird = false;
         bool enemyActivateInfiniteImpermanenceFromHand = false;
         List<int> infiniteImpermanenceList = new List<int>();
@@ -496,6 +495,27 @@ namespace WindBot.Game.AI.Decks
             return false;
         }
 
+        public bool CheckShouldNoMoreSpSummon()
+        {
+            if (CheckAtAdvantage() && enemyResolvedEffectIdList.Contains(_CardId.MaxxC) && DefaultCheckWhetherEnemyCanDraw()
+                && Util.IsTurn1OrMain2())
+            {
+                return true;
+            }
+            return false;
+        }
+
+        public bool CheckShouldNoMoreSpSummon(CardLocation loc)
+        {
+            if (CheckShouldNoMoreSpSummon()) return true;
+            if (!CheckAtAdvantage() || !DefaultCheckWhetherEnemyCanDraw() || !Util.IsTurn1OrMain2()) return false;
+            if (enemyResolvedEffectIdList.Contains(_CardId.MulcharmyPurulia) && (loc & CardLocation.Hand) != 0) return true;
+            if (enemyResolvedEffectIdList.Contains(_CardId.MulcharmyFuwalos) && (loc & (CardLocation.Deck | CardLocation.Extra)) != 0) return true;
+            if (enemyResolvedEffectIdList.Contains(_CardId.MulcharmyNyalus) && (loc & (CardLocation.Grave | CardLocation.Removed)) != 0) return true;
+
+            return false;
+        }
+
         /// <summary>
         /// Check whether last chain card should be disabled.
         /// </summary>
@@ -635,7 +655,6 @@ namespace WindBot.Game.AI.Decks
 
         public override void OnNewTurn()
         {
-            enemyActivateMaxxC = false;
             enemyActivateLockBird = false;
 
             infiniteImpermanenceList.Clear();
@@ -654,8 +673,6 @@ namespace WindBot.Game.AI.Decks
             ChainInfo currentChain = Duel.GetCurrentSolvingChainInfo();
             if (currentChain != null && !Duel.IsCurrentSolvingChainNegated() && currentChain.ActivatePlayer == 1)
             {
-                if (currentChain.IsActivateCode(_CardId.MaxxC))
-                    enemyActivateMaxxC = true;
                 if (currentChain.IsActivateCode(_CardId.LockBird))
                     enemyActivateLockBird = true;
                 if (currentChain.IsActivateCode(_CardId.InfiniteImpermanence) && !enemyActivateInfiniteImpermanenceFromHand)
@@ -892,7 +909,7 @@ namespace WindBot.Game.AI.Decks
             }
 
             // special summon token
-            if (CheckWhetherNegated() || (CheckAtAdvantage() && enemyActivateMaxxC && Util.IsTurn1OrMain2()))
+            if (CheckWhetherNegated() || CheckShouldNoMoreSpSummon(CardLocation.Hand | CardLocation.Extra))
             {
                 return false;
             }
@@ -1250,7 +1267,7 @@ namespace WindBot.Game.AI.Decks
             {
                 return false;
             }
-            if (CheckAtAdvantage() && enemyActivateMaxxC && Util.IsTurn1OrMain2())
+            if (CheckShouldNoMoreSpSummon(CardLocation.Hand | CardLocation.Extra))
             {
                 return false;
             }
@@ -1444,7 +1461,7 @@ namespace WindBot.Game.AI.Decks
                 Util.GetStringId(CardId.TenyiSpirit_Ashuna, 0)
             };
             if (!checkEffectDesc.Contains(ActivateDescription) || summoned || !Bot.HasInExtra(CardId.ShamanOfTheTenyi)
-            || (CheckAtAdvantage() && enemyActivateMaxxC))
+            || CheckShouldNoMoreSpSummon(CardLocation.Extra | CardLocation.Grave))
             {
                 return false;
             }
@@ -1476,7 +1493,7 @@ namespace WindBot.Game.AI.Decks
             {
                 return false;
             }
-            if (CheckAtAdvantage() && enemyActivateMaxxC)
+            if (CheckShouldNoMoreSpSummon(CardLocation.Hand))
             {
                 return false;
             }
@@ -1574,7 +1591,7 @@ namespace WindBot.Game.AI.Decks
             }
             if (CheckAtAdvantage())
             {
-                if (enemyActivateMaxxC && Util.IsTurn1OrMain2())
+                if (CheckShouldNoMoreSpSummon(CardLocation.Grave | CardLocation.Extra))
                 {
                     return false;
                 }
@@ -2071,7 +2088,7 @@ namespace WindBot.Game.AI.Decks
 
         public bool DracoBerserkerOfTheTenyiSpSummon()
         {
-            if (CheckAtAdvantage() && enemyActivateMaxxC && Util.IsTurn1OrMain2())
+            if (CheckShouldNoMoreSpSummon(CardLocation.Extra))
             {
                 return false;
             }
@@ -2082,6 +2099,10 @@ namespace WindBot.Game.AI.Decks
 
         public bool SwordsoulGrandmaster_ChixiaoSpSummon()
         {
+            if (CheckShouldNoMoreSpSummon(CardLocation.Extra))
+            {
+                return false;
+            }
             if (CheckAtAdvantage() && enemyActivateLockBird)
             {
                 return false;
@@ -2234,7 +2255,7 @@ namespace WindBot.Game.AI.Decks
 
         public bool ShamanOfTheTenyiSpSummon()
         {
-            if (CheckAtAdvantage() && enemyActivateMaxxC && Util.IsTurn1OrMain2())
+            if (CheckShouldNoMoreSpSummon(CardLocation.Extra))
             {
                 Logger.DebugWriteLine("[Shaman] advantage & maxxc, skip");
                 return false;
@@ -2612,7 +2633,10 @@ namespace WindBot.Game.AI.Decks
 
             } else {
                 // search
-                if (CheckAtAdvantage() && enemyActivateMaxxC && Util.IsTurn1OrMain2())
+                if (CheckAtAdvantage() && DefaultCheckWhetherEnemyCanDraw()
+                    && enemyResolvedEffectIdList.Any(id => id == _CardId.MaxxC || id == _CardId.MulcharmyPurulia
+                        || id == _CardId.MulcharmyFuwalos || id == _CardId.MulcharmyNyalus)
+                    && Util.IsTurn1OrMain2())
                 {
                     if (Bot.HasInDeck(CardId.SwordsoulBlackout))
                     {
@@ -2871,7 +2895,7 @@ namespace WindBot.Game.AI.Decks
             } else 
             {
                 // special summon
-                if (CheckAtAdvantage() && enemyActivateMaxxC && Util.IsTurn1OrMain2())
+                if (CheckShouldNoMoreSpSummon(CardLocation.Grave))
                 {
                     return false;
                 }


### PR DESCRIPTION
# Reduce combo under Maxx C / Mulcharmy by summon location

## Summary / 摘要

Stop extra summons when the opponent would draw from our play, using `DefaultExecutor.enemyResolvedEffectIdList` and `DefaultCheckWhetherEnemyCanDraw()`. Maxx C still blocks any special summon; Mulcharmy only blocks the matching origin.

对手会因我方行动抽卡时减少展开。改用基类已结算效果列表和抽卡检查，不再各自记 Maxx C 旗标。Maxx C 覆盖任意特召；Mulcharmy 只覆盖对应来源区域。

- **Mulcharmy Purulia**: Normal/Special Summon from **hand**
- **Mulcharmy Fuwalos**: Special Summon from **Deck / Extra**
- **Mulcharmy Nyalus (Meowls)**: Special Summon from **GY / banishment**

Ash / Called By / similar negation of Maxx C is unchanged. Local Lock Bird flags used for search limits are kept.

灰流、墓地指定等“优势下不打 Maxx C”的无效逻辑未改。用于限制检索的本地 Lock Bird 旗标保留。

## Changes / 改动

Shared pattern (same as `ApophisExecutor`):

公共写法（与 `ApophisExecutor` 一致）：

- No-arg check: at advantage + resolved Maxx C + opponent can draw + existing timing (turn 1 / Main 2, etc.)
- `CardLocation` overload: no-arg Maxx C first, then Purulia / Fuwalos / Nyalus by origin
- Drop per-deck `enemyActivateMaxxC` (and Ryzeal’s Mulcharmy bools); rely on base `OnChainSolved` / `OnNewTurn`

无参检查：占优 + 已结算 Maxx C + 对方能抽卡 + 该牌组原有时机。  
带区域重载：先走 Maxx C，再按来源匹配三张 Mulcharmy。  
删除各牌组本地 Maxx C（以及 Ryzeal 的三张 Mulcharmy）旗标，改用基类连锁结算记录。

| Deck | Notes |
|------|--------|
| **Ryzeal** | Same location overloads; only the data source changed |
| **Albaz** | Added location overload; hand / Deck / GY / Extra call sites updated |
| **Dogmatika** | Still requires a passable board (`Punishment` / high-level Spellcaster / Fleurdelis). Ecclesia search under draw engines also covers Mulcharmy |
| **Exosister** | `CheckLessOperation(CardLocation)` (no turn-1/M2 limit). Removed unused `gibrineEffect3Activated` / `asophielEffect3Activated` |
| **Labrynth** | Kept Cooclock exception. Extra Deck uses `isLabrynth: false`. Big Welcome picks a copy from a location that would not feed Mulcharmy when possible (GY → Deck → Hand fallback). Cooclock bounce-vs-SS option restored |
| **Swordsoul** | Central `CheckShouldNoMoreSpSummon`. Both Maxx C and Mulcharmy require **advantage** before stopping |

| 牌组 | 说明 |
|------|------|
| **Ryzeal** | 已有按区域调用，只换数据源 |
| **Albaz** | 新增区域重载，手卡/卡组/墓地/额外调用点分别传入 |
| **Dogmatika** | 仍要求已有过牌手段。教义检索过牌也覆盖 Mulcharmy |
| **Exosister** | `CheckLessOperation` 按区域扩展，无先攻/M2 限制。删除未使用字段 |
| **Labrynth** | 保留 Cooclock 例外。额外怪兽 `isLabrynth: false`。大欢迎尽量从不喂抽的区域特召。Cooclock 特召/回手选项保留原判断 |
| **Swordsoul** | 抽出统一检查。Maxx C 与 Mulcharmy 都需**占优**才停手 |