### PR TITLE
Add OneForSynchro

### DIFF
--- a/Game/AI/CardExtension.cs
+++ b/Game/AI/CardExtension.cs
@@ -99,6 +99,82 @@ namespace WindBot.Game.AI
             return Enum.IsDefined(typeof(OneForXyz), card.Id);
         }
 
+        /// <summary>
+        /// Whether this monster on the field can use cards in the hand as Synchro Material.
+        /// </summary>
+        public static bool IsOneForSynchro(this ClientCard card)
+        {
+            return Enum.IsDefined(typeof(OneForSynchro), card.Id);
+        }
+
+        /// <summary>
+        /// Whether this chain's activated effect can Synchro Summon even without Tuner + non-Tuner on the field.
+        /// Matches ActivateDescription, HINT_OPSELECTED announces, or -1 when that is the card's only synchro activate.
+        /// </summary>
+        /// <param name="chain">The chain snapshot to check.</param>
+        /// <returns>True if the chain should be treated as a OneForSynchro effect.</returns>
+        public static bool IsOneForSynchroEffect(this ChainInfo chain)
+        {
+            if (chain == null)
+                return false;
+
+            // During chain building, cards like "Ashtra" etc. use SelectFromOptions, with options written into Announces
+            if (chain.Announces != null)
+            {
+                foreach (int announce in chain.Announces)
+                {
+                    if (Enum.IsDefined(typeof(OneForSynchroEffect), announce))
+                        return true;
+                }
+            }
+
+            int desc = chain.ActivateDescription;
+            if (desc != -1)
+                return Enum.IsDefined(typeof(OneForSynchroEffect), desc);
+
+            // Some optionally activated effects may set the description to -1.
+            // Fall back only for cards that are almost certainly the Synchro-related one.
+            return IsOneForSynchroEffectWhenDescriptionUnknown(chain);
+        }
+
+        /// <summary>
+        /// Fallback when ActivateDescription is -1: the card has only one relevant activate, or location distinguishes it.
+        /// </summary>
+        private static bool IsOneForSynchroEffectWhenDescriptionUnknown(ChainInfo chain)
+        {
+            return IsOneForSynchroEffectUnknownDescId(chain, chain.ActivateId)
+                || (chain.ActivateAlias != 0
+                    && chain.ActivateAlias != chain.ActivateId
+                    && IsOneForSynchroEffectUnknownDescId(chain, chain.ActivateAlias));
+        }
+
+        private static bool IsOneForSynchroEffectUnknownDescId(ChainInfo chain, int id)
+        {
+            switch (id)
+            {
+                case 93665266: // Crystron Quan
+                case 20050865: // Crystron Citree
+                case 66938505: // Crystron Rion
+                case 25148255: // Junk Anchor
+                case 89326990: // Speedroid Ohajikid
+                case 92932860: // Performapal Miss Director, no SetDescription
+                case 88170262: // Kewl Tune Remix
+                case 65961304: // Kewl Tune B2B
+                case 40493210: // Magikey Locking, no SetDescription
+                case 89974904: // Synchro Call, no SetDescription
+                case 9402966:  // Superheavy Samurai Battleball, no SetDescription
+                case 14507213: // Synchro Material, no SetDescription
+                case 62899696: // Speedroid Maliciousmagnet
+                    return true;
+                case 43904702: // Kewl Tune Clip: ① from hand, ② from GY
+                    return chain.HasLocation(CardLocation.Hand);
+                case 99471856: // Crystron Tristaros: ① from field, ② from GY
+                    return chain.HasLocation(CardLocation.MonsterZone);
+                default:
+                    return false;
+            }
+        }
+
         public static bool IsFusionSpell(this ClientCard card)
         {
             return Enum.IsDefined(typeof(FusionSpell), card.Id);

--- a/Game/AI/Decks/AlbazExecutor.cs
+++ b/Game/AI/Decks/AlbazExecutor.cs
@@ -3056,7 +3056,7 @@ namespace WindBot.Game.AI.Decks
                             {
                                 ClientCard material = materialList[0];
                                 albazFlag |= material.HasType(CardType.Ritual | CardType.Fusion | CardType.Synchro | CardType.Xyz | CardType.Link);
-                                albazFlag |= material.IsFloodgate() || material.IsOneForXyz() || Util.GetWorstBotMonster().GetDefensePower() < material.Attack;
+                                albazFlag |= material.IsFloodgate() || material.IsOneForXyz() || material.IsOneForSynchro() || Util.GetWorstBotMonster().GetDefensePower() < material.Attack;
                             }
                             return albazFlag;
                         }
@@ -4893,7 +4893,7 @@ namespace WindBot.Game.AI.Decks
                     {
                         ClientCard material = materialList[0];
                         albazFlag |= material.HasType(CardType.Ritual | CardType.Fusion | CardType.Synchro | CardType.Xyz | CardType.Link);
-                        albazFlag |= material.IsFloodgate() || material.IsOneForXyz() || Util.GetWorstBotMonster().GetDefensePower() < material.Attack;
+                        albazFlag |= material.IsFloodgate() || material.IsOneForXyz() || material.IsOneForSynchro() || Util.GetWorstBotMonster().GetDefensePower() < material.Attack;
                         albazFlag |= Duel.Player == 1 && Duel.Phase == DuelPhase.End && Duel.LastChainPlayer == -1;
                     }
 
@@ -5491,7 +5491,7 @@ namespace WindBot.Game.AI.Decks
                     {
                         ClientCard material = materialList[0];
                         checkFlag |= material.HasType(CardType.Ritual | CardType.Fusion | CardType.Synchro | CardType.Xyz | CardType.Link);
-                        checkFlag |= material.IsFloodgate() || material.IsOneForXyz() || Util.GetWorstBotMonster()?.GetDefensePower() < material.Attack;
+                        checkFlag |= material.IsFloodgate() || material.IsOneForXyz() || material.IsOneForSynchro() || Util.GetWorstBotMonster()?.GetDefensePower() < material.Attack;
                         checkFlag |= Duel.Player == 1 && Duel.Phase == DuelPhase.End && Duel.LastChainPlayer == -1;
                     }
                 }

--- a/Game/AI/Decks/LabrynthExecutor.cs
+++ b/Game/AI/Decks/LabrynthExecutor.cs
@@ -3008,12 +3008,24 @@ namespace WindBot.Game.AI.Decks
                     return true;
                 }
             }
+            foreach (ChainInfo chain in Duel.CurrentChainInfo)
+            {
+                if (chain == null || chain.ActivatePlayer != 1 || !chain.IsOneForSynchroEffect())
+                    continue;
+                ClientCard related = chain.RelatedCard;
+                if (related != null && (related.IsDisabled() || currentNegateMonsterList.Contains(related)))
+                    continue;
+                if (dimensionBarrierAnnouncing && related != null)
+                    currentNegateMonsterList.Add(related);
+                return true;
+            }
             if (Duel.Player == 1 && !Util.ChainContainsCard(CardId.DestructiveDarumaKarmaCannon) && Enemy.ExtraDeck.Count() > 0)
             {
                 bool tunerCheck = false;
                 bool nontunerCheck = false;
                 foreach (ClientCard monster in Enemy.GetMonsters())
                 {
+                    if (monster.IsOneForSynchro()) return true;
                     if (monster.IsFacedown() || monster.HasType(CardType.Xyz | CardType.Link)) continue;
                     if (monster.HasType(CardType.Tuner)) tunerCheck = true;
                     else nontunerCheck = true;

--- a/Game/AI/DefaultExecutor.cs
+++ b/Game/AI/DefaultExecutor.cs
@@ -1594,6 +1594,11 @@ namespace WindBot.Game.AI
                         AI.SelectOption(XYZ);
                         return true;
                     }
+                    if (monster.IsOneForSynchro())
+                    {
+                        AI.SelectOption(SYNCHRO);
+                        return true;
+                    }
                 }
                 if (tuner && nontuner)
                 {
@@ -1616,34 +1621,44 @@ namespace WindBot.Game.AI
                     return true;
                 }
             }
-            ClientCard lastchaincard = Util.GetLastChainCard();
-            if (Duel.LastChainPlayer == 1 && lastchaincard != null && !lastchaincard.IsDisabled()
-                && (lastchaincard.HasType(CardType.Spell | CardType.Trap) || lastchaincard.Location == CardLocation.MonsterZone))
+            ChainInfo lastChain = Duel.CurrentChainInfo.LastOrDefault();
+            if (Duel.LastChainPlayer == 1 && lastChain != null
+                && (lastChain.RelatedCard == null || !lastChain.RelatedCard.IsDisabled()))
             {
-                if (lastchaincard.HasType(CardType.Ritual))
-                {
-                    AI.SelectOption(RITUAL);
-                    return true;
-                }
-                if (lastchaincard.HasType(CardType.Fusion))
-                {
-                    AI.SelectOption(FUSION);
-                    return true;
-                }
-                if (lastchaincard.HasType(CardType.Synchro))
+                if (lastChain.IsOneForSynchroEffect())
                 {
                     AI.SelectOption(SYNCHRO);
                     return true;
                 }
-                if (lastchaincard.HasType(CardType.Xyz))
+                ClientCard lastchaincard = lastChain.RelatedCard;
+                if (lastchaincard != null
+                    && (lastchaincard.HasType(CardType.Spell | CardType.Trap) || lastchaincard.Location == CardLocation.MonsterZone))
                 {
-                    AI.SelectOption(XYZ);
-                    return true;
-                }
-                if (lastchaincard.IsFusionSpell())
-                {
-                    AI.SelectOption(FUSION);
-                    return true;
+                    if (lastchaincard.HasType(CardType.Ritual))
+                    {
+                        AI.SelectOption(RITUAL);
+                        return true;
+                    }
+                    if (lastchaincard.HasType(CardType.Fusion))
+                    {
+                        AI.SelectOption(FUSION);
+                        return true;
+                    }
+                    if (lastchaincard.HasType(CardType.Synchro))
+                    {
+                        AI.SelectOption(SYNCHRO);
+                        return true;
+                    }
+                    if (lastchaincard.HasType(CardType.Xyz))
+                    {
+                        AI.SelectOption(XYZ);
+                        return true;
+                    }
+                    if (lastchaincard.IsFusionSpell())
+                    {
+                        AI.SelectOption(FUSION);
+                        return true;
+                    }
                 }
             }
             if (Util.IsChainTarget(Card))

--- a/Game/AI/Enums/OneForSynchro.cs
+++ b/Game/AI/Enums/OneForSynchro.cs
@@ -1,0 +1,46 @@
+namespace WindBot.Game.AI.Enums
+{
+    /// <summary>
+    /// Monsters that can use cards in the hand as Synchro Material
+    /// when this card on the field is used as Synchro Material.
+    /// </summary>
+    public enum OneForSynchro
+    {
+        EccentricBoy = 16825874,
+        MaleficParallelGear = 74509280,
+        MaraoftheNordicAlfar = 73417207,
+        TGCyberMagician = 64910482,
+        MechaPhantomBeastBlueImpala = 67489919,
+        Tatsunoko = 55863245,
+        Tatsunecro = 3096468,
+        KewlTuneMix = 16509007,
+        KewlTuneClip = 43904702,
+        KewlTuneReco = 89392810,
+        KewlTuneCue = 16387555,
+        KewlTuneTrackMaker = 42781164,
+        KewlTuneRotary = 17209452
+    }
+
+    /// <summary>
+    /// Activate descriptions or HINT_OPSELECTED announces for effects that can
+    /// Synchro Summon even when the field does not currently have Tuner + non-Tuner.
+    /// Values are Util.GetStringId(cardId, offset) = cardId * 16 + offset.
+    /// </summary>
+    public enum OneForSynchroEffect
+    {
+        CrystronQuan = 93665266 * 16 + 0,
+        CrystronCitree = 20050865 * 16 + 0,
+        CrystronRion = 66938505 * 16 + 0,
+        CrystronTristaros = 99471856 * 16 + 0,
+        JunkAnchor = 25148255 * 16 + 0,
+        SpeedroidOhajikid = 89326990 * 16 + 0,
+        KewlTuneClip = 43904702 * 16 + 0,
+        KewlTuneRemix = 88170262 * 16 + 0,
+        KewlTuneB2B = 65961304 * 16 + 0,
+        SpeedroidMaliciousmagnet = 62899696 * 16 + 1,
+        TurboTaintedHotRodGT19 = 16769305 * 16 + 1,
+        AshtraInsectPoison = 64455720 * 16 + 1,
+        AshtraCursedRoar = 91444835 * 16 + 1,
+        AshtraDivineDomain = 37839434 * 16 + 1
+    }
+}


### PR DESCRIPTION
## Summary

- 新增 `OneForSynchro` / `OneForSynchroEffect` 已知卡分类，用于识别“场上没有调整 + 非调整也能同调”的怪兽与效果。  
  Add `OneForSynchro` / `OneForSynchroEffect` known-card enums for monsters and effects that can Synchro Summon without Tuner + non-Tuner already on the field.
- 默认「次元障壁 / Dimensional Barrier」、拉比林斯迷宫 / Labrynth 的「次元障壁 / Dimensional Barrier」，以及「阿不思的落胤 / Fallen of Albaz」融合素材评估会使用上述分类，避免漏判这类同调。  
  Default Dimensional Barrier, Labrynth Dimensional Barrier, and Fallen of Albaz fusion-material evaluation now use these enums so those Synchro lines are not missed.
- 连锁侧改为读取 `Duel.CurrentChainInfo`，以便同时用 `ActivateDescription`、`Announces` 和 `-1` 回退判断效果。  
  Chain-side checks now read `Duel.CurrentChainInfo`, so `ActivateDescription`, `Announces`, and the `-1` fallback can all be used.

## 背景 / Background

原先「次元障壁 / Dimensional Barrier」把“对方可能同调”主要理解成两类情况：场上已有调整 + 非调整，或连锁卡本身是同调怪兽 / 同调相关卡。这会漏掉两类常见局面：  
Previously, Dimensional Barrier treated “the opponent may Synchro Summon” mainly as Tuner + non-Tuner already on the field, or the chain card itself being a Synchro monster / Synchro-related card. That missed two common cases:

1. 场上这只怪兽当同调素材时，可以用手牌当素材。此时场上不必同时有调整 + 非调整。例如「古怪少年 / Eccentric Boy」、「龙子 / Tatsunoko」、「杀手级调整曲 / Kewl Tune」等。  
   When this on-field monster is used as Synchro Material, a card in the hand can also be used as material. Tuner + non-Tuner do not both need to be on the field. Examples: Eccentric Boy, Tatsunoko, Kewl Tune.
2. 发动效果后就能同调，不依赖场上现成的调整 + 非调整。例如「水晶机巧 / Crystron」、「艮神鬼 / Ashtra」、「杀手级调整曲·削波手 / Kewl Tune Clip」、「杀手级调整曲·再混音手 / Kewl Tune Remix」、「魔键锭-施- / Magikey Locking」。效果描述有时是具体 `StringId`，有时写进 `ChainInfo.Announces`，可选诱发还可能是 `-1`。  
   Activating an effect can Synchro Summon without Tuner + non-Tuner already on the field. Examples: Crystron, Ashtra, Kewl Tune Clip, Kewl Tune Remix, Magikey Locking. The description may be a concrete `StringId`, a value written into `ChainInfo.Announces`, or `-1` for optional triggers.

这组改动与已有的 `OneForXyz` 同类：把已知卡收进枚举，再在公共检查里复用。  
This follows the existing `OneForXyz` pattern: collect known cards into enums, then reuse them in shared checks.

## 改动 / Changes

### 已知卡与查询接口 / Known cards and query helpers

新增 `Game/AI/Enums/OneForSynchro.cs`：  
Add `Game/AI/Enums/OneForSynchro.cs`:

- `OneForSynchro`：场上这只怪兽当同调素材时，可以用手牌当素材。  
  `OneForSynchro`: when this on-field monster is used as Synchro Material, a card in the hand can also be used as material.
- `OneForSynchroEffect`：效果描述或 `HINT_OPSELECTED` 宣告值，编码为 `cardId * 16 + offset`。  
  `OneForSynchroEffect`: activate descriptions or `HINT_OPSELECTED` announce values, encoded as `cardId * 16 + offset`.

`CardExtension` 增加：  
`CardExtension` adds:

- `ClientCard.IsOneForSynchro()`：按卡号查 `OneForSynchro`。  
  `ClientCard.IsOneForSynchro()`: look up `OneForSynchro` by card ID.
- `ChainInfo.IsOneForSynchroEffect()`：按顺序匹配 `Announces`、`ActivateDescription`；描述为 `-1` 时，只对“几乎可以确定就是这条同调效果”的卡做回退。回退会看发动位置：「杀手级调整曲·削波手 / Kewl Tune Clip」只在手牌，「水晶机巧-三位玉晶 / Crystron Tristaros」只在怪兽区域。  
  `ChainInfo.IsOneForSynchroEffect()`: match `Announces`, then `ActivateDescription`; if the description is `-1`, fall back only for cards that are almost certainly this Synchro effect. The fallback uses activation location: Kewl Tune Clip from the hand only, Crystron Tristaros from the Monster Zone only.

没有 `SetDescription` 的卡不进 `OneForSynchroEffect` 枚举，只走 `-1` 回退，例如「魔键锭-施- / Magikey Locking」、「同调呼唤 / Synchro Call」、「超重武者 魂-C / Superheavy Samurai Battleball」、「同调素材 / Synchro Material」、「娱乐伙伴 诱导女导演 / Performapal Miss Director」。艮神鬼 / Ashtra 一类在连锁建立时用 `SelectFromOptions` 的卡，依赖 `ChainInfo.Announces`（#282）。  
Cards without `SetDescription` are not in the `OneForSynchroEffect` enum and only use the `-1` fallback, e.g. Magikey Locking, Synchro Call, Superheavy Samurai Battleball, Synchro Material, Performapal Miss Director. Ashtra cards that use `SelectFromOptions` while the chain is built depend on `ChainInfo.Announces` (#282).

### 调用点 / Call sites

- **`DefaultDimensionalBarrier`**：对方场上有 `IsOneForSynchro()` 怪兽时选同调；最新连锁是 `IsOneForSynchroEffect()` 时也选同调。最新连锁改为 `CurrentChainInfo.LastOrDefault()`，关联卡为空或未无效时仍可按效果描述判断。  
  **`DefaultDimensionalBarrier`**: choose Synchro if the opponent has an `IsOneForSynchro()` monster, or if the latest chain is `IsOneForSynchroEffect()`. The latest chain is now `CurrentChainInfo.LastOrDefault()`, so the effect can still be judged when the related card is null or not disabled.
- **`LabrynthExecutor.DimensionalBarrierForSynchro`**：同样检查连锁中的 OneForSynchro 效果，以及对方场上的 OneForSynchro 怪兽。  
  **`LabrynthExecutor.DimensionalBarrierForSynchro`**: the same checks for OneForSynchro effects on the chain and OneForSynchro monsters on the opponent's field.
- **`AlbazExecutor`**：三处融合素材评估把 OneForSynchro 怪兽与 OneForXyz、Floodgate 一样视为高价值素材。  
  **`AlbazExecutor`**: three fusion-material checks now treat OneForSynchro monsters as high-value materials, same as OneForXyz and Floodgate.

## 文件 / Files

| 文件 / File | 说明 / Notes |
|------|------|
| `Game/AI/Enums/OneForSynchro.cs` | 新增枚举 / New enums |
| `Game/AI/CardExtension.cs` | 查询接口与 `-1` 回退 / Query helpers and `-1` fallback |
| `Game/AI/DefaultExecutor.cs` | 默认「次元障壁 / Dimensional Barrier」 |
| `Game/AI/Decks/LabrynthExecutor.cs` | 拉比林斯迷宫 / Labrynth「次元障壁 / Dimensional Barrier」 |
| `Game/AI/Decks/AlbazExecutor.cs` | 「阿不思的落胤 / Fallen of Albaz」融合素材优先级 / fusion material priority |

## 枚举收录卡名 / Cards in the enums

名称来自 ygocdb.com。艮神鬼 / Ashtra 目前没有 `en_name`，英文用 `wiki_en`。  
Names are from ygocdb.com. Ashtra cards currently have no `en_name`; English names use `wiki_en`.

### `OneForSynchro`

场上这只怪兽当同调素材时，可以用手牌当素材。  
On-field monsters that can use a card in the hand as Synchro Material.

| 中文 / Chinese | 英文 / English |
|------|------|
| 古怪少年 | Eccentric Boy |
| 罪 平行齿轮 | Malefic Parallel Gear |
| 极星灵 黑精灵 | Mara of the Nordic Alfar |
| 科技属 电子化魔术师 | T.G. Cyber Magician |
| 幻兽机 蓝冲高角羚 | Mecha Phantom Beast Blue Impala |
| 龙子 | Tatsunoko |
| 尸龙子 | Tatsunecro |
| 杀手级调整曲·混音手 | Kewl Tune Mix |
| 杀手级调整曲·削波手 | Kewl Tune Clip |
| 杀手级调整曲·唱片师 | Kewl Tune Reco |
| 杀手级调整曲·提示员 | Kewl Tune Cue |
| 杀手级调整曲·音轨制作人 | Kewl Tune Track Maker |
| 杀手级调整曲·旋钮手 | Kewl Tune Rotary |

### `OneForSynchroEffect`

效果描述或 `HINT_OPSELECTED` 宣告。  
Activate descriptions or `HINT_OPSELECTED` announces.

| 中文 / Chinese | 英文 / English |
|------|------|
| 水晶机巧-量子白晶 | Crystron Quan |
| 水晶机巧-矩阵黄晶 | Crystron Citree |
| 水晶机巧-胶子黑晶 | Crystron Rion |
| 水晶机巧-三位玉晶 | Crystron Tristaros |
| 废品压阵者 | Junk Anchor |
| 疾行机人 弹子小子 | Speedroid Ohajikid |
| 杀手级调整曲·削波手 | Kewl Tune Clip |
| 杀手级调整曲·再混音手 | Kewl Tune Remix |
| 杀手级调整曲 B2B | Kewl Tune B2B |
| 疾行机人 磁铁恶魔 | Speedroid Maliciousmagnet |
| 魔界造车-GT19 | Turbo-Tainted Hot Rod GT19 |
| 色鬼之虫毒 | Ashtra Insect Poison |
| 依鬼之咒咆 | Ashtra Cursed Roar |
| 剑鬼之神域 | Ashtra Divine Domain |

### `-1` 回退额外覆盖 / Extra cards in the `-1` fallback

这些卡没有 `SetDescription`，只在描述为 `-1` 时按卡号（及发动位置）回退。  
These cards have no `SetDescription` and are only matched by card ID (and location) when the description is `-1`.

| 中文 / Chinese | 英文 / English |
|------|------|
| 娱乐伙伴 诱导女导演 | Performapal Miss Director |
| 魔键锭-施- | Magikey Locking |
| 同调呼唤 | Synchro Call |
| 超重武者 魂-C | Superheavy Samurai Battleball |
| 同调素材 | Synchro Material |

「杀手级调整曲·削波手 / Kewl Tune Clip」在手牌、「水晶机巧-三位玉晶 / Crystron Tristaros」在怪兽区域时，描述为 `-1` 也会走这条回退。  
Kewl Tune Clip from the hand and Crystron Tristaros from the Monster Zone also use this fallback when the description is `-1`.