### PR TITLE
Replace local Lock Bird flags with shared search/draw checks

### DIFF
--- a/Game/AI/Decks/AlbazExecutor.cs
+++ b/Game/AI/Decks/AlbazExecutor.cs
@@ -196,7 +196,6 @@ namespace WindBot.Game.AI.Decks
         };
 
         bool summoned = false;
-        bool enemyActivateLockBird = false;
         int dimensionShifterCount = 0;
         bool enemyActivateInfiniteImpermanenceFromHand = false;
         bool theBystialLubellionSelecting = false;
@@ -624,25 +623,7 @@ namespace WindBot.Game.AI.Decks
                         case CardId.AluberTheJesterOfDespia:
                         case CardId.AluberTheJesterOfDespia + 1:
                         case CardId.SpringansKitt:
-                            checkDict = new Dictionary<int, Func<bool>> {
-                                {CardId.BrandedFusion, () => BrandedFusionActivateCheck()},
-                                {CardId.BrandedLost, () => {
-                                    if (Duel.Player == 0 && Duel.Phase >= DuelPhase.End) return false;
-                                    if (Bot.HasInHandOrInSpellZone(CardId.BrandedFusion) && BrandedFusionActivateCheck()) return true;
-                                    if (Bot.HasInHandOrInSpellZone(CardId.BrandedInWhite) && BrandedInWhiteActivateCheck()) return true;
-                                    if (Bot.HasInHandOrInSpellZone(CardId.BrandedInRed) && BrandedInRedActivateCheck() != null) return true;
-                                    if (!summoned && Bot.HasInHand(CardId.FallenOfAlbaz) && CheckAlbazFusion()) return true;
-                                    if ((Bot.HasInMonstersZone(CardId.BlazingCartesiaTheVirtuous) || (!summoned && Bot.HasInHand(CardId.BlazingCartesiaTheVirtuous)))) return true;
-                                    return false;
-                                }
-                                },
-                                {CardId.BrandedInHighSpirits, BrandedInHighSpiritsActivateCheck},
-                                {CardId.BrandedInRed, () => (Duel.Phase == DuelPhase.End && nadirActivated) || BrandedInRedActivateCheck() != null },
-                                {CardId.BrandedInWhite, BrandedInWhiteActivateCheck },
-                                {CardId.BrandedRetribution, () => cards.Any(c => c.IsCode(CardId.BrandedRetribution) && c.Location == CardLocation.Removed) },
-                                {CardId.BrightestBlazingBrandedKing, () => Bot.GetMonsters().Any(c => c.IsFaceup() && c.IsCode(albazFusionMonster)) },
-                                {CardId.BrandedOpening, () => Bot.Hand.Count > 2 }
-                            };
+                            checkDict = GetAluberKittSearchCheckDict(cards);
                             break;
                         case CardId.NadirServant:
                             if (!summoned)
@@ -2344,7 +2325,6 @@ namespace WindBot.Game.AI.Decks
             }
 
             summoned = false;
-            enemyActivateLockBird = false;
             enemyActivateInfiniteImpermanenceFromHand = false;
             nadirActivated = false;
             fusionToGYFlag = false;
@@ -2411,8 +2391,6 @@ namespace WindBot.Game.AI.Decks
                 {
                     if (currentChain.ActivatePlayer == 1)
                     {
-                        if (currentChain.IsActivateCode(_CardId.LockBird))
-                            enemyActivateLockBird = true;
                         if (currentChain.IsActivateCode(CardId.DimensionShifter))
                             dimensionShifterCount = 2;
                     }
@@ -2739,7 +2717,7 @@ namespace WindBot.Game.AI.Decks
 
         public bool AluberTheJesterOfDespiaSummon()
         {
-            if (CheckWhetherNegated(true, true, CardType.Monster) || enemyActivateLockBird || activatedCardIdList.Contains(Card.Id)) return false;
+            if (CheckWhetherNegated(true, true, CardType.Monster) || !DefaultCheckWhetherBotCanSearch() || activatedCardIdList.Contains(Card.Id)) return false;
             summoned = true;
             return true;
         }
@@ -2945,9 +2923,64 @@ namespace WindBot.Game.AI.Decks
             return false;
         }
 
+        /// <summary>
+        /// Search priority shared by Aluber and Springans Kitt.
+        /// </summary>
+        public Dictionary<int, Func<bool>> GetAluberKittSearchCheckDict(IList<ClientCard> cards)
+        {
+            return new Dictionary<int, Func<bool>> {
+                {CardId.BrandedFusion, () => BrandedFusionActivateCheck()},
+                {CardId.BrandedLost, () => {
+                    if (Duel.Player == 0 && Duel.Phase >= DuelPhase.End) return false;
+                    if (Bot.HasInHandOrInSpellZone(CardId.BrandedFusion) && BrandedFusionActivateCheck()) return true;
+                    if (Bot.HasInHandOrInSpellZone(CardId.BrandedInWhite) && BrandedInWhiteActivateCheck()) return true;
+                    if (Bot.HasInHandOrInSpellZone(CardId.BrandedInRed) && BrandedInRedActivateCheck() != null) return true;
+                    if (!summoned && Bot.HasInHand(CardId.FallenOfAlbaz) && CheckAlbazFusion()) return true;
+                    if ((Bot.HasInMonstersZone(CardId.BlazingCartesiaTheVirtuous) || (!summoned && Bot.HasInHand(CardId.BlazingCartesiaTheVirtuous)))) return true;
+                    return false;
+                }
+                },
+                {CardId.BrandedInHighSpirits, BrandedInHighSpiritsActivateCheck},
+                {CardId.BrandedInRed, () => (Duel.Phase == DuelPhase.End && nadirActivated) || BrandedInRedActivateCheck() != null },
+                {CardId.BrandedInWhite, BrandedInWhiteActivateCheck },
+                {CardId.BrandedRetribution, () => {
+                    if (cards != null)
+                        return cards.Any(c => c.IsCode(CardId.BrandedRetribution) && c.Location == CardLocation.Removed && c.IsFaceup());
+                    return Bot.Banished.Any(c => c != null && c.IsFaceup() && c.IsCode(CardId.BrandedRetribution));
+                } },
+                {CardId.BrightestBlazingBrandedKing, () => Bot.GetMonsters().Any(c => c.IsFaceup() && c.IsCode(albazFusionMonster)) },
+                {CardId.BrandedOpening, () => Bot.Hand.Count > 2 }
+            };
+        }
+
+        /// <summary>
+        /// Kitt can add from grave or face-up banished. Face-down banished cards cannot be added.
+        /// </summary>
+        public bool CheckSpringansKittCanAddFromGraveOrBanished(int cardId)
+        {
+            if (Bot.HasInGraveyard(cardId)) return true;
+            return Bot.Banished.Any(c => c != null && c.IsFaceup() && c.IsCode(cardId));
+        }
+
+        /// <summary>
+        /// Get the first Kitt add target that does not need searching the deck.
+        /// Aluber can only add from deck, so this check is Kitt-only.
+        /// </summary>
+        public int GetSpringansKittPreferredAddIdWithoutSearch()
+        {
+            foreach (KeyValuePair<int, Func<bool>> pair in GetAluberKittSearchCheckDict(null))
+            {
+                if (!pair.Value()) continue;
+                if (CheckSpringansKittCanAddFromGraveOrBanished(pair.Key))
+                    return pair.Key;
+            }
+            return 0;
+        }
+
         public bool SpringansKittSummon()
         {
-            if (CheckWhetherNegated(true, true, CardType.Monster) || enemyActivateLockBird || activatedCardIdList.Contains(Card.Id + 1)) return false;
+            if (CheckWhetherNegated(true, true, CardType.Monster) || activatedCardIdList.Contains(Card.Id + 1)) return false;
+            if (!DefaultCheckWhetherBotCanSearch() && GetSpringansKittPreferredAddIdWithoutSearch() == 0) return false;
             summoned = true;
             return true;
         }
@@ -4162,7 +4195,7 @@ namespace WindBot.Game.AI.Decks
                     && !CheckShouldNoMoreSpSummon(CardLocation.Deck) && Bot.HasInExtra(CardId.GranguignolTheDuskDragon) && Bot.HasInDeck(CardId.BlazingCartesiaTheVirtuous);
                 if (canCallCartesia) return false;
             }
-            bool goal = Bot.HasInDeck(CardId.AluberTheJesterOfDespia) && !activatedCardIdList.Contains(CardId.AluberTheJesterOfDespia) && !enemyActivateLockBird;
+            bool goal = Bot.HasInDeck(CardId.AluberTheJesterOfDespia) && !activatedCardIdList.Contains(CardId.AluberTheJesterOfDespia) && DefaultCheckWhetherBotCanSearch();
             goal |= Bot.HasInDeck(CardId.GuidingQuemTheVirtuous);
             if (goal)
             {
@@ -4309,7 +4342,7 @@ namespace WindBot.Game.AI.Decks
             List<ClientCard> problemCardList = GetProblematicEnemyCardList(false, false, CardType.Monster);
             if (problemCardList.Count > 0 || (Duel.Phase == DuelPhase.End && Duel.Player == 1))
             {
-                if (!enemyActivateLockBird)
+                if (DefaultCheckWhetherBotCanDraw())
                 {
                     foreach (ClientCard target in graveTargetList)
                     {

--- a/Game/AI/Decks/DogmatikaExecutor.cs
+++ b/Game/AI/Decks/DogmatikaExecutor.cs
@@ -143,7 +143,6 @@ namespace WindBot.Game.AI.Decks
         };
 
         List<int> currentNegatingIdList = new List<int>();
-        bool enemyActivateLockBird = false;
         List<int> infiniteImpermanenceList = new List<int>();
         bool summoned = false;
         List<int> activatedCardIdList = new List<int>();
@@ -489,7 +488,7 @@ namespace WindBot.Game.AI.Decks
 
             // Garura
             if (baseAtk <= 1500 && Bot.HasInExtra(CardId.GaruraWingsOfResonantLife) && CheckCalledbytheGrave(CardId.GaruraWingsOfResonantLife) == 0
-                && !activatedCardIdList.Contains(CardId.GaruraWingsOfResonantLife) && !enemyActivateLockBird)
+                && !activatedCardIdList.Contains(CardId.GaruraWingsOfResonantLife) && DefaultCheckWhetherBotCanDraw())
             {
                 selectResult = Bot.ExtraDeck.FirstOrDefault(card => card.IsCode(CardId.GaruraWingsOfResonantLife));
                 if (selectResult != null)
@@ -500,7 +499,7 @@ namespace WindBot.Game.AI.Decks
 
             // Ash Dragon
             if (baseAtk <= 2500 && Bot.HasInExtra(CardId.TitanikladTheAshDragon) && CheckCalledbytheGrave(CardId.TitanikladTheAshDragon) == 0
-                && !discardExtraThisTurn.Contains(CardId.TitanikladTheAshDragon) && !enemyActivateLockBird)
+                && !discardExtraThisTurn.Contains(CardId.TitanikladTheAshDragon) && DefaultCheckWhetherBotCanSearch())
             {
                 bool successFlag = !activatedCardIdList.Contains(CardId.DogmatikaEcclesia) && Bot.HasInDeck(CardId.DogmatikaEcclesia);
                 successFlag |= Bot.GetMonsters().Any(card => card.IsFaceup() && card.HasSetcode(SetcodeDogmatika)) && !Bot.HasInHand(CardId.DogmatikaFleurdelis) && Bot.HasInDeck(CardId.DogmatikaFleurdelis);
@@ -529,7 +528,7 @@ namespace WindBot.Game.AI.Decks
                 }
             }
 
-            if (baseAtk <= 600 && Bot.HasInExtra(CardId.HeraldOfTheArcLight) && !enemyActivateLockBird)
+            if (baseAtk <= 600 && Bot.HasInExtra(CardId.HeraldOfTheArcLight) && DefaultCheckWhetherBotCanSearch())
             {
                 if (GetNeedSearchRitualCardIdList().Count() > 0)
                 {
@@ -568,7 +567,6 @@ namespace WindBot.Game.AI.Decks
             ClientCard lastChainCard = Util.GetLastChainCard();
             if (lastChainCard != null && Duel.LastChainPlayer == 1)
             {
-                if (lastChainCard.IsCode(_CardId.LockBird)) enemyActivateLockBird = false;
                 if (lastChainCard.IsCode(CardId.DimensionShifter)) dimensionShifterCount = 0;
                 if (lastChainCard.Controller == 1 && lastChainCard.Location == CardLocation.MonsterZone)
                 {
@@ -905,10 +903,10 @@ namespace WindBot.Game.AI.Decks
                         {
                             bool checkFlag = !activatedCardIdList.Contains(CardId.DogmatikaEcclesia) && Bot.HasInDeck(CardId.DogmatikaEcclesia)
                                 && CheckCalledbytheGrave(CardId.DogmatikaEcclesia) == 0;
-                            checkFlag |= Bot.HasInDeck(CardId.DogmatikaFleurdelis) && !Bot.HasInHand(CardId.DogmatikaFleurdelis) && !enemyActivateLockBird;
+                            checkFlag |= Bot.HasInDeck(CardId.DogmatikaFleurdelis) && !Bot.HasInHand(CardId.DogmatikaFleurdelis) && DefaultCheckWhetherBotCanSearch();
                             if (checkFlag) discardList.Add(ashDragon);
                         }
-                        if (garura != null && !activatedCardIdList.Contains(CardId.GaruraWingsOfResonantLife) && !enemyActivateLockBird) discardList.Add(garura);
+                        if (garura != null && !activatedCardIdList.Contains(CardId.GaruraWingsOfResonantLife) && DefaultCheckWhetherBotCanDraw()) discardList.Add(garura);
                         if (arcLight != null && GetNeedSearchRitualCardIdList().Count() > 0) discardList.Add(arcLight);
                         if (psy != null) discardList.Add(psy);
                         if (duskDragon != null) discardList.Add(duskDragon);
@@ -999,7 +997,6 @@ namespace WindBot.Game.AI.Decks
                 enemySpSummonFromExLastTurn = 0;
                 enemySpSummonFromExThisTurn = 0;
             }
-            enemyActivateLockBird = false;
             omegaActivateCount = 0;
             enemySpSummonFromExLastTurn = enemySpSummonFromExThisTurn;
             enemySpSummonFromExThisTurn = 0;
@@ -1117,8 +1114,6 @@ namespace WindBot.Game.AI.Decks
             ChainInfo currentChain = Duel.GetCurrentSolvingChainInfo();
             if (currentChain != null && !Duel.IsCurrentSolvingChainNegated() && currentChain.ActivatePlayer == 1)
             {
-                if (currentChain.IsActivateCode(_CardId.LockBird))
-                    enemyActivateLockBird = true;
                 if (currentChain.IsActivateCode(CardId.DimensionShifter))
                     dimensionShifterCount = 2;
                 if (currentChain.IsActivateCode(_CardId.InfiniteImpermanence))
@@ -1394,7 +1389,11 @@ namespace WindBot.Game.AI.Decks
                             List<ClientCard> destroyList = GetNormalEnemyTargetList(true, false);
                             if (destroyList.Count() == 0) continue;
                         }
-                        if (enemyActivateLockBird && (checkId == CardId.HeraldOfTheArcLight || checkId == CardId.GaruraWingsOfResonantLife))
+                        if (!DefaultCheckWhetherBotCanSearch() && checkId == CardId.HeraldOfTheArcLight)
+                        {
+                            continue;
+                        }
+                        if (!DefaultCheckWhetherBotCanDraw() && checkId == CardId.GaruraWingsOfResonantLife)
                         {
                             continue;
                         }
@@ -1564,7 +1563,7 @@ namespace WindBot.Game.AI.Decks
 
         public bool DogmatikaEcclesiaSummon()
         {
-            if (enemyActivateLockBird) return false;
+            if (!DefaultCheckWhetherBotCanSearch()) return false;
             if (CheckWhetherNegated()) return false;
             if (activatedCardIdList.Contains(Card.Id)) return false;
 
@@ -1586,7 +1585,7 @@ namespace WindBot.Game.AI.Decks
                         return false;
                     }
                 }
-                if (enemyActivateLockBird)
+                if (!DefaultCheckWhetherBotCanSearch())
                 {
                     if (Bot.HasInHand(CardId.DogmatikaFleurdelis) && !Bot.GetMonsters().Any(card => card.IsFaceup() && card.HasSetcode(SetcodeDogmatika)))
                     {
@@ -2442,7 +2441,7 @@ namespace WindBot.Game.AI.Decks
             }
             if (Bot.HasInDeck(CardId.DogmatikaFleurdelis))
             {
-                if (!Bot.HasInHand(CardId.DogmatikaFleurdelis) && !enemyActivateLockBird)
+                if (!Bot.HasInHand(CardId.DogmatikaFleurdelis) && DefaultCheckWhetherBotCanSearch())
                 {
                     if (Bot.GetMonsters().Any(card => card.IsFaceup() && card.HasSetcode(SetcodeDogmatika)))
                     {
@@ -2496,7 +2495,7 @@ namespace WindBot.Game.AI.Decks
             if (Card.Location == CardLocation.Grave)
             {
                 if (!activatedCardIdList.Contains(CardId.DogmatikaEcclesia) && Bot.HasInDeck(CardId.DogmatikaEcclesia)
-                    && CheckCalledbytheGrave(CardId.DogmatikaEcclesia) == 0 && !enemyActivateLockBird)
+                    && CheckCalledbytheGrave(CardId.DogmatikaEcclesia) == 0 && DefaultCheckWhetherBotCanSearch())
                 {
                     AI.SelectCard(CardId.DogmatikaEcclesia);
                     return true;

--- a/Game/AI/Decks/ExosisterExecutor.cs
+++ b/Game/AI/Decks/ExosisterExecutor.cs
@@ -158,7 +158,6 @@ namespace WindBot.Game.AI.Decks
         List<int> ExosisterSpellTrapList = new List<int>{CardId.ExosisterPax, CardId.ExosisterArment, CardId.ExosisterVadis, CardId.ExosisterReturnia};
 
         List<int> currentNegatingIdList = new List<int>();
-        bool enemyActivateLockBird = false;
         bool enemyMoveGrave = false;
         bool paxCallToField = false;
         List<int> infiniteImpermanenceList = new List<int>();
@@ -682,10 +681,6 @@ namespace WindBot.Game.AI.Decks
 
             if (player == 1)
             {
-                if (card.IsCode(_CardId.LockBird) && CheckCalledbytheGrave(_CardId.LockBird) == 0)
-                {
-                    enemyActivateLockBird = true;
-                }
                 if (card.IsCode(_CardId.InfiniteImpermanence))
                 {
                     for (int i = 0; i < 5; ++i)
@@ -729,8 +724,6 @@ namespace WindBot.Game.AI.Decks
             ChainInfo currentChain = Duel.GetCurrentSolvingChainInfo();
             if (currentChain != null && !Duel.IsCurrentSolvingChainNegated() && currentChain.ActivatePlayer == 1)
             {
-                if (currentChain.IsActivateCode(_CardId.LockBird))
-                    enemyActivateLockBird = true;
                 if (currentChain.IsActivateCode(_CardId.InfiniteImpermanence))
                 {
                     for (int i = 0; i < 5; ++i)
@@ -784,7 +777,6 @@ namespace WindBot.Game.AI.Decks
 
         public override void OnNewTurn()
         {
-            enemyActivateLockBird = false;
             infiniteImpermanenceList.Clear();
             currentNegatingIdList.Clear();
 
@@ -2455,7 +2447,7 @@ namespace WindBot.Game.AI.Decks
             {
                 return false;
             }
-            if (enemyActivateLockBird && CheckAtAdvantage())
+            if (!DefaultCheckWhetherBotCanSearch() && CheckAtAdvantage())
             {
                 return false;
             }
@@ -2493,7 +2485,7 @@ namespace WindBot.Game.AI.Decks
             {
                 return false;
             }
-            if (enemyActivateLockBird && CheckAtAdvantage())
+            if (!DefaultCheckWhetherBotCanSearch() && CheckAtAdvantage())
             {
                 return false;
             }
@@ -2519,7 +2511,7 @@ namespace WindBot.Game.AI.Decks
             {
                 return false;
             }
-            if (enemyActivateLockBird && CheckAtAdvantage())
+            if (!DefaultCheckWhetherBotCanDraw() && CheckAtAdvantage())
             {
                 return false;
             }
@@ -2549,7 +2541,7 @@ namespace WindBot.Game.AI.Decks
             {
                 return false;
             }
-            if (enemyActivateLockBird && CheckAtAdvantage())
+            if (!DefaultCheckWhetherBotCanSearch() && CheckAtAdvantage())
             {
                 return false;
             }
@@ -2569,7 +2561,7 @@ namespace WindBot.Game.AI.Decks
             {
                 return false;
             }
-            if (enemyActivateLockBird && CheckAtAdvantage())
+            if (!DefaultCheckWhetherBotCanSearch() && CheckAtAdvantage())
             {
                 return false;
             }
@@ -2591,7 +2583,7 @@ namespace WindBot.Game.AI.Decks
             {
                 return false;
             }
-            if (enemyActivateLockBird && CheckAtAdvantage())
+            if (!DefaultCheckWhetherBotCanSearch() && CheckAtAdvantage())
             {
                 return false;
             }
@@ -2692,7 +2684,7 @@ namespace WindBot.Game.AI.Decks
 
         public bool ExosisterMikailisAdvancedSpSummonCheck()
         {
-            if (!CheckLessOperation() || enemyActivateLockBird)
+            if (!CheckLessOperation() || !DefaultCheckWhetherBotCanSearch())
             {
                 return false;
             }
@@ -2708,7 +2700,7 @@ namespace WindBot.Game.AI.Decks
             }
 
             // check searched spell/trap
-            if (!enemyActivateLockBird)
+            if (DefaultCheckWhetherBotCanSearch())
             {
                 foreach (int cardId in ExosisterSpellTrapList)
                 {
@@ -2745,7 +2737,7 @@ namespace WindBot.Game.AI.Decks
 
         public bool ExosisterKaspitellAdvancedSpSummonCheck()
         {
-            if (!CheckLessOperation() || enemyActivateLockBird)
+            if (!CheckLessOperation() || !DefaultCheckWhetherBotCanSearch())
             {
                 return false;
             }
@@ -2781,7 +2773,7 @@ namespace WindBot.Game.AI.Decks
             {
                 forMagnifica = true;
             }
-            if (enemyActivateLockBird)
+            if (!DefaultCheckWhetherBotCanSearch())
             {
                 searchMartha = false;
                 searchStella = false;

--- a/Game/AI/Decks/LabrynthExecutor.cs
+++ b/Game/AI/Decks/LabrynthExecutor.cs
@@ -761,7 +761,8 @@ namespace WindBot.Game.AI.Decks
                     ClientCard arianna = GetWelcomeOrBigWelcomeTarget(cards, CardId.AriannaTheLabrynthServant);
                     if (arianna != null && !summonInChainList.Any(card => card.IsCode(CardId.AriannaTheLabrynthServant)))
                     {
-                        bool canActivateCheck = !activatedCardIdList.Contains(CardId.AriannaTheLabrynthServant) && !CheckWhetherNegated(true, true, CardType.Monster);
+                        bool canActivateCheck = !activatedCardIdList.Contains(CardId.AriannaTheLabrynthServant) && !CheckWhetherNegated(true, true, CardType.Monster)
+                            && DefaultCheckWhetherBotCanSearch();
                         if (canActivateCheck)
                         {
                             bool checkFlag = !(!activatedCardIdList.Contains(CardId.BigWelcomeLabrynth) &&
@@ -874,7 +875,8 @@ namespace WindBot.Game.AI.Decks
                     if (Duel.Player == 0 && Duel.Phase <= DuelPhase.Main2)
                     {
                         if (!summoned && !activatedCardIdList.Contains(CardId.AriannaTheLabrynthServant) && !CheckWhetherNegated(true, true, CardType.Monster)
-                            && CheckCalledbytheGrave(CardId.AriannaTheLabrynthServant) == 0 && arianna != null && !Bot.HasInHand(CardId.AriannaTheLabrynthServant))
+                            && CheckCalledbytheGrave(CardId.AriannaTheLabrynthServant) == 0 && arianna != null && !Bot.HasInHand(CardId.AriannaTheLabrynthServant)
+                            && DefaultCheckWhetherBotCanSearch())
                         {
                             return Util.CheckSelectCount(new List<ClientCard> { arianna }, cards, min, max);
                         }
@@ -1025,7 +1027,8 @@ namespace WindBot.Game.AI.Decks
                     }
 
                     if (!activatedCardIdList.Contains(CardId.AriannaTheLabrynthServant) && !CheckWhetherNegated(true, true, CardType.Monster)
-                        && CheckCalledbytheGrave(CardId.AriannaTheLabrynthServant) == 0 && arianna != null && !Bot.HasInHand(CardId.AriannaTheLabrynthServant))
+                        && CheckCalledbytheGrave(CardId.AriannaTheLabrynthServant) == 0 && arianna != null && !Bot.HasInHand(CardId.AriannaTheLabrynthServant)
+                        && DefaultCheckWhetherBotCanSearch())
                     {
                         return Util.CheckSelectCount(new List<ClientCard> { arianna }, cards, min, max);
                     }
@@ -1102,7 +1105,8 @@ namespace WindBot.Game.AI.Decks
                         return Util.CheckSelectCount(new List<ClientCard> { GetWelcomeOrBigWelcomeTarget(cards, CardId.LovelyLabrynthOfTheSilverCastle) }, cards, min, max);
                     }
                     if (cards.Any(c => c.IsCode(CardId.AriannaTheLabrynthServant))
-                        && !activatedCardIdList.Contains(CardId.AriannaTheLabrynthServant) && !Bot.HasInMonstersZone(CardId.AriannaTheLabrynthServant))
+                        && !activatedCardIdList.Contains(CardId.AriannaTheLabrynthServant) && !Bot.HasInMonstersZone(CardId.AriannaTheLabrynthServant)
+                        && DefaultCheckWhetherBotCanSearch())
                     {
                         return Util.CheckSelectCount(new List<ClientCard> { GetWelcomeOrBigWelcomeTarget(cards, CardId.AriannaTheLabrynthServant) }, cards, min, max);
                     }
@@ -1112,7 +1116,8 @@ namespace WindBot.Game.AI.Decks
                         return Util.CheckSelectCount(new List<ClientCard> { GetWelcomeOrBigWelcomeTarget(cards, CardId.LovelyLabrynthOfTheSilverCastle) }, cards, min, max);
                     }
                     if (cards.Any(c => c.IsCode(CardId.AriannaTheLabrynthServant))
-                        && !activatedCardIdList.Contains(CardId.AriannaTheLabrynthServant) && !chainSummoningIdList.Contains(CardId.AriannaTheLabrynthServant))
+                        && !activatedCardIdList.Contains(CardId.AriannaTheLabrynthServant) && !chainSummoningIdList.Contains(CardId.AriannaTheLabrynthServant)
+                        && DefaultCheckWhetherBotCanSearch())
                     {
                         return Util.CheckSelectCount(new List<ClientCard> { GetWelcomeOrBigWelcomeTarget(cards, CardId.AriannaTheLabrynthServant) }, cards, min, max);
                     }
@@ -1460,7 +1465,8 @@ namespace WindBot.Game.AI.Decks
                 {
                     bool checkFlag = false;
                     if (!activatedCardIdList.Contains(CardId.AriannaTheLabrynthServant) && Bot.HasInHand(CardId.AriannaTheLabrynthServant)
-                        && !CheckWhetherNegated(true, true, CardType.Monster) && !chainSummoningIdList.Contains(CardId.AriannaTheLabrynthServant))
+                        && !CheckWhetherNegated(true, true, CardType.Monster) && !chainSummoningIdList.Contains(CardId.AriannaTheLabrynthServant)
+                        && DefaultCheckWhetherBotCanSearch())
                     {
                         checkFlag = true;
                         AI.SelectCard(CardId.AriannaTheLabrynthServant);
@@ -2034,7 +2040,8 @@ namespace WindBot.Game.AI.Decks
                     }
                 }
                 if (Bot.HasInHand(CardId.AriannaTheLabrynthServant) && !activatedCardIdList.Contains(CardId.AriannaTheLabrynthServant)
-                    && !CheckWhetherNegated(true, true) && !chainSummoningIdList.Contains(CardId.AriannaTheLabrynthServant))
+                    && !CheckWhetherNegated(true, true) && !chainSummoningIdList.Contains(CardId.AriannaTheLabrynthServant)
+                    && DefaultCheckWhetherBotCanSearch())
                 {
                     bool searchFlag = false;
                     if (Duel.Player == 1)
@@ -2100,7 +2107,8 @@ namespace WindBot.Game.AI.Decks
                 if (CheckShouldNoMoreSpSummon(CardLocation.Deck) && !(haveRollback && Bot.Graveyard.Any(card => card.IsCode(CardId.WelcomeLabrynth, CardId.BigWelcomeLabrynth)))) return false;
                 int specialSummonId = 0;
                 // arianna
-                if (!activatedCardIdList.Contains(CardId.AriannaTheLabrynthServant) && Bot.HasInDeck(CardId.AriannaTheLabrynthServant))
+                if (!activatedCardIdList.Contains(CardId.AriannaTheLabrynthServant) && Bot.HasInDeck(CardId.AriannaTheLabrynthServant)
+                    && DefaultCheckWhetherBotCanSearch())
                 {
                     specialSummonId = CardId.AriannaTheLabrynthServant;
                 }
@@ -2197,7 +2205,7 @@ namespace WindBot.Game.AI.Decks
         public bool AriannaTheLabrynthServantSummon()
         {
             // summon for search
-            if (!CheckWhetherNegated(true, true) && !activatedCardIdList.Contains(Card.Id))
+            if (!CheckWhetherNegated(true, true) && !activatedCardIdList.Contains(Card.Id) && DefaultCheckWhetherBotCanSearch())
             {
                 summoned = true;
                 return true;
@@ -2371,7 +2379,7 @@ namespace WindBot.Game.AI.Decks
             shouldTriggerBigWelcomeFlag |= Duel.Player == 1 && GetProblematicEnemyCardList(false).Count() == 0 && GetProblematicEnemyMonster(selfType: CardType.Monster) == null
                 && Enemy.Hand.Count() == 1;
             if (checkArianna) shouldTriggerBigWelcomeFlag |= Duel.Player == 0 && !summoned && Bot.HasInHandOrHasInMonstersZone(CardId.AriannaTheLabrynthServant)
-                && !activatedCardIdList.Contains(CardId.AriannaTheLabrynthServant);
+                && !activatedCardIdList.Contains(CardId.AriannaTheLabrynthServant) && DefaultCheckWhetherBotCanSearch();
             shouldTriggerBigWelcomeFlag |= Duel.Player == 0 && Duel.Phase <= DuelPhase.Main2;
             return shouldTriggerBigWelcomeFlag;
         }
@@ -2605,7 +2613,8 @@ namespace WindBot.Game.AI.Decks
                 if (ariannaCheck)
                 {
                     if (Bot.HasInDeck(CardId.AriannaTheLabrynthServant) && !activatedCardIdList.Contains(CardId.AriannaTheLabrynthServant)
-                        && !CheckWhetherNegated(true, true, CardType.Monster) && !chainSummoningIdList.Contains(CardId.AriannaTheLabrynthServant))
+                        && !CheckWhetherNegated(true, true, CardType.Monster) && !chainSummoningIdList.Contains(CardId.AriannaTheLabrynthServant)
+                        && DefaultCheckWhetherBotCanSearch())
                     {
                         if (!noSelect)
                         {
@@ -2642,7 +2651,8 @@ namespace WindBot.Game.AI.Decks
                             chainSummoningIdList.Add(CardId.LovelyLabrynthOfTheSilverCastle);
                         }
                         else if (!activatedCardIdList.Contains(CardId.AriannaTheLabrynthServant) && Bot.HasInDeck(CardId.AriannaTheLabrynthServant)
-                            && !CheckWhetherNegated(true, true, CardType.Monster) && !chainSummoningIdList.Contains(CardId.AriannaTheLabrynthServant))
+                            && !CheckWhetherNegated(true, true, CardType.Monster) && !chainSummoningIdList.Contains(CardId.AriannaTheLabrynthServant)
+                            && DefaultCheckWhetherBotCanSearch())
                         {
                             chainSummoningIdList.Add(CardId.AriannaTheLabrynthServant);
                         }
@@ -3181,6 +3191,7 @@ namespace WindBot.Game.AI.Decks
                 bool activateFlag = DefaultOnBecomeTarget();
                 activateFlag |= Duel.Player == 1 && !activatedCardIdList.Contains(CardId.BigWelcomeLabrynth) && activateTimingFlag;
                 activateFlag |= Duel.Player == 0 && !summoned && !Bot.HasInHand(CardId.AriannaTheLabrynthServant) && !activatedCardIdList.Contains(CardId.AriannaTheLabrynthServant)
+                    && DefaultCheckWhetherBotCanSearch()
                     && !(Duel.Phase < DuelPhase.Main1 && Bot.HasInHand(CardId.PotOfExtravagance) && Bot.ExtraDeck.Count() >= 3)
                     && !(Duel.CurrentChain.Any(card => card.IsCode(CardId.PotOfExtravagance) && card.Controller == 0));
                 if (activateFlag && !noSelect)
@@ -3275,7 +3286,8 @@ namespace WindBot.Game.AI.Decks
 
                 // bounce arianna
                 if (Duel.Player == 0 && Duel.Phase <= DuelPhase.Main2 && !summoned && !Bot.HasInHand(CardId.AriannaTheLabrynthServant)
-                    && !activatedCardIdList.Contains(CardId.AriannaTheLabrynthServant) && !chainSummoningIdList.Contains(CardId.AriannaTheLabrynthServant))
+                    && !activatedCardIdList.Contains(CardId.AriannaTheLabrynthServant) && !chainSummoningIdList.Contains(CardId.AriannaTheLabrynthServant)
+                    && DefaultCheckWhetherBotCanSearch())
                 {
                     ClientCard target = targetList.FirstOrDefault(card => card.IsCode(CardId.AriannaTheLabrynthServant));
                     if (target != null)
@@ -3774,10 +3786,12 @@ namespace WindBot.Game.AI.Decks
                 }
                 if (select == null && rage != null && (Duel.Player == 0 || (!activatedCardIdList.Contains(CardId.UnchainedSoulOfRage) && (Duel.Phase == DuelPhase.Main1 || Duel.Phase == DuelPhase.Main2)))
                     && Bot.HasInExtra(new List<int> { CardId.UnchainedSoulOfAnguish, CardId.SPLittleKnight })) select = rage;
-                if (select == null && arianna != null && Duel.Player == 0 && !activatedCardIdList.Contains(CardId.AriannaTheLabrynthServant)) select = arianna;
+                if (select == null && arianna != null && Duel.Player == 0 && !activatedCardIdList.Contains(CardId.AriannaTheLabrynthServant)
+                    && DefaultCheckWhetherBotCanSearch()) select = arianna;
                 if (select == null && lovely != null && Duel.Player == 1 && Util.GetBestAttack(Enemy) < 2900) select = lovely;
                 if (select == null && lady != null && Duel.Player == 1 && Util.GetBestAttack(Enemy) < 3000) select = lady;
-                if (select == null && arianna != null && !activatedCardIdList.Contains(CardId.AriannaTheLabrynthServant)) select = arianna;
+                if (select == null && arianna != null && !activatedCardIdList.Contains(CardId.AriannaTheLabrynthServant)
+                    && DefaultCheckWhetherBotCanSearch()) select = arianna;
                 if (select == null && bestAttack != null) select = bestAttack;
 
                 if (select != null)
@@ -4088,7 +4102,8 @@ namespace WindBot.Game.AI.Decks
                     (!activatedCardIdList.Contains(CardId.LovelyLabrynthOfTheSilverCastle) || Bot.HasInSpellZoneOrInGraveyard(CardId.BigWelcomeLabrynth))) rebornTarget = lovely;
                 if (rebornTarget == null && bestAttack != null && CheckCanDirectAttack()
                         && GetBotCurrentTotalAttack() < Enemy.LifePoints && GetBotCurrentTotalAttack() + bestAttack.Attack >= Enemy.LifePoints) rebornTarget = bestAttack;
-                if (rebornTarget == null && arianna != null && Duel.Player == 0 && !activatedCardIdList.Contains(CardId.AriannaTheLabrynthServant)) rebornTarget = arianna;
+                if (rebornTarget == null && arianna != null && Duel.Player == 0 && !activatedCardIdList.Contains(CardId.AriannaTheLabrynthServant)
+                    && DefaultCheckWhetherBotCanSearch()) rebornTarget = arianna;
                 if (rebornTarget == null && bestAttack != null) rebornTarget = bestAttack;
                 if (rebornTarget != null)
                 {

--- a/Game/AI/Decks/RyzealExecutor.cs
+++ b/Game/AI/Decks/RyzealExecutor.cs
@@ -174,7 +174,6 @@ namespace WindBot.Game.AI.Decks
 
         int maxSummonCount = 1;
         int summonCount = 1;
-        bool lockBirdSolved = false;
         int dimensionShifterCount = 0;
         bool botActivateMulcharmy = false;
         bool botSolvingCross = false;
@@ -458,7 +457,7 @@ namespace WindBot.Game.AI.Decks
 
             checkFlag |= !activatedCardIdList.Contains(CardId.RyzealDuodrive + 1) && Bot.HasInExtra(CardId.RyzealDuodrive)
                 && !DefaultCheckWhetherCardIdIsNegated(CardId.RyzealDuodrive) && !CheckWhetherNegated(true, true, CardType.Monster)
-                && summonCount > 0 && Bot.Hand.Count(c => c.Level == 4) > 0 && GetLevel4CountOnField() == 1 && !lockBirdSolved
+                && summonCount > 0 && Bot.Hand.Count(c => c.Level == 4) > 0 && GetLevel4CountOnField() == 1 && DefaultCheckWhetherBotCanSearch()
                 && !skipDuodriver;
 
             return checkFlag;
@@ -703,7 +702,7 @@ namespace WindBot.Game.AI.Decks
             if (Bot.HasInSpellZone(CardId.RyzealCross, true, true))
             {
                 // sending duodrive because not enough material on field
-                if (Bot.HasInExtra(CardId.RyzealDuodrive) && !activatedCardIdList.Contains(CardId.RyzealDuodrive + 1) && !lockBirdSolved)
+                if (Bot.HasInExtra(CardId.RyzealDuodrive) && !activatedCardIdList.Contains(CardId.RyzealDuodrive + 1) && DefaultCheckWhetherBotCanSearch())
                 {
                     bool checkOverlay = true;
                     ClientCard duoDrive = Bot.MonsterZone.FirstOrDefault(c => c != null && c.IsCode(CardId.RyzealDuodrive) && !resultList.Contains(c));
@@ -1571,7 +1570,6 @@ namespace WindBot.Game.AI.Decks
             }
 
             summonCount = maxSummonCount;
-            lockBirdSolved = false;
             if (dimensionShifterCount > 0) dimensionShifterCount--;
             enemyActivateInfiniteImpermanenceFromHand = false;
             botActivateMulcharmy = false;
@@ -1639,8 +1637,6 @@ namespace WindBot.Game.AI.Decks
             {
                 if (!Duel.IsCurrentSolvingChainNegated())
                 {
-                    if (currentChain.IsActivateCode(_CardId.LockBird))
-                        lockBirdSolved = true;
                     if (currentChain.IsActivateCode(_CardId.DimensionShifter))
                         dimensionShifterCount = 2;
                     if (currentChain.ActivatePlayer == 0)
@@ -1915,7 +1911,7 @@ namespace WindBot.Game.AI.Decks
             }
             bool spsummonFlag = lv4Count == 1;
             spsummonFlag |= !CheckWhetherNegated(true, true, CardType.Monster) && Bot.HasInDeck(CardId.IceRyzeal, CardId.ExRyzeal)
-                && !activatedCardIdList.Contains(CardId.ThodeRyzeal) && !lockBirdSolved;
+                && !activatedCardIdList.Contains(CardId.ThodeRyzeal) && DefaultCheckWhetherBotCanSearch();
             if (GetLevel4CountOnField() == 0)
             {
                 spsummonFlag |= GetLevel4FinalCountOnField(true, out _) >= 2 && !CheckWhetherHaveFinalMonster();
@@ -2059,7 +2055,7 @@ namespace WindBot.Game.AI.Decks
             }
             if (Duel.Turn == 1)
             {
-                bool checkFlag = !activatedCardIdList.Contains(CardId.ExRyzeal) && !lockBirdSolved && !DefaultCheckWhetherCardIdIsNegated(CardId.ExRyzeal) && !Bot.HasInMonstersZone(_CardId.Number41BagooskatheTerriblyTiredTapir);
+                bool checkFlag = !activatedCardIdList.Contains(CardId.ExRyzeal) && DefaultCheckWhetherBotCanSearch() && !DefaultCheckWhetherCardIdIsNegated(CardId.ExRyzeal) && !Bot.HasInMonstersZone(_CardId.Number41BagooskatheTerriblyTiredTapir);
                 checkFlag |= !Bot.MonsterZone.Any(c => c != null && c.IsFaceup() && c.HasType(CardType.Xyz)) && GetLevel4CountOnField() == 1;
                 if (checkFlag)
                 {
@@ -2180,7 +2176,7 @@ namespace WindBot.Game.AI.Decks
         public bool MulcharmyFuwalosActivate()
         {
             if (CheckWhetherNegated(true) || Duel.Player == 0) return false;
-            if (lockBirdSolved || Duel.CurrentChain.Any(c => c.IsCode(_CardId.LockBird))) return false;
+            if (!DefaultCheckWhetherBotCanDraw() || Duel.CurrentChain.Any(c => c.IsCode(_CardId.LockBird))) return false;
             if (Duel.Phase > DuelPhase.Main1) return false;
 
             botActivateMulcharmy = true;
@@ -2190,7 +2186,7 @@ namespace WindBot.Game.AI.Decks
         public bool MulcharmyPuruliaActivate()
         {
             if (CheckWhetherNegated(true) || Duel.Player == 0) return false;
-            if (lockBirdSolved || Duel.CurrentChain.Any(c => c.IsCode(_CardId.LockBird))) return false;
+            if (!DefaultCheckWhetherBotCanDraw() || Duel.CurrentChain.Any(c => c.IsCode(_CardId.LockBird))) return false;
             if (Duel.Phase > DuelPhase.Main1) return false;
             if (botActivateMulcharmy) return false;
 
@@ -2201,7 +2197,7 @@ namespace WindBot.Game.AI.Decks
         public bool MulcharmyNyalusActivate()
         {
             if (CheckWhetherNegated(true) || Duel.Player == 0) return false;
-            if (lockBirdSolved || Duel.CurrentChain.Any(c => c.IsCode(_CardId.LockBird))) return false;
+            if (!DefaultCheckWhetherBotCanDraw() || Duel.CurrentChain.Any(c => c.IsCode(_CardId.LockBird))) return false;
             if (Duel.Phase > DuelPhase.Main1) return false;
             if (botActivateMulcharmy) return false;
 
@@ -2232,7 +2228,7 @@ namespace WindBot.Game.AI.Decks
 
         public bool MaxxCActivate()
         {
-            if (CheckWhetherNegated(true) || Duel.LastChainPlayer == 0 || lockBirdSolved) return false;
+            if (CheckWhetherNegated(true) || Duel.LastChainPlayer == 0 || !DefaultCheckWhetherBotCanDraw()) return false;
             return DefaultMaxxC();
         }
 
@@ -2302,7 +2298,7 @@ namespace WindBot.Game.AI.Decks
                 if (res >= 0) return res;
             }
             // draw?
-            if (!lockBirdSolved)
+            if (DefaultCheckWhetherBotCanDraw())
             {
                 bool checkFlag = CheckCanContinueSummon();
                 if (!checkFlag)
@@ -3052,7 +3048,7 @@ namespace WindBot.Game.AI.Decks
             checkFlag &= !DefaultCheckWhetherCardIdIsNegated(CardId.RyzealDuodrive);
             checkFlag &= !activatedCardIdList.Contains(CardId.RyzealDuodrive + 1);
             checkFlag &= !CheckWhetherNegated(true, true, CardType.Monster);
-            checkFlag &= !lockBirdSolved;
+            checkFlag &= DefaultCheckWhetherBotCanSearch();
             checkFlag &= !CheckShouldNoMoreSpSummon(CardLocation.Extra);
 
             return checkFlag;
@@ -3116,7 +3112,7 @@ namespace WindBot.Game.AI.Decks
                 bool flag = hasNode;
                 flag &= Util.IsTurn1OrMain2();
                 flag &= Bot.HasInExtra(CardId.TwinsOfTheEclipse) && Bot.MonsterZone.Any(c => c != null && c.IsFaceup() && c.HasType(CardType.Xyz));
-                flag &= (GetNegateEffectCount() >= 2 || lockBirdSolved);
+                flag &= GetNegateEffectCount() >= 2 || !DefaultCheckWhetherBotCanDraw();
 
                 if (flag)
                 {
@@ -3164,7 +3160,7 @@ namespace WindBot.Game.AI.Decks
 
             // 60
             ClientCard no60 = Duel.MainPhase.SpecialSummonableCards.FirstOrDefault(c => c.IsCode(CardId.Number60DugaresTheTimeless));
-            if (no60 != null && !lockBirdSolved)
+            if (no60 != null && DefaultCheckWhetherBotCanDraw())
             {
                 bool flag = Bot.Deck.Count() > 2;
 
@@ -3863,7 +3859,7 @@ namespace WindBot.Game.AI.Decks
 
         public bool Number60DugaresTheTimelessDrawEffect()
         {
-            if (lockBirdSolved || Bot.Deck.Count < 2) return false;
+            if (!DefaultCheckWhetherBotCanDraw() || Bot.Deck.Count < 2) return false;
             activatedCardIdList.Add(CardId.Number60DugaresTheTimeless);
             return true;
         }

--- a/Game/AI/Decks/SwordsoulExecutor.cs
+++ b/Game/AI/Decks/SwordsoulExecutor.cs
@@ -151,7 +151,6 @@ namespace WindBot.Game.AI.Decks
 
 
         List<int> currentNegatingIdList = new List<int>();
-        bool enemyActivateLockBird = false;
         bool enemyActivateInfiniteImpermanenceFromHand = false;
         List<int> infiniteImpermanenceList = new List<int>();
 
@@ -655,8 +654,6 @@ namespace WindBot.Game.AI.Decks
 
         public override void OnNewTurn()
         {
-            enemyActivateLockBird = false;
-
             infiniteImpermanenceList.Clear();
 
             summoned = false;
@@ -673,8 +670,6 @@ namespace WindBot.Game.AI.Decks
             ChainInfo currentChain = Duel.GetCurrentSolvingChainInfo();
             if (currentChain != null && !Duel.IsCurrentSolvingChainNegated() && currentChain.ActivatePlayer == 1)
             {
-                if (currentChain.IsActivateCode(_CardId.LockBird))
-                    enemyActivateLockBird = true;
                 if (currentChain.IsActivateCode(_CardId.InfiniteImpermanence) && !enemyActivateInfiniteImpermanenceFromHand)
                 {
                     for (int i = 0; i < 5; ++i)
@@ -2103,7 +2098,7 @@ namespace WindBot.Game.AI.Decks
             {
                 return false;
             }
-            if (CheckAtAdvantage() && enemyActivateLockBird)
+            if (CheckAtAdvantage() && !DefaultCheckWhetherBotCanSearch())
             {
                 return false;
             }

--- a/Game/AI/DefaultExecutor.cs
+++ b/Game/AI/DefaultExecutor.cs
@@ -1974,6 +1974,17 @@ namespace WindBot.Game.AI
         }
 
         /// <summary>
+        /// Check whether bot can draw cards.
+        /// </summary>
+        /// <returns></returns>
+        protected bool DefaultCheckWhetherBotCanDraw()
+        {
+            if (resolvedEffectIdList.Contains(_CardId.LockBird))
+                return false;
+            return true;
+        }
+
+        /// <summary>
         /// Check whether enemy can draw cards.
         /// </summary>
         /// <returns></returns>

--- a/Game/AI/DefaultExecutor.cs
+++ b/Game/AI/DefaultExecutor.cs
@@ -1961,7 +1961,7 @@ namespace WindBot.Game.AI
             if (Bot.HasInMonstersZone(_CardId.ThunderKingRaiOh, notDisabled: true, faceUp: true)
                 || Enemy.HasInMonstersZone(_CardId.ThunderKingRaiOh, notDisabled: true, faceUp: true))
                 return false;
-            if (Enemy.HasInMonstersZone(_CardId.ThunderDragonColossus))
+            if (Enemy.HasInMonstersZone(_CardId.ThunderDragonColossus, notDisabled: true, faceUp: true))
                 return false;
             if (Bot.HasInSpellZone(_CardId.DeckLockdown, notDisabled: true, faceUp: true)
                 || Enemy.HasInSpellZone(_CardId.DeckLockdown, notDisabled: true, faceUp: true)


### PR DESCRIPTION
## Summary / 摘要

Drop per-deck `enemyActivateLockBird` / `lockBirdSolved` flags. Use `DefaultExecutor.resolvedEffectIdList` plus three APIs:

删除各牌组本地 Lock Bird 旗标，改用基类已结算效果列表和三个检查：

- `DefaultCheckWhetherBotCanSearch()` — bot adding from **Deck** (Lock Bird, Rai-Oh, Colossus, Deck Lockdown, Mistake, etc.)
- `DefaultCheckWhetherBotCanDraw()` — bot drawing (Lock Bird)
- `DefaultCheckWhetherEnemyCanDraw()` — opponent drawing (unchanged; still Lock Bird)

Search-limited plays now also respect floodgates such as Rai-Oh, not only Lock Bird. Base records a **resolved, non-negated** Lock Bird from **either player**. Exosister no longer flags on activation; Dogmatika no longer clears the flag in `CheckDeactiveFlag`. Chain-time Lock Bird (not yet resolved) is still handled with `CurrentChain` / `CheckLastChainShouldNegated`.

检索向效果现在也会避开雷王等封锁，不只看 Lock Bird。基类只在**未被无效的结算**后记账，且记**双方**。Exosister 不再在发动时提前记；教导不再在无效时清旗。连锁中尚未结算的 Lock Bird 仍用 `CurrentChain` / `CheckLastChainShouldNegated`。Labrynth 仅补阿里安娜检索检查。

**Trickstar** keeps its own `lockbird_useful` / `lockbird_used` logic in this PR. That deck uses Lock Bird as a combo piece (when to activate it, and when to chain Reincarnation), not as a shared “cannot search / cannot draw” gate. It will be migrated in a later pull request.

**Trickstar** 本次不改。该牌组有自己的 `lockbird_useful` / `lockbird_used`，用来判断何时发动锁鸟、以及是否连锁转生，不是这套公共的检索/抽卡检查。后续另开 pull request 再改。

## Changes / 改动

| Deck | Notes |
|------|--------|
| **DefaultExecutor** | Add `DefaultCheckWhetherBotCanDraw()` |
| **Albaz** | Aluber / Branded Opening skip when the bot cannot search. Kitt still Normal Summons if the preferred Branded S/T is in GY or **face-up** banished (Kitt can add from there; Aluber cannot). Guardian Chimera via Branded in Red is gated by `BotCanDraw` (Chimera draws). Shared Aluber/Kitt add-priority dict |
| **Dogmatika** | Garura uses `BotCanDraw`; Herald / Titaniklad / Ecclesia / Luluwalilith use `BotCanSearch`. Keep Lock Bird in `CheckLastChainShouldNegated` |
| **Exosister** | NS still requires advantage. Mikailis / Kaspitell Advanced skipped when the bot cannot search. Irene NS uses `BotCanDraw` (Irene draws) |
| **Swordsoul** | Skip Chixiao at advantage when the bot cannot search |
| **Ryzeal** | Duodrive / Thode / Ex search lines use `BotCanSearch`. No.60, Triple Tactics draw, Maxx C, and bot Mulcharmy use `BotCanDraw`. No.41 if hand traps >= 2 **or** the bot cannot draw |
| **Labrynth** | Arianna search uses `BotCanSearch`: NS-for-search, monster-zone search activate, and summoning/bouncing/reviving her to search (Welcome / Big Welcome / Ariane / Yama). Attack NS and the hand reveal effect are unchanged |
| **Trickstar** | Unchanged here; own Lock Bird activate / Reincarnation logic. Follow-up PR |

| 牌组 | 说明 |
|------|------|
| **DefaultExecutor** | 新增 `DefaultCheckWhetherBotCanDraw()` |
| **Albaz** | 阿尔贝 / 烙印开幕：不能检索则跳过。姬特：优先烙印魔陷在墓地或**表侧**除外时仍通召（姬特 可从那些区域加入；阿尔贝不能）。红烙印选奇美拉用 `BotCanDraw`（嵌合是抽卡）。抽出 阿尔贝/姬特 加手优先级 |
| **Dogmatika** | Garura 用抽卡检查；虹光 / 灰烬龙 / 教导圣女 / 卢瓦用检索检查。连锁中无效 Lock Bird 保留 |
| **Exosister** | 通召仍要求占优。Mikailis / Kaspitell Advanced 不能检索则不走。伊莱娜通召用抽卡检查 |
| **Swordsoul** | 占优且不能检索则不出赤霄 |
| **Ryzeal** | 双驱 / 剑极 / 外燃检索线用 `BotCanSearch`。No.60、三战极意抽卡、Maxx C、我方 Mulcharmy 用 `BotCanDraw`。手坑 >= 2 或不能抽卡时出 No.41 |
| **Labrynth** | 阿里安娜检索用 `BotCanSearch`：检索向通召、场上发动检索，以及为检索而特召/弹回/复苏她（欢迎 / 大欢迎 / 阿莱安娜 / 阎魔）。打点通召和手卡揭示效果不改 |
| **Trickstar** | 本次不改；自有锁鸟发动 / 转生连锁逻辑。后续 PR |
